### PR TITLE
fix: better batch status conditions

### DIFF
--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -48,10 +48,13 @@ fn to_batch_response(batch: fusillade::Batch) -> BatchResponse {
         "failed"
     } else if is_finished {
         "completed"
-    } else if batch.in_progress_requests > 0 || batch.completed_requests > 0 {
-        "in_progress"
     } else {
-        "validating"
+        // Any batch that has been validated (total_requests > 0) but not finished
+        // is considered "in_progress". This includes:
+        // - Batches actively processing (in_progress_requests > 0)
+        // - Batches with some completed work (completed_requests > 0)
+        // - Batches queued and waiting for capacity (only pending_requests > 0)
+        "in_progress"
     };
 
     // Compute timestamps based on status


### PR DESCRIPTION
UI shows 'validating' until requests are written into the db. After validation of file and writing of requests, the batch is 'in progress', even if it is queued behind another batch that has saturated the target model. 

Status is determined by evaluating these conditions in order:

- cancelled: cancelling_at set + all requests finished
- cancelling: cancelling_at set + requests still processing
- validating: total_requests == 0 (file import in progress)
- failed: All requests finished + all failed
- completed: All requests finished + at least one succeeded
- in_progress: Default for validated batches (includes actively processing, partially completed, or queued/waiting states)