### PR TITLE
chore: bump outlet to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwctl"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3416,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "outlet"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673b9c8576287972fad699668cc6e3161d563bc2fedd041981e1c1d99c9df7af"
+checksum = "cf1fe92691fe9a54b63b9b5e424801da9a1d1f3c7dd0b3492fcbfb1e2e1e4a98"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -74,7 +74,7 @@ axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
-outlet = "0.4.3"
+outlet = "0.4.4"
 outlet-postgres = "0.4.4"
 async-openai = { version = "0.29.2", default-features = false }
 brotli = "8.0"


### PR DESCRIPTION
## Summary
- Bump outlet from 0.4.3 to 0.4.4

This update includes the fix to process request handlers concurrently using JoinSet instead of sequentially.

## Test plan
- [ ] CI passes