### PR TITLE
feat: make pool metrics sample interval configurable

### DIFF
--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -969,6 +969,28 @@ pub struct BackgroundServicesConfig {
     pub batch_daemon: DaemonConfig,
     /// Leader election configuration for multi-instance deployments
     pub leader_election: LeaderElectionConfig,
+    /// Configuration for database pool metrics sampling
+    pub pool_metrics: PoolMetricsSamplerConfig,
+}
+
+/// Database pool metrics sampling configuration.
+///
+/// Controls how often database connection pool metrics are sampled and recorded.
+/// Metrics include connection counts (total, idle, in-use, max) for each pool.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct PoolMetricsSamplerConfig {
+    /// How often to sample pool metrics (default: 5s)
+    #[serde(with = "humantime_serde")]
+    pub sample_interval: Duration,
+}
+
+impl Default for PoolMetricsSamplerConfig {
+    fn default() -> Self {
+        Self {
+            sample_interval: Duration::from_secs(5),
+        }
+    }
 }
 
 /// Onwards configuration sync service configuration.

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1530,8 +1530,11 @@ async fn setup_background_services(
             });
         }
         let metrics_shutdown = shutdown_token.clone();
+        let metrics_config = db::PoolMetricsConfig {
+            sample_interval: config.background_services.pool_metrics.sample_interval,
+        };
         background_tasks.spawn("pool-metrics-sampler", async move {
-            db::run_pool_metrics_sampler(pools, db::PoolMetricsConfig::default(), metrics_shutdown).await
+            db::run_pool_metrics_sampler(pools, metrics_config, metrics_shutdown).await
         });
     }
 


### PR DESCRIPTION
## Summary
- Add `background_services.pool_metrics.sample_interval` config option to control how often database connection pool metrics are sampled
- Defaults to 5 seconds (preserving existing behavior)

## Configuration

Via config.yaml:
```yaml
background_services:
  pool_metrics:
    sample_interval: 10s
```

Via environment variable:
```bash
DWCTL_BACKGROUND_SERVICES__POOL_METRICS__SAMPLE_INTERVAL=10s
```

## Test plan
- [ ] Verify default behavior unchanged (5s interval)
- [ ] Test custom interval via config.yaml
- [ ] Test custom interval via env var