### PR TITLE
fix(dashboard): pass is_composite filter to models API

### DIFF
--- a/dashboard/src/api/control-layer/client.ts
+++ b/dashboard/src/api/control-layer/client.ts
@@ -235,6 +235,8 @@ const modelApi = {
     if (options?.accessible !== undefined)
       params.set("accessible", options.accessible.toString());
     if (options?.search) params.set("search", options.search);
+    if (options?.is_composite !== undefined)
+      params.set("is_composite", options.is_composite.toString());
 
     const url = `/admin/api/v1/models${params.toString() ? "?" + params.toString() : ""}`;
     const response = await fetch(url);


### PR DESCRIPTION
## Summary
- Fixed the virtual/hosted model type filter in the Models page not working
- The `is_composite` query parameter was defined in `ModelsQuery` type but was never being added to the API request URL in `client.ts`

## Test plan
- [x] Lint passes (`just lint ts`)
- [x] Tests pass (`just test ts`)
- [ ] Manual test: Navigate to Models page, open Filter popover, toggle between All/Virtual/Hosted and verify filtering works