### PR TITLE
fix weird stripe api restraint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwctl"
-version = "0.29.0"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/dwctl/src/payment_providers/stripe.rs
+++ b/dwctl/src/payment_providers/stripe.rs
@@ -86,11 +86,6 @@ impl PaymentProvider for StripeProvider {
                 business: Some(CreateCheckoutSessionNameCollectionBusiness::new(true)),
                 individual: None,
             })
-            .customer_update(CreateCheckoutSessionCustomerUpdate {
-                address: Some(CreateCheckoutSessionCustomerUpdateAddress::Auto),
-                name: Some(CreateCheckoutSessionCustomerUpdateName::Auto),
-                shipping: None,
-            })
             .saved_payment_method_options(CreateCheckoutSessionSavedPaymentMethodOptions {
                 allow_redisplay_filters: None,
                 payment_method_save: Some(CreateCheckoutSessionSavedPaymentMethodOptionsPaymentMethodSave::Enabled),
@@ -112,7 +107,13 @@ impl PaymentProvider for StripeProvider {
         if let Some(existing_id) = &user.payment_provider_id {
             // This is who is giving the credits
             tracing::debug!("Using existing Stripe customer ID {} for user {}", existing_id, user.id);
-            checkout_params = checkout_params.customer(existing_id.as_str());
+            checkout_params = checkout_params
+                .customer(existing_id.as_str())
+                .customer_update(CreateCheckoutSessionCustomerUpdate {
+                    address: Some(CreateCheckoutSessionCustomerUpdateAddress::Auto),
+                    name: Some(CreateCheckoutSessionCustomerUpdateName::Auto),
+                    shipping: None,
+                })
         } else {
             tracing::debug!("No customer ID found for user {}, Stripe will create one", user.id);
             // Provide customer email for the new customer


### PR DESCRIPTION
stripe is incapable of ignoring the customer_update field even if there's no customer, make it conditional instead