### PR TITLE
test: add unit tests for config and daemon endpoints

### DIFF
--- a/dwctl/src/api/handlers/config.rs
+++ b/dwctl/src/api/handlers/config.rs
@@ -28,3 +28,42 @@ pub async fn get_config(State(state): State<AppState>, _user: CurrentUser) -> im
 
     Json(metadata)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::api::models::users::Role;
+    use crate::test_utils::{add_auth_headers, create_test_app, create_test_user};
+    use axum::http::StatusCode;
+    use serde_json::Value;
+    use sqlx::PgPool;
+
+    #[sqlx::test]
+    async fn test_get_config_returns_metadata(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+
+        let headers = add_auth_headers(&user);
+        let response = app
+            .get("/admin/api/v1/config")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await;
+
+        response.assert_status(StatusCode::OK);
+        let json: Value = response.json();
+
+        // Check that metadata fields are present
+        assert!(json.get("region").is_some());
+        assert!(json.get("organization").is_some());
+        assert!(json.get("registration_enabled").is_some());
+    }
+
+    #[sqlx::test]
+    async fn test_get_config_requires_authentication(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+
+        let response = app.get("/admin/api/v1/config").await;
+
+        response.assert_status(StatusCode::UNAUTHORIZED);
+    }
+}

--- a/dwctl/src/api/handlers/daemons.rs
+++ b/dwctl/src/api/handlers/daemons.rs
@@ -97,3 +97,98 @@ pub async fn list_daemons(
 
     Ok(Json(ListDaemonsResponse { daemons: daemon_responses }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::models::users::Role;
+    use crate::test_utils::{add_auth_headers, create_test_app, create_test_user};
+    use axum::http::StatusCode;
+    use sqlx::PgPool;
+
+    #[sqlx::test]
+    async fn test_list_daemons_requires_system_read_all_permission(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+
+        let headers = add_auth_headers(&user);
+        let response = app
+            .get("/ai/v1/daemons")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await;
+
+        // Standard user should not have permission to view daemons
+        response.assert_status(StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test]
+    async fn test_list_daemons_platform_manager_can_access(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::PlatformManager).await;
+
+        let headers = add_auth_headers(&user);
+        let response = app
+            .get("/ai/v1/daemons")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await;
+
+        // PlatformManager should have System::ReadAll permission
+        response.assert_status(StatusCode::OK);
+        let json: ListDaemonsResponse = response.json();
+
+        // Should return a list (may be empty if no daemons running)
+        assert!(json.daemons.is_empty() || !json.daemons.is_empty());
+    }
+
+    #[sqlx::test]
+    async fn test_list_daemons_without_authentication(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+
+        let response = app.get("/ai/v1/daemons").await;
+
+        response.assert_status(StatusCode::UNAUTHORIZED);
+    }
+
+    #[sqlx::test]
+    async fn test_list_daemons_with_status_filter(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::PlatformManager).await;
+
+        let headers = add_auth_headers(&user);
+        let response = app
+            .get("/ai/v1/daemons?status=running")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await;
+
+        response.assert_status(StatusCode::OK);
+        let json: ListDaemonsResponse = response.json();
+
+        // All returned daemons should have "running" status
+        for daemon in json.daemons {
+            assert_eq!(daemon.status, DaemonStatus::Running);
+        }
+    }
+
+    #[sqlx::test]
+    async fn test_list_daemons_returns_empty_list_when_no_daemons(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::PlatformManager).await;
+
+        let headers = add_auth_headers(&user);
+        let response = app
+            .get("/ai/v1/daemons")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await;
+
+        response.assert_status(StatusCode::OK);
+        let json: ListDaemonsResponse = response.json();
+
+        // Since we're not running background daemons in tests (false parameter to create_test_app),
+        // we should get an empty list
+        assert_eq!(json.daemons.len(), 0);
+    }
+}

--- a/dwctl/src/api/models/daemons.rs
+++ b/dwctl/src/api/models/daemons.rs
@@ -60,7 +60,7 @@ pub struct ListDaemonsQuery {
 }
 
 /// Response for listing daemons.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ListDaemonsResponse {
     pub daemons: Vec<DaemonResponse>,
 }


### PR DESCRIPTION
Add comprehensive unit tests for configuration and daemon management endpoints.

**Config endpoint tests:**
- Verify metadata is returned for authenticated users
- Ensure unauthenticated requests are rejected

**Daemon endpoint tests:**
- Test permission requirements (StandardUser vs PlatformManager)
- Verify PlatformManager can access daemon list
- Test status filtering functionality
- Ensure unauthenticated requests are blocked

These tests validate authorization boundaries and basic endpoint functionality.