### PR TITLE
fix: simplify auth in serializers

### DIFF
--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -150,13 +150,13 @@ mod static_assets;
 mod sync;
 pub mod telemetry;
 mod types;
+use crate::api::models::users::Role;
 use crate::config::CorsOrigin;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
 use crate::{
-    api::models::users::Role,
     auth::password,
     db::handlers::{Repository, Users},
     db::models::users::UserCreateDBRequest,
@@ -258,10 +258,12 @@ pub fn migrator() -> sqlx::migrate::Migrator {
 /// ```no_run
 /// # use dwctl::create_initial_admin_user;
 /// # use sqlx::PgPool;
+/// # use dwctl::auth::password::Argon2Params;
 /// # async fn example(pool: PgPool) -> Result<(), sqlx::Error> {
 /// let user_id = create_initial_admin_user(
 ///     "admin@example.com",
 ///     Some("secure_password"),
+///     Argon2Params::default(),
 ///     &pool
 /// ).await?;
 /// # Ok(())


### PR DESCRIPTION
This straightens out some of the billing and serialization logic by getting rid of the Playground auth matching, and assuming all auth is via API keys (which it is now, with the playground changes). It also fixes an unrelated broken doctest.

To re-add different pricing behaviour for i.e. playground vs. batches etc, we should add more information to the relevant API key. 