### PR TITLE
ci: dispatch event to downstream on main push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -407,6 +407,26 @@ jobs:
             })
             console.log(`Triggered deployment for version ${{ github.event.release.tag_name }}`)
 
+  notify-downstream:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dispatch to downstream
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.DEPLOY_PAT }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: '${{ secrets.DEPLOY_TARGET_OWNER }}',
+              repo: '${{ secrets.DEPLOY_TARGET_REPO }}',
+              event_type: 'control-layer-main-push',
+              client_payload: {
+                sha: context.sha
+              }
+            })
+
   publish-crates:
     if: github.event_name == 'release' && !github.event.release.prerelease
     runs-on: depot-ubuntu-24.04


### PR DESCRIPTION
## Summary
- Adds a `notify-downstream` job to CI that fires on pushes to `main`
- Dispatches a `control-layer-main-push` event (with SHA) to the internal repo after the Docker image is built
- Enables the internal repo to trigger staging deployments automatically

## Test plan
- [ ] Verify the workflow YAML is valid (CI will check this)
- [ ] Merge and push a commit to main → confirm dispatch is received by internal repo