### PR TITLE
feat: trigger deployment on release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -385,6 +385,28 @@ jobs:
           # Report metrics to Somnial
           curl -X POST "https://charts.somnial.co/doubleword-control-layer/e2e-docker-duration?value=${E2E_DURATION}" || true
 
+  notify-deploy:
+    if: github.event_name == 'release' && !github.event.release.prerelease
+    needs: [build, frontend-test, backend-test, security-scan, e2e-test-docker]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger deployment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DEPLOY_PAT }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: '${{ secrets.DEPLOY_TARGET_OWNER }}',
+              repo: '${{ secrets.DEPLOY_TARGET_REPO }}',
+              event_type: 'control-layer-release',
+              client_payload: {
+                version: '${{ github.event.release.tag_name }}',
+                sha: context.sha
+              }
+            })
+            console.log(`Triggered deployment for version ${{ github.event.release.tag_name }}`)
+
   publish-crates:
     if: github.event_name == 'release' && !github.event.release.prerelease
     runs-on: depot-ubuntu-24.04


### PR DESCRIPTION
## Summary
- Adds `notify-deploy` job to CI workflow that triggers after releases
- Sends `repository_dispatch` event to the internal deployment repo
- Only runs on non-prerelease releases, after all CI checks pass

## How it works
1. Release is published on control-layer
2. CI runs: build, tests, security scan, e2e tests
3. `notify-deploy` job sends dispatch event with version and SHA
4. Internal repo receives event and creates a PR to update the image tag

## Security
- Target repo owner/name stored as secrets (not in code)
- Uses a dedicated PAT with minimal scope

## Test plan
- [ ] Secrets configured: `DEPLOY_PAT`, `DEPLOY_TARGET_OWNER`, `DEPLOY_TARGET_REPO`
- [ ] Test with manual dispatch before real release
- [ ] Verify PR is created in internal repo