### PR TITLE
fix: use database NOW() for updated_at timestamps to prevent clock skew

### DIFF
--- a/.sqlx/query-6afd42e77c2350436b0d52248ec850d57892b6410d283c6139cb5a6b875bc02d.json
+++ b/.sqlx/query-6afd42e77c2350436b0d52248ec850d57892b6410d283c6139cb5a6b875bc02d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO groups (name, description, created_by, created_at, updated_at, source)\n            VALUES ($1, $2, $3, $4, $5, 'native')\n            RETURNING *\n            ",
+  "query": "\n            INSERT INTO groups (name, description, created_by, source)\n            VALUES ($1, $2, $3, 'native')\n            RETURNING *\n            ",
   "describe": {
     "columns": [
       {
@@ -43,9 +43,7 @@
       "Left": [
         "Varchar",
         "Text",
-        "Uuid",
-        "Timestamptz",
-        "Timestamptz"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -58,5 +56,5 @@
       false
     ]
   },
-  "hash": "693115f4302a611508670602d0e3701bd2306e47366d90280eecfacd90d0c5e4"
+  "hash": "6afd42e77c2350436b0d52248ec850d57892b6410d283c6139cb5a6b875bc02d"
 }

--- a/.sqlx/query-db0884e544b51277f9c834762a4925c46cb5f747ccd3e78d037df725ab5280b1.json
+++ b/.sqlx/query-db0884e544b51277f9c834762a4925c46cb5f747ccd3e78d037df725ab5280b1.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO inference_endpoints (name, description, url, api_key, model_filter, auth_header_name, auth_header_prefix, created_by, created_at, updated_at)\n            VALUES ($1, $2, $3, $4, $5, COALESCE($6, 'Authorization'), COALESCE($7, 'Bearer '), $8, $9, $10)\n            RETURNING *\n            ",
+  "query": "\n            INSERT INTO inference_endpoints (name, description, url, api_key, model_filter, auth_header_name, auth_header_prefix, created_by)\n            VALUES ($1, $2, $3, $4, $5, COALESCE($6, 'Authorization'), COALESCE($7, 'Bearer '), $8)\n            RETURNING *\n            ",
   "describe": {
     "columns": [
       {
@@ -68,9 +68,7 @@
         "TextArray",
         "Text",
         "Text",
-        "Uuid",
-        "Timestamptz",
-        "Timestamptz"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -87,5 +85,5 @@
       false
     ]
   },
-  "hash": "2b36a5920371b8c8d172b3f987c4c271dae0b3a9a5dfe71bb7b392b395672184"
+  "hash": "db0884e544b51277f9c834762a4925c46cb5f747ccd3e78d037df725ab5280b1"
 }

--- a/dwctl/migrations/034_add_updated_at_triggers.sql
+++ b/dwctl/migrations/034_add_updated_at_triggers.sql
@@ -1,0 +1,21 @@
+-- Create a generic function to update updated_at timestamp
+-- This can be reused across multiple tables
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- Add trigger for groups table
+CREATE TRIGGER update_groups_updated_at
+    BEFORE UPDATE ON groups
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Add trigger for inference_endpoints table
+CREATE TRIGGER update_inference_endpoints_updated_at
+    BEFORE UPDATE ON inference_endpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
Add PostgreSQL triggers to automatically set `updated_at` using database time instead of application time. This prevents inconsistencies when the application server and database server have different clocks.

**Changes:**
- Create reusable `update_updated_at_column()` function
- Add trigger for `groups` table  
- Add trigger for `inference_endpoints` table

**Benefits:**
- Prevents timestamp inconsistencies due to clock skew between app and DB servers
- Ensures `updated_at` is always set by the database on UPDATE operations
- Can be easily extended to other tables in the future

The trigger function is generic and can be reused across any table with an `updated_at` column.