### PR TITLE
feat: add tracing instrumentation to request serialization flow

### DIFF
--- a/dwctl/src/metrics/gen_ai.rs
+++ b/dwctl/src/metrics/gen_ai.rs
@@ -8,6 +8,7 @@
 
 use async_trait::async_trait;
 use prometheus::{HistogramOpts, HistogramVec, Registry};
+use tracing::instrument;
 
 use crate::{metrics::MetricsRecorder, request_logging::serializers::HttpAnalyticsRow};
 
@@ -146,6 +147,7 @@ impl GenAiMetrics {
 
 #[async_trait]
 impl MetricsRecorder for GenAiMetrics {
+    #[instrument(skip_all)]
     async fn record_from_analytics(&self, row: &HttpAnalyticsRow) {
         // Extract operation from response_type
         let operation = match row.response_type.as_str() {

--- a/dwctl/src/request_logging/serializers.rs
+++ b/dwctl/src/request_logging/serializers.rs
@@ -1,3 +1,44 @@
+//! Request and response serialization for AI proxy analytics.
+//!
+//! This module provides the serialization layer between the [outlet] request logging
+//! middleware and the analytics database. It parses incoming AI requests, extracts
+//! usage metrics from responses, records analytics data, and handles credit deduction.
+//!
+//! # Request Path
+//!
+//! When [outlet] intercepts an incoming request, it calls [`parse_ai_request`] to parse
+//! the JSON body into an [`AiRequest`] variant (ChatCompletions, Completions, Embeddings,
+//! or Other). This happens synchronously before the request is forwarded upstream.
+//!
+//! # Response Path
+//!
+//! After the upstream response completes, [outlet] calls the response serializer.
+//! This is split into two phases:
+//!
+//! **Inline** (in the serializer closure):
+//! 1. Parse response body via [`parse_ai_response`] (handles JSON, SSE streams, compression)
+//! 2. Extract [`UsageMetrics`] (tokens, model, duration)
+//! 3. Extract auth info from headers
+//! 4. Return parsed [`AiResponse`] to outlet
+//!
+//! **Fire-and-forget** (spawned via `tokio::spawn`):
+//! 1. Lookup API key → user_id, email
+//! 2. Lookup model tariffs → price per token
+//! 3. Write [`HttpAnalyticsRow`] to `http_analytics` table
+//! 4. Deduct credits (if 2xx status and pricing configured)
+//! 5. Record Prometheus metrics
+//!
+//! The spawned task runs independently - outlet doesn't wait for it.
+//!
+//! # Credit Deduction
+//!
+//! Credits are deducted based on token usage and model-specific pricing. The serializer
+//! looks up the model's tariffs (input/output price per token) and creates a credit
+//! transaction for each successful request. Failed requests (non-2xx status codes) do
+//! not incur charges.
+//!
+//! [outlet]: https://github.com/doublewordai/outlet
+
 use crate::config::Config;
 use crate::db::errors::Result as DbResult;
 use crate::db::handlers::Credits;
@@ -12,7 +53,7 @@ use serde_json::Value;
 use sqlx::PgPool;
 use std::fmt;
 use std::str;
-use tracing::{debug, error, instrument, warn};
+use tracing::{Instrument, debug, error, info_span, instrument, warn};
 use uuid::Uuid;
 
 use super::utils;
@@ -116,6 +157,7 @@ pub struct UsageMetrics {
 /// # Behavior
 /// - Returns `AiRequest::Other(Value::Null)` for missing or empty bodies
 /// - On parse failure, returns error with base64-encoded body for safe PostgreSQL storage
+#[instrument(skip_all)]
 pub fn parse_ai_request(request_data: &RequestData) -> Result<ParsedAIRequest, SerializationError> {
     let headers = request_data
         .headers
@@ -174,6 +216,7 @@ pub fn parse_ai_request(request_data: &RequestData) -> Result<ParsedAIRequest, S
 /// - Handles gzip/brotli decompression based on Content-Encoding headers
 /// - Parses streaming responses (SSE format) vs non-streaming based on request stream parameter
 /// - On parse failure, returns error with base64-encoded decompressed body
+#[instrument(skip_all)]
 pub fn parse_ai_response(request_data: &RequestData, response_data: &ResponseData) -> Result<AiResponse, SerializationError> {
     let bytes = match &response_data.body {
         Some(body) => body.as_ref(),
@@ -222,6 +265,7 @@ impl UsageMetrics {
     ///
     /// # Returns
     /// A `UsageMetrics` struct with extracted model, tokens, and timing data
+    #[instrument(skip_all, name = "extract_usage_metrics")]
     pub fn extract(
         instance_id: Uuid,
         request_data: &RequestData,
@@ -266,6 +310,7 @@ impl UsageMetrics {
 
 impl Auth {
     /// Extract authentication from request headers
+    #[instrument(skip_all, name = "extract_auth")]
     pub fn from_request(request_data: &RequestData, _config: &Config) -> Self {
         // Check for API key in Authorization header
         if let Some(auth_header) = Self::get_header_value(request_data, "authorization")
@@ -397,6 +442,7 @@ pub async fn store_analytics_record(
             model_name
         )
         .fetch_optional(pool)
+        .instrument(info_span!("fetch_model_info"))
         .await?;
 
         if let Some(model_info) = model_info {
@@ -527,6 +573,7 @@ pub async fn store_analytics_record(
         row.custom_id
     )
     .fetch_one(pool)
+    .instrument(info_span!("insert_http_analytics"))
     .await?;
 
     // =======================================================================
@@ -832,6 +879,13 @@ where
     /// metadata (status code, duration, model, user, etc.) is still recorded.
     pub fn create_serializer(self) -> impl Fn(&RequestData, &ResponseData) -> Result<AiResponse, SerializationError> + Send + Sync {
         move |request_data: &RequestData, response_data: &ResponseData| {
+            let serializer_span = info_span!(
+                "response_serializer",
+                correlation_id = request_data.correlation_id,
+                status = %response_data.status
+            );
+            let _guard = serializer_span.enter();
+
             // Try to parse the response - may fail for error responses (4xx, 5xx)
             let parse_result = parse_ai_response(request_data, response_data);
 
@@ -852,35 +906,40 @@ where
             let pool_clone = self.pool.clone();
             let metrics_recorder_clone = self.metrics_recorder.clone();
             let request_data_clone = request_data.clone();
+            let correlation_id = request_data.correlation_id;
 
             // The write to the analytics table and metrics recording
             // This runs for ALL responses, including errors
-            tokio::spawn(async move {
-                // Store to database - this enriches with user/pricing data and returns complete row
-                let result = store_analytics_record(&pool_clone, &metrics, &auth, &request_data_clone).await;
+            let async_span = info_span!("analytics_storage", correlation_id = correlation_id);
+            tokio::spawn(
+                async move {
+                    // Store to database - this enriches with user/pricing data and returns complete row
+                    let result = store_analytics_record(&pool_clone, &metrics, &auth, &request_data_clone).await;
 
-                // Record analytics processing lag regardless of success/failure
-                // This measures time from response completion to storage attempt completion
-                let total_ms = chrono::Utc::now().signed_duration_since(metrics.timestamp).num_milliseconds();
-                let lag_ms = total_ms - metrics.duration_ms;
-                histogram!("dwctl_analytics_lag_seconds").record(lag_ms as f64 / 1000.0);
+                    // Record analytics processing lag regardless of success/failure
+                    // This measures time from response completion to storage attempt completion
+                    let total_ms = chrono::Utc::now().signed_duration_since(metrics.timestamp).num_milliseconds();
+                    let lag_ms = total_ms - metrics.duration_ms;
+                    histogram!("dwctl_analytics_lag_seconds").record(lag_ms as f64 / 1000.0);
 
-                match result {
-                    Ok(complete_row) => {
-                        // Record metrics using the complete row (called AFTER database write)
-                        if let Some(ref recorder) = metrics_recorder_clone {
-                            recorder.record_from_analytics(&complete_row).await;
+                    match result {
+                        Ok(complete_row) => {
+                            // Record metrics using the complete row (called AFTER database write)
+                            if let Some(ref recorder) = metrics_recorder_clone {
+                                recorder.record_from_analytics(&complete_row).await;
+                            }
+                        }
+                        Err(e) => {
+                            error!(
+                                correlation_id = metrics.correlation_id,
+                                error = %e,
+                                "Failed to store analytics data"
+                            );
                         }
                     }
-                    Err(e) => {
-                        error!(
-                            correlation_id = metrics.correlation_id,
-                            error = %e,
-                            "Failed to store analytics data"
-                        );
-                    }
                 }
-            });
+                .instrument(async_span),
+            );
 
             // Return the parse result - outlet-postgres will handle SerializationError
             // by storing the fallback_data (base64 encoded response)

--- a/dwctl/src/request_logging/utils.rs
+++ b/dwctl/src/request_logging/utils.rs
@@ -3,6 +3,7 @@
 use crate::request_logging::models::AiResponse;
 use outlet_postgres::SerializationError;
 use std::io::Read as _;
+use tracing::instrument;
 
 use super::models::{ChatCompletionChunk, SseParseError};
 
@@ -72,6 +73,7 @@ fn process_sse_chunks(chunks: Vec<String>) -> AiResponse {
 ///
 /// # Errors
 /// Returns error if both SSE parsing and JSON deserialization fail
+#[instrument(skip_all)]
 pub(crate) fn parse_streaming_response(body_str: &str) -> Result<AiResponse, Box<dyn std::error::Error>> {
     // Streaming: expect SSE, fallback to JSON
     parse_sse_chunks(body_str)
@@ -84,6 +86,7 @@ pub(crate) fn parse_streaming_response(body_str: &str) -> Result<AiResponse, Box
 ///
 /// # Errors
 /// Returns error if JSON deserialization fails
+#[instrument(skip_all)]
 pub(crate) fn parse_non_streaming_response(body_str: &str) -> Result<AiResponse, Box<dyn std::error::Error>> {
     serde_json::from_str(body_str).map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
 }
@@ -92,6 +95,7 @@ pub(crate) fn parse_non_streaming_response(body_str: &str) -> Result<AiResponse,
 ///
 /// # Errors
 /// Returns `SerializationError` if brotli decompression fails
+#[instrument(skip_all, name = "decompress_response")]
 pub(crate) fn decompress_response_if_needed(
     bytes: &[u8],
     headers: &std::collections::HashMap<String, Vec<bytes::Bytes>>,


### PR DESCRIPTION
## Summary

- Add `#[instrument]` attributes throughout the response serialization pipeline to enable timing analysis
- Instrument functions in `serializers.rs`: `parse_ai_request`, `parse_ai_response`, `extract_usage_metrics`, `extract_auth`
- Add parent spans `response_serializer` and `analytics_storage` with correlation_id for request tracking
- Instrument utility functions in `utils.rs`: `parse_streaming_response`, `parse_non_streaming_response`, `decompress_response_if_needed`
- Instrument `record_from_analytics` in `gen_ai.rs`

This provides visibility into where time is spent during request logging, useful for identifying bottlenecks in high-throughput scenarios.

## Test plan

- [x] `cargo build` passes
- [x] `just lint rust` passes
- [x] `just test rust` passes (673 tests)