### PR TITLE
feat: add pool exhaustion error handling with 503 response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwctl"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/dwctl/src/errors.rs
+++ b/dwctl/src/errors.rs
@@ -71,6 +71,10 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
 
+/// Retry-After header value (in seconds) for 503 Service Unavailable responses
+/// when the database connection pool is exhausted.
+const POOL_EXHAUSTED_RETRY_AFTER_SECS: &str = "30";
+
 #[derive(ThisError, Debug)]
 pub enum Error {
     /// Authentication required but not provided
@@ -146,6 +150,7 @@ impl Error {
                 DbError::CheckViolation { .. } => StatusCode::BAD_REQUEST,
                 DbError::ProtectedEntity { .. } => StatusCode::FORBIDDEN,
                 DbError::InvalidModelField { .. } => StatusCode::BAD_REQUEST,
+                DbError::PoolExhausted => StatusCode::SERVICE_UNAVAILABLE,
                 DbError::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
             },
             Error::Other(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -193,6 +198,7 @@ impl Error {
                     format!("Cannot {operation:?} {entity_type}: {reason}")
                 }
                 DbError::InvalidModelField { field } => format!("Field '{field}' must not be empty or whitespace"),
+                DbError::PoolExhausted => "Service temporarily overloaded, please retry".to_string(),
                 DbError::Other(_) => "Database error occurred".to_string(),
             },
             Error::Other(_) => "Internal server error".to_string(),
@@ -216,6 +222,9 @@ impl IntoResponse for Error {
         match &self {
             Error::Database(DbError::Other(_)) | Error::Internal { .. } | Error::Other(_) => {
                 tracing::error!("Internal service error: {:#}", self);
+            }
+            Error::Database(DbError::PoolExhausted) => {
+                tracing::warn!("Database connection pool exhausted - service overloaded");
             }
             Error::Database(_) => {
                 tracing::warn!("Database constraint error: {}", self);
@@ -253,6 +262,17 @@ impl IntoResponse for Error {
                 };
 
                 (status, axum::response::Json(body)).into_response()
+            }
+            // Handle pool exhaustion with Retry-After header
+            Error::Database(DbError::PoolExhausted) => {
+                use axum::http::header::RETRY_AFTER;
+                use serde_json::json;
+                let body = json!({
+                    "error": "service_unavailable",
+                    "message": self.user_message(),
+                    "retry_after_seconds": 30
+                });
+                (status, [(RETRY_AFTER, POOL_EXHAUSTED_RETRY_AFTER_SECS)], axum::response::Json(body)).into_response()
             }
             // Handle database unique violations with minimal structured JSON
             Error::Database(DbError::UniqueViolation { constraint, table, .. }) => {


### PR DESCRIPTION
## Summary

- Add `DbError::PoolExhausted` variant for SQLx pool timeout errors
- Return 503 Service Unavailable with `Retry-After: 30` header
- Record `dwctl_db_pool_acquire_timeouts_total` metric counter
- Log warning when pool exhaustion occurs

## Motivation

When the database connection pool is exhausted (all connections in use and acquire times out), we should:
1. Return an appropriate HTTP status (503) instead of 500
2. Include `Retry-After` header so clients can implement proper backoff
3. Track the metric for monitoring/alerting

## Test plan

- [x] All existing tests pass
- [x] Linting passes