### PR TITLE
feat: add progress bar for file uploads

### DIFF
--- a/dashboard/src/api/control-layer/hooks.ts
+++ b/dashboard/src/api/control-layer/hooks.ts
@@ -731,6 +731,23 @@ export function useUploadFile() {
   });
 }
 
+export function useUploadFileWithProgress() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      data,
+      onProgress,
+    }: {
+      data: FileUploadRequest;
+      onProgress?: (percent: number) => void;
+    }) => dwctlApi.files.uploadWithProgress(data, onProgress),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.files.lists() });
+    },
+  });
+}
+
 export function useDeleteFile() {
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
## Summary
- Add upload progress tracking using XMLHttpRequest to provide visual feedback during file uploads
- Previously uploads showed only a spinner with no indication of progress, which felt like hanging for larger files
- Progress bar shows percentage and animates smoothly during upload

## Test plan
- [ ] Upload a small file and verify upload completes successfully
- [ ] Upload a larger file (several MB) and verify progress bar animates from 0% to 100%
- [ ] Cancel/close modal during upload and verify state resets properly
- [ ] Verify error handling still works if upload fails