### PR TITLE
ui: spinners consistency

### DIFF
--- a/dashboard/src/components/features/batches/BatchesTable/columns.tsx
+++ b/dashboard/src/components/features/batches/BatchesTable/columns.tsx
@@ -37,7 +37,7 @@ const getStatusIcon = (status: BatchStatus) => {
       return <XCircle className="w-4 h-4 text-gray-600" />;
     case "in_progress":
     case "finalizing":
-      return <Loader2 className="w-4 h-4 text-gray-600 animate-spin" />;
+      return <Loader2 className="w-4 h-4 text-blue-600 animate-spin" />;
     case "validating":
     case "cancelling":
       return <Clock className="w-4 h-4 text-yellow-600" />;

--- a/dashboard/src/components/features/batches/FilesTable/columns.tsx
+++ b/dashboard/src/components/features/batches/FilesTable/columns.tsx
@@ -74,7 +74,7 @@ export const createFileColumns = (
       // Choose icon based on purpose and progress
       let icon = <FileInput className="w-4 h-4 text-gray-500" />;
       if (isInProgress) {
-        icon = <Loader2 className="w-4 h-4 text-gray-600 animate-spin" />;
+        icon = <Loader2 className="w-4 h-4 text-blue-600 animate-spin" />;
       } else if (file.purpose === "batch_output") {
         icon = <FileCheck className="w-4 h-4 text-green-600" />;
       } else if (file.purpose === "batch_error") {


### PR DESCRIPTION
Replaced inconsistent blue-600 spinner colors with the standard colors used throughout the app for visual consistency.

Changes:
- FilesTable: Changed Loader2 from text-blue-600 to text-gray-600
- BatchesTable: Changed Loader2 from text-blue-600 to text-gray-600
- FileRequests: Changed div spinner from border-blue-600 to border-doubleword-accent-blue
- ViewFileRequestsModal: Changed div spinner from border-blue-600 to border-doubleword-accent-blue

Fixes #122