### PR TITLE
fix: UX bug responses still showing error

### DIFF
--- a/dashboard/src/components/features/batches/BatchInfo/BatchInfo.tsx
+++ b/dashboard/src/components/features/batches/BatchInfo/BatchInfo.tsx
@@ -894,7 +894,7 @@ const BatchInfo: React.FC = () => {
                       </div>
                     )}
 
-                    {batch.failed_at && (
+                    {batch.failed_at && batch.status === "failed" && (
                       <div>
                         <p className="text-sm text-gray-600 mb-1">Failed</p>
                         <p className="text-sm font-medium text-red-600">

--- a/dashboard/src/components/features/batches/BatchInfo/batch-results-columns.tsx
+++ b/dashboard/src/components/features/batches/BatchInfo/batch-results-columns.tsx
@@ -29,10 +29,10 @@ const getContentPreview = (
 
   if (contentType === "input") {
     content = result.input_body;
+  } else if (result.response_body) {
+    content = result.response_body;
   } else if (result.error) {
     content = { error: result.error };
-  } else {
-    content = result.response_body;
   }
 
   const previewText = content


### PR DESCRIPTION
Batch views are slightly off when retried. They still showed errors in the responses in results view and in the details view we had failed at on the timeline