### PR TITLE
feat: decouple analytics/billing from request logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwctl"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3480,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "outlet"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1fe92691fe9a54b63b9b5e424801da9a1d1f3c7dd0b3492fcbfb1e2e1e4a98"
+checksum = "b4f758dc3f2fc74b18f4df9222b5bd7d2ed540547c38f09e0840b5d6c16f9b6e"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -74,7 +74,7 @@ axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
-outlet = "0.4.4"
+outlet = "0.4.5"
 outlet-postgres = "0.4.5"
 async-openai = { version = "0.29.2", default-features = false }
 brotli = "8.0"

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -138,8 +138,19 @@ pub struct Config {
     pub background_services: BackgroundServicesConfig,
     /// Enable Prometheus metrics endpoint at `/internal/metrics`
     pub enable_metrics: bool,
-    /// Enable request/response logging to PostgreSQL
+    /// Enable request/response logging to PostgreSQL (outlet-postgres)
+    ///
+    /// When enabled, raw request and response bodies are stored in the
+    /// `http_requests` and `http_responses` tables for debugging and auditing.
     pub enable_request_logging: bool,
+    /// Enable analytics and billing (http_analytics table, credit deduction, Prometheus metrics)
+    ///
+    /// Can be enabled independently of `enable_request_logging`. When enabled without
+    /// request logging, analytics data is still recorded but raw request/response
+    /// bodies are not stored.
+    ///
+    /// When disabled, no analytics, billing, or GenAI metrics are recorded.
+    pub enable_analytics: bool,
     /// Enable OpenTelemetry OTLP export for distributed tracing
     pub enable_otel_export: bool,
     /// Credit system configuration
@@ -1157,6 +1168,7 @@ impl Default for Config {
             background_services: BackgroundServicesConfig::default(),
             enable_metrics: true,
             enable_request_logging: true,
+            enable_analytics: true,
             enable_otel_export: false,
             credits: CreditsConfig::default(),
             sample_files: SampleFilesConfig::default(),

--- a/dwctl/src/db/handlers/api_keys.rs
+++ b/dwctl/src/db/handlers/api_keys.rs
@@ -1855,6 +1855,7 @@ mod tests {
             auth: Default::default(),
             enable_metrics: false,
             enable_request_logging: false,
+            enable_analytics: true,
             enable_otel_export: false,
             credits: Default::default(),
             batches: Default::default(),

--- a/dwctl/src/request_logging/analytics_handler.rs
+++ b/dwctl/src/request_logging/analytics_handler.rs
@@ -1,0 +1,214 @@
+//! Analytics request handler for AI proxy requests.
+//!
+//! This module provides [`AnalyticsHandler`], a standalone implementation of the [`outlet::RequestHandler`]
+//! trait that handles analytics, billing (credit deduction), and Prometheus metrics recording.
+//!
+//! # Decoupling from Request Logging
+//!
+//! Previously, analytics was coupled to request logging via outlet-postgres. The analytics logic
+//! lived inside a "serializer" callback, meaning if request logging was disabled, no analytics
+//! would be recorded either.
+//!
+//! This handler can be used independently or composed with other handlers (like PostgresHandler
+//! for request logging) using [`outlet::MultiHandler`].
+//!
+//! # What This Handler Does
+//!
+//! For each response:
+//! 1. Parses the AI response to extract token usage
+//! 2. Extracts authentication info from request headers
+//! 3. Stores analytics to `http_analytics` table
+//! 4. Deducts credits based on token usage and model pricing
+//! 5. Records Prometheus metrics
+//!
+//! # Example
+//!
+//! ```ignore
+//! use outlet::{MultiHandler, RequestLoggerConfig, RequestLoggerLayer};
+//! use dwctl::request_logging::AnalyticsHandler;
+//!
+//! // Create standalone analytics handler
+//! let analytics = AnalyticsHandler::new(pool, instance_id, config, metrics_recorder);
+//!
+//! // Use with MultiHandler for composition
+//! let handler = MultiHandler::new()
+//!     .with(postgres_handler)  // request logging
+//!     .with(analytics);        // analytics/billing
+//!
+//! let layer = RequestLoggerLayer::new(outlet_config, handler);
+//! ```
+
+use crate::config::Config;
+use crate::request_logging::AiResponse;
+use crate::request_logging::serializers::{Auth, UsageMetrics, parse_ai_response, store_analytics_record};
+use metrics::histogram;
+use outlet::{RequestData, RequestHandler, ResponseData};
+use serde_json::Value;
+use sqlx::PgPool;
+use tracing::{Instrument, error, info_span};
+use uuid::Uuid;
+
+/// A request handler that stores analytics data and records metrics.
+///
+/// This handler implements [`outlet::RequestHandler`] and can be used standalone or composed
+/// with other handlers using [`outlet::MultiHandler`].
+///
+/// # Type Parameters
+///
+/// * `M` - The metrics recorder type, must implement [`crate::metrics::MetricsRecorder`]
+pub struct AnalyticsHandler<M = crate::metrics::GenAiMetrics>
+where
+    M: crate::metrics::MetricsRecorder + Clone + 'static,
+{
+    pool: PgPool,
+    instance_id: Uuid,
+    config: Config,
+    metrics_recorder: Option<M>,
+}
+
+impl<M> AnalyticsHandler<M>
+where
+    M: crate::metrics::MetricsRecorder + Clone + 'static,
+{
+    /// Creates a new analytics handler.
+    ///
+    /// # Arguments
+    ///
+    /// * `pool` - Database connection pool for storing analytics data
+    /// * `instance_id` - Unique identifier for this service instance
+    /// * `config` - Application configuration
+    /// * `metrics_recorder` - Optional metrics recorder for Prometheus metrics
+    pub fn new(pool: PgPool, instance_id: Uuid, config: Config, metrics_recorder: Option<M>) -> Self {
+        Self {
+            pool,
+            instance_id,
+            config,
+            metrics_recorder,
+        }
+    }
+}
+
+impl<M> RequestHandler for AnalyticsHandler<M>
+where
+    M: crate::metrics::MetricsRecorder + Clone + Send + Sync + 'static,
+{
+    /// No-op for request phase - analytics only needs response data.
+    async fn handle_request(&self, _data: RequestData) {
+        // Analytics doesn't need the request phase
+    }
+
+    /// Handles analytics, billing, and metrics recording for a completed response.
+    ///
+    /// This method:
+    /// 1. Parses the AI response to extract token usage
+    /// 2. Extracts authentication info from request headers
+    /// 3. Stores analytics to `http_analytics` table
+    /// 4. Deducts credits based on token usage and model pricing
+    /// 5. Records Prometheus metrics
+    async fn handle_response(&self, request_data: RequestData, response_data: ResponseData) {
+        let correlation_id = request_data.correlation_id;
+        let span = info_span!(
+            "analytics_handler",
+            correlation_id = correlation_id,
+            status = %response_data.status
+        );
+
+        async {
+            // Try to parse the response - may fail for error responses (4xx, 5xx)
+            let parse_result = parse_ai_response(&request_data, &response_data);
+
+            // Use parsed response for metrics, or fallback to Other for error responses
+            let metrics_response = match &parse_result {
+                Ok(response) => response.clone(),
+                Err(_) => AiResponse::Other(Value::Null),
+            };
+
+            // Extract basic metrics - captures status_code, duration, model from request, etc.
+            let metrics = UsageMetrics::extract(self.instance_id, &request_data, &response_data, &metrics_response, &self.config);
+
+            // Extract auth information from headers
+            let auth = Auth::from_request(&request_data, &self.config);
+
+            // Store to database - this enriches with user/pricing data and returns complete row
+            let result = store_analytics_record(&self.pool, &metrics, &auth, &request_data).await;
+
+            // Record analytics processing lag regardless of success/failure
+            // This measures time from response completion to storage attempt completion
+            let total_ms = chrono::Utc::now().signed_duration_since(metrics.timestamp).num_milliseconds();
+            let lag_ms = total_ms - metrics.duration_ms;
+            histogram!("dwctl_analytics_lag_seconds").record(lag_ms as f64 / 1000.0);
+
+            match result {
+                Ok(complete_row) => {
+                    // Record metrics using the complete row (called AFTER database write)
+                    if let Some(ref recorder) = self.metrics_recorder {
+                        recorder.record_from_analytics(&complete_row).await;
+                    }
+                }
+                Err(e) => {
+                    error!(
+                        correlation_id = metrics.correlation_id,
+                        error = %e,
+                        "Failed to store analytics data"
+                    );
+                }
+            }
+        }
+        .instrument(span)
+        .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{Method, StatusCode, Uri};
+    use std::collections::HashMap;
+    use std::time::{Duration, SystemTime};
+
+    fn create_test_request_data() -> RequestData {
+        RequestData {
+            correlation_id: 123,
+            timestamp: SystemTime::now(),
+            method: Method::POST,
+            uri: Uri::from_static("/ai/v1/chat/completions"),
+            headers: HashMap::new(),
+            body: None,
+        }
+    }
+
+    fn create_test_response_data() -> ResponseData {
+        ResponseData {
+            correlation_id: 123,
+            timestamp: SystemTime::now(),
+            status: StatusCode::OK,
+            headers: HashMap::new(),
+            body: None,
+            duration_to_first_byte: Duration::from_millis(10),
+            duration: Duration::from_millis(100),
+        }
+    }
+
+    #[test]
+    fn test_analytics_handler_creation() {
+        // Just verify the type can be constructed with the expected parameters
+        // Actual database tests would require integration test setup
+        let _config = Config::default();
+        // Handler would be created like:
+        // let handler = AnalyticsHandler::new(pool, Uuid::new_v4(), config, None::<GenAiMetrics>);
+    }
+
+    #[test]
+    fn test_request_data_creation() {
+        let data = create_test_request_data();
+        assert_eq!(data.correlation_id, 123);
+        assert_eq!(data.method, Method::POST);
+    }
+
+    #[test]
+    fn test_response_data_creation() {
+        let data = create_test_response_data();
+        assert_eq!(data.correlation_id, 123);
+        assert_eq!(data.status, StatusCode::OK);
+    }
+}

--- a/dwctl/src/request_logging/mod.rs
+++ b/dwctl/src/request_logging/mod.rs
@@ -1,5 +1,7 @@
+pub mod analytics_handler;
 pub mod models;
 pub mod serializers;
 mod utils;
 
+pub use analytics_handler::AnalyticsHandler;
 pub use models::{AiRequest, AiResponse, ParsedAIRequest};

--- a/dwctl/src/request_logging/serializers.rs
+++ b/dwctl/src/request_logging/serializers.rs
@@ -45,7 +45,7 @@ use crate::db::handlers::Credits;
 use crate::db::models::credits::{CreditTransactionCreateDBRequest, CreditTransactionType};
 use crate::request_logging::models::{AiRequest, AiResponse, ChatCompletionChunk, ParsedAIRequest};
 use crate::request_logging::utils::{extract_header_as_string, extract_header_as_uuid};
-use metrics::{counter, histogram};
+use metrics::counter;
 use outlet::{RequestData, ResponseData};
 use outlet_postgres::SerializationError;
 use rust_decimal::{Decimal, prelude::ToPrimitive};
@@ -53,7 +53,7 @@ use serde_json::Value;
 use sqlx::PgPool;
 use std::fmt;
 use std::str;
-use tracing::{Instrument, debug, error, info_span, instrument, warn};
+use tracing::{Instrument, debug, info_span, instrument, warn};
 use uuid::Uuid;
 
 use super::utils;
@@ -859,120 +859,6 @@ impl From<&AiResponse> for TokenMetrics {
                 response_type: "other".to_string(),
                 response_model: None,
             },
-        }
-    }
-}
-
-pub struct AnalyticsResponseSerializer<M = crate::metrics::GenAiMetrics>
-where
-    M: crate::metrics::MetricsRecorder + Clone + 'static,
-{
-    pool: PgPool,
-    instance_id: Uuid,
-    config: Config,
-    metrics_recorder: Option<M>,
-}
-
-impl<M> AnalyticsResponseSerializer<M>
-where
-    M: crate::metrics::MetricsRecorder + Clone + 'static,
-{
-    /// Creates a new analytics response serializer.
-    ///
-    /// # Arguments
-    /// * `pool` - Database connection pool for storing analytics data
-    /// * `instance_id` - Unique identifier for this service instance
-    /// * `config` - Application configuration
-    /// * `metrics_recorder` - Optional metrics recorder
-    pub fn new(pool: PgPool, instance_id: Uuid, config: Config, metrics_recorder: Option<M>) -> Self {
-        Self {
-            pool,
-            instance_id,
-            config,
-            metrics_recorder,
-        }
-    }
-
-    /// Creates a serializer function that parses responses and stores analytics data.
-    ///
-    /// # Returns
-    /// A closure that implements the outlet-postgres serializer interface:
-    /// - Takes `RequestData` and `ResponseData` as input
-    /// - Returns parsed `AiResponse` or `SerializationError`
-    /// - Asynchronously stores analytics metrics to database
-    /// - Logs errors if analytics storage fails
-    ///
-    /// # Analytics Storage
-    /// Analytics are stored for ALL responses, including error responses (4xx, 5xx).
-    /// Even if the response cannot be parsed as a valid AI response, the request
-    /// metadata (status code, duration, model, user, etc.) is still recorded.
-    pub fn create_serializer(self) -> impl Fn(&RequestData, &ResponseData) -> Result<AiResponse, SerializationError> + Send + Sync {
-        move |request_data: &RequestData, response_data: &ResponseData| {
-            let serializer_span = info_span!(
-                "response_serializer",
-                correlation_id = request_data.correlation_id,
-                status = %response_data.status
-            );
-            let _guard = serializer_span.enter();
-
-            // Try to parse the response - may fail for error responses (4xx, 5xx)
-            let parse_result = parse_ai_response(request_data, response_data);
-
-            // Use parsed response for metrics, or fallback to Other for error responses
-            let metrics_response = match &parse_result {
-                Ok(response) => response.clone(),
-                Err(_) => AiResponse::Other(Value::Null),
-            };
-
-            // Basic metrics - extracted regardless of parse success
-            // This captures status_code, duration, model from request, etc.
-            let metrics = UsageMetrics::extract(self.instance_id, request_data, response_data, &metrics_response, &self.config);
-
-            // Auth information
-            let auth = Auth::from_request(request_data, &self.config);
-
-            // Clone data for async processing
-            let pool_clone = self.pool.clone();
-            let metrics_recorder_clone = self.metrics_recorder.clone();
-            let request_data_clone = request_data.clone();
-            let correlation_id = request_data.correlation_id;
-
-            // The write to the analytics table and metrics recording
-            // This runs for ALL responses, including errors
-            let async_span = info_span!("analytics_storage", correlation_id = correlation_id);
-            tokio::spawn(
-                async move {
-                    // Store to database - this enriches with user/pricing data and returns complete row
-                    let result = store_analytics_record(&pool_clone, &metrics, &auth, &request_data_clone).await;
-
-                    // Record analytics processing lag regardless of success/failure
-                    // This measures time from response completion to storage attempt completion
-                    let total_ms = chrono::Utc::now().signed_duration_since(metrics.timestamp).num_milliseconds();
-                    let lag_ms = total_ms - metrics.duration_ms;
-                    histogram!("dwctl_analytics_lag_seconds").record(lag_ms as f64 / 1000.0);
-
-                    match result {
-                        Ok(complete_row) => {
-                            // Record metrics using the complete row (called AFTER database write)
-                            if let Some(ref recorder) = metrics_recorder_clone {
-                                recorder.record_from_analytics(&complete_row).await;
-                            }
-                        }
-                        Err(e) => {
-                            error!(
-                                correlation_id = metrics.correlation_id,
-                                error = %e,
-                                "Failed to store analytics data"
-                            );
-                        }
-                    }
-                }
-                .instrument(async_span),
-            );
-
-            // Return the parse result - outlet-postgres will handle SerializationError
-            // by storing the fallback_data (base64 encoded response)
-            parse_result
         }
     }
 }

--- a/dwctl/src/test/utils.rs
+++ b/dwctl/src/test/utils.rs
@@ -151,6 +151,7 @@ pub fn create_test_config() -> crate::config::Config {
         },
         enable_metrics: false,
         enable_request_logging: false,
+        enable_analytics: true,
         enable_otel_export: false,
         credits: crate::config::CreditsConfig::default(),
         batches: BatchConfig {


### PR DESCRIPTION
## Summary

- Add `enable_analytics` config option to independently control analytics/billing
- Add `AnalyticsHandler` as standalone `RequestHandler` implementation
- Use `outlet::MultiHandler` to compose handlers based on config flags
- Remove unused `AnalyticsResponseSerializer`
- Bump outlet to 0.4.5 (adds `MultiHandler`)

## Motivation

Previously, analytics/billing (credit deduction, Prometheus metrics, `http_analytics` table) was coupled to request logging. If `enable_request_logging = false`, no analytics would happen either.

Now users can independently control:
- `enable_request_logging`: raw request/response storage via outlet-postgres
- `enable_analytics`: analytics data, billing, and Prometheus metrics

## Test plan

- [x] All 721 existing tests pass
- [x] E2E test verifies credit deduction still works
- [x] Linting passes