### PR TITLE
perf: add expression index for http_analytics id::text joins

### DIFF
--- a/dwctl/migrations/048_add_http_analytics_id_text_index.sql
+++ b/dwctl/migrations/048_add_http_analytics_id_text_index.sql
@@ -1,3 +1,5 @@
+-- no-transaction
+
 -- Add expression index for efficient joins between credits_transactions and http_analytics
 --
 -- The join `credits_transactions.source_id = http_analytics.id::text` requires a type cast


### PR DESCRIPTION
## Summary

- Adds expression index `idx_http_analytics_id_text` on `http_analytics ((id::text))`
- Fixes slow transaction listing queries that join `credits_transactions.source_id = http_analytics.id::text`
- The type cast prevented the planner from using the primary key index

**Performance improvement: ~4s → ~15ms**

## Test plan

- [x] Verified with `EXPLAIN ANALYZE` on production branch
- [x] Query now uses nested loop with index scan instead of sequential scan