### PR TITLE
feat: improve batch modal UX with filename editing and copy updates

### DIFF
--- a/dashboard/src/api/control-layer/client.ts
+++ b/dashboard/src/api/control-layer/client.ts
@@ -1097,7 +1097,7 @@ const filesApi = {
     return new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();
       const formData = new FormData();
-      formData.append("file", data.file);
+      formData.append("file", data.file, data.filename || data.file.name);
       formData.append("purpose", data.purpose);
 
       if (data.expires_after) {

--- a/dashboard/src/api/control-layer/types.ts
+++ b/dashboard/src/api/control-layer/types.ts
@@ -812,6 +812,7 @@ export interface FileListResponse {
 export interface FileUploadRequest {
   file: File;
   purpose: string;
+  filename?: string;
   expires_after?: {
     anchor: "created_at";
     seconds: number;

--- a/dashboard/src/components/modals/CreateBatchModal/CreateBatchModal.test.tsx
+++ b/dashboard/src/components/modals/CreateBatchModal/CreateBatchModal.test.tsx
@@ -9,6 +9,7 @@ import * as hooks from "../../../api/control-layer/hooks";
 vi.mock("../../../api/control-layer/hooks", () => ({
   useCreateBatch: vi.fn(),
   useUploadFile: vi.fn(),
+  useUploadFileWithProgress: vi.fn(),
   useFiles: vi.fn(),
   useFileCostEstimate: vi.fn(),
   useConfig: vi.fn(() => ({
@@ -55,6 +56,26 @@ describe("CreateBatchModal", () => {
 
     // Default mock for useUploadFile
     vi.mocked(hooks.useUploadFile).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+      isError: false,
+      error: null,
+      isSuccess: false,
+      data: undefined,
+      mutate: vi.fn(),
+      reset: vi.fn(),
+      status: "idle",
+      context: undefined,
+      failureCount: 0,
+      failureReason: null,
+      isIdle: true,
+      isPaused: false,
+      submittedAt: 0,
+      variables: undefined,
+    } as any);
+
+    // Default mock for useUploadFileWithProgress
+    vi.mocked(hooks.useUploadFileWithProgress).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
       isError: false,
@@ -183,7 +204,7 @@ describe("CreateBatchModal", () => {
 
       // Add a description
       const descriptionInput = screen.getByPlaceholderText(
-        /daily evaluation batch/i,
+        /Data generation task/i,
       );
       await user.type(descriptionInput, "Test batch");
 
@@ -331,7 +352,7 @@ describe("CreateBatchModal", () => {
 
       // Find and focus the description input - use screen since Dialog renders in a portal
       const descriptionInput = screen.getByPlaceholderText(
-        /daily evaluation batch/i,
+        /Data generation task/i,
       );
       await user.click(descriptionInput);
       await user.type(descriptionInput, "Test batch description");
@@ -393,7 +414,7 @@ describe("CreateBatchModal", () => {
 
       // Find and focus the description input - use screen since Dialog renders in a portal
       const descriptionInput = screen.getByPlaceholderText(
-        /daily evaluation batch/i,
+        /Data generation task/i,
       );
       await user.click(descriptionInput);
       await user.type(descriptionInput, "Test description");
@@ -440,7 +461,7 @@ describe("CreateBatchModal", () => {
 
       // Find and focus the description input - use screen since Dialog renders in a portal
       const descriptionInput = screen.getByPlaceholderText(
-        /daily evaluation batch/i,
+        /Data generation task/i,
       );
       await user.click(descriptionInput);
       await user.type(descriptionInput, "Test description");
@@ -489,7 +510,7 @@ describe("CreateBatchModal", () => {
 
       // Find and focus the description input (don't type anything) - use screen since Dialog renders in a portal
       const descriptionInput = screen.getByPlaceholderText(
-        /daily evaluation batch/i,
+        /Data generation task/i,
       );
       await user.click(descriptionInput);
 

--- a/dashboard/src/components/modals/CreateFileModal/UploadFileModal.tsx
+++ b/dashboard/src/components/modals/CreateFileModal/UploadFileModal.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../ui/dialog";
 import { Button } from "../../ui/button";
 import { Label } from "../../ui/label";
+import { Input } from "../../ui/input";
 import {
   Select,
   SelectContent,
@@ -48,6 +49,7 @@ export function UploadFileModal({
   const [dragActive, setDragActive] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [uploadProgress, setUploadProgress] = useState<number>(0);
+  const [filename, setFilename] = useState<string>("");
 
   const uploadMutation = useUploadFileWithProgress();
   const { data: config } = useConfig();
@@ -78,6 +80,7 @@ export function UploadFileModal({
       const droppedFile = e.dataTransfer.files[0];
       if (droppedFile.name.endsWith(".jsonl")) {
         setFile(droppedFile);
+        setFilename(droppedFile.name);
       } else {
         setError("Please upload a .jsonl file");
       }
@@ -89,6 +92,7 @@ export function UploadFileModal({
       const selectedFile = e.target.files[0];
       if (selectedFile.name.endsWith(".jsonl")) {
         setFile(selectedFile);
+        setFilename(selectedFile.name);
         setError(null);
       } else {
         setError("Please upload a .jsonl file");
@@ -123,6 +127,7 @@ export function UploadFileModal({
         data: {
           file,
           purpose: "batch",
+          filename: filename || undefined,
           expires_after: {
             anchor: "created_at",
             seconds: expirationSeconds,
@@ -131,10 +136,11 @@ export function UploadFileModal({
         onProgress: setUploadProgress,
       });
 
-      toast.success(`File "${file.name}" uploaded successfully`);
+      toast.success(`File "${filename || file.name}" uploaded successfully`);
       setFile(null);
       setExpirationSeconds(2592000);
       setUploadProgress(0);
+      setFilename("");
       onSuccess?.();
       onClose();
     } catch (error) {
@@ -153,6 +159,7 @@ export function UploadFileModal({
     setExpirationSeconds(2592000);
     setError(null);
     setUploadProgress(0);
+    setFilename("");
     onClose();
   };
 
@@ -255,6 +262,22 @@ export function UploadFileModal({
                   style={{ width: `${uploadProgress}%` }}
                 />
               </div>
+            </div>
+          )}
+
+          {/* Filename Input (optional) */}
+          {file && (
+            <div className="space-y-2">
+              <Label htmlFor="filename">
+                New filename <span className="text-gray-400">(optional)</span>
+              </Label>
+              <Input
+                id="filename"
+                value={filename}
+                onChange={(e) => setFilename(e.target.value)}
+                placeholder={file.name}
+                disabled={uploadMutation.isPending}
+              />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Add editable filename field to batch and file upload modals
- Prepopulate filename input with original filename for easy editing
- Update copy to "Complete file upload to generate inference cost estimate"
- Update description placeholder to "e.g., Data generation task"

Fixes DW-394

## Test plan
- [ ] Upload a file via the batch modal and verify filename field is prepopulated
- [ ] Edit the filename and verify the uploaded file uses the new name
- [ ] Verify the new copy text appears correctly
- [ ] Test file upload via the files page modal as well