### PR TITLE
fix: add histogram buckets for fusillade_retry_attempts_on_success

### DIFF
--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -256,11 +256,19 @@ fn get_or_install_prometheus_handle() -> PrometheusHandle {
             // Custom histogram buckets for cache sync lag (1ms to 10s)
             const CACHE_SYNC_LAG_BUCKETS: &[f64] = &[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0];
 
+            // Custom histogram buckets for fusillade retry attempts (0-10 retries)
+            const RETRY_ATTEMPTS_BUCKETS: &[f64] = &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+
             PrometheusBuilder::new()
                 .set_buckets_for_metric(Matcher::Full("dwctl_analytics_lag_seconds".to_string()), ANALYTICS_LAG_BUCKETS)
                 .expect("Failed to set custom buckets for dwctl_analytics_lag_seconds")
                 .set_buckets_for_metric(Matcher::Full("dwctl_cache_sync_lag_seconds".to_string()), CACHE_SYNC_LAG_BUCKETS)
                 .expect("Failed to set custom buckets for dwctl_cache_sync_lag_seconds")
+                .set_buckets_for_metric(
+                    Matcher::Full("fusillade_retry_attempts_on_success".to_string()),
+                    RETRY_ATTEMPTS_BUCKETS,
+                )
+                .expect("Failed to set custom buckets for fusillade_retry_attempts_on_success")
                 .install_recorder()
                 .expect("Failed to install Prometheus recorder")
         })


### PR DESCRIPTION
## Summary
- Adds explicit histogram bucket configuration for the `fusillade_retry_attempts_on_success` metric
- Buckets are 0-10 to track retry attempt counts (0 = first attempt succeeded, 1 = 1 retry needed, etc.)
- Fixes the metric being exported as a summary with quantiles instead of a histogram with buckets

## Background
Without explicit bucket configuration, the `metrics` crate exports histograms as summaries with pre-calculated quantiles. This makes the retry attempts metric hard to interpret in Grafana dashboards - it shows confusing quantile values instead of a clear distribution.

With proper buckets, we can visualize:
- What % of requests succeed on first try
- What % need 1, 2, 3+ retries
- Retry patterns per model

## Test plan
- [x] `just lint rust` passes
- [x] `just test rust` passes (all 673 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)