### PR TITLE
fix: add default 30-day expiry for files when none specified

### DIFF
--- a/fusillade/src/manager/postgres.rs
+++ b/fusillade/src/manager/postgres.rs
@@ -846,7 +846,8 @@ impl<H: HttpClient + 'static> Storage for PostgresRequestManager<H> {
                 None
             }
         } else {
-            None
+            // Default to 30 days if no expiry is specified
+            Some(Utc::now() + chrono::Duration::days(30))
         };
 
         let description = metadata.description.clone();


### PR DESCRIPTION
Previously, files without an explicit expiry date would have no expiry (expires_at = None), allowing them to persist indefinitely. This fix sets a sensible default of 30 days from creation when no expiry is specified.

The logic now:
- If expires_after_anchor and expires_after_seconds are provided: use them
- Otherwise: default to 30 days from creation

This prevents accumulation of old files and provides better data retention management out of the box.

Fixes #117