### PR TITLE
fix!: hide virtual model information from non-platform managers. And bump API version

### DIFF
--- a/dashboard/src/components/features/models/ModelInfo/ModelInfo.tsx
+++ b/dashboard/src/components/features/models/ModelInfo/ModelInfo.tsx
@@ -455,18 +455,12 @@ const ModelInfo: React.FC = () => {
                     </p>
                   )}
                   {!canManageGroups &&
-                    (model.is_composite ? (
-                      <p className="text-doubleword-neutral-600 mt-1 inline-flex items-center gap-1">
-                        <GitMerge className="h-3 w-3" />
-                        Virtual Model
+                    !model.is_composite &&
+                    canViewEndpoints && (
+                      <p className="text-doubleword-neutral-600 mt-1">
+                        {endpoint?.name || "Unknown endpoint"}
                       </p>
-                    ) : (
-                      canViewEndpoints && (
-                        <p className="text-doubleword-neutral-600 mt-1">
-                          {endpoint?.name || "Unknown endpoint"}
-                        </p>
-                      )
-                    ))}
+                    )}
                 </div>
                 <div className="flex items-center justify-center sm:justify-start gap-3">
                   {canManageGroups && (

--- a/dashboard/src/components/features/models/Models/Models.tsx
+++ b/dashboard/src/components/features/models/Models/Models.tsx
@@ -173,7 +173,7 @@ const Models: React.FC = () => {
                       <SlidersHorizontal className="h-4 w-4" />
                       <span className="hidden sm:inline">Filter</span>
                       <ChevronDown className="h-3 w-3 opacity-50" />
-                      {(filterProvider !== "all" || filterModelType !== "all" || showAccessibleOnly) && (
+                      {(filterProvider !== "all" || (canManageGroups && filterModelType !== "all") || showAccessibleOnly) && (
                         <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-blue-500" />
                       )}
                     </Button>
@@ -204,25 +204,27 @@ const Models: React.FC = () => {
                           </Select>
                         </div>
                       )}
-                      <div className="space-y-2">
-                        <Label>Model Type</Label>
-                        <div className="flex rounded-md border border-input overflow-hidden">
-                          {(["all", "virtual", "hosted"] as const).map((type) => (
-                            <button
-                              key={type}
-                              onClick={() => setFilterModelType(type)}
-                              className={`flex-1 px-2 py-1.5 text-xs font-medium transition-colors ${
-                                filterModelType === type
-                                  ? "bg-primary text-primary-foreground"
-                                  : "bg-background hover:bg-muted text-muted-foreground"
-                              }`}
-                              aria-label={`Show ${type === "all" ? "all models" : type + " models"}`}
-                            >
-                              {type === "all" ? "All" : type === "virtual" ? "Virtual" : "Hosted"}
-                            </button>
-                          ))}
+                      {canManageGroups && (
+                        <div className="space-y-2">
+                          <Label>Model Type</Label>
+                          <div className="flex rounded-md border border-input overflow-hidden">
+                            {(["all", "virtual", "hosted"] as const).map((type) => (
+                              <button
+                                key={type}
+                                onClick={() => setFilterModelType(type)}
+                                className={`flex-1 px-2 py-1.5 text-xs font-medium transition-colors ${
+                                  filterModelType === type
+                                    ? "bg-primary text-primary-foreground"
+                                    : "bg-background hover:bg-muted text-muted-foreground"
+                                }`}
+                                aria-label={`Show ${type === "all" ? "all models" : type + " models"}`}
+                              >
+                                {type === "all" ? "All" : type === "virtual" ? "Virtual" : "Hosted"}
+                              </button>
+                            ))}
+                          </div>
                         </div>
-                      </div>
+                      )}
                       {!isStatusMode && canManageGroups && (
                         <div className="flex items-center justify-between">
                           <Label htmlFor="access-toggle" className="cursor-pointer">

--- a/dashboard/src/components/features/models/Models/ModelsContent.tsx
+++ b/dashboard/src/components/features/models/Models/ModelsContent.tsx
@@ -307,7 +307,7 @@ export const ModelsContent: React.FC<ModelsContentProps> = ({
                               </CardTitle>
                             )}
 
-                            {model.is_composite && (
+                            {canManageGroups && model.is_composite && (
                               <HoverCard openDelay={200} closeDelay={100}>
                                 <HoverCardTrigger asChild>
                                   <Badge
@@ -531,8 +531,8 @@ export const ModelsContent: React.FC<ModelsContentProps> = ({
                           )}
                         </div>
 
-                        {/* ROW 2: Endpoint or Hosted Model Count */}
-                        {model.is_composite ? (
+                        {/* ROW 2: Endpoint or Hosted Model Count (only for platform managers) */}
+                        {canManageGroups && model.is_composite ? (
                           <CardDescription className="flex items-center gap-1.5 min-w-0 mb-2">
                             <span className="text-gray-600 text-sm">
                               <span className="font-medium">
@@ -544,6 +544,7 @@ export const ModelsContent: React.FC<ModelsContentProps> = ({
                             </span>
                           </CardDescription>
                         ) : (
+                          !model.is_composite &&
                           canViewEndpoints &&
                           model.endpoint && (
                             <CardDescription className="flex items-center gap-1.5 min-w-0 mb-2">


### PR DESCRIPTION
## Summary
- Hides the "Virtual" badge on model cards from non-platform managers
- Hides the "N hosted models" count from non-platform managers  
- Hides the Model Type filter (all/virtual/hosted) from non-platform managers
- Removes the "Virtual Model" label in ModelInfo for non-platform managers

Virtual models now appear identical to regular models for standard users. They technically already did (because the backend API blocked them out) but this PR means that if you're secretly an admin (like me in prod, or everyone in dev) you don't get sneaky buttons. 

## Test plan
- [x] Lint passes (`just lint ts`)
- [x] Tests pass (`just test ts` - 338 tests)
- [ ] Manual verification: log in as standard user and confirm virtual models show no distinguishing indicators