### PR TITLE
feat: upgrade fusillade to 2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,9 +1886,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2567d1f6788d0655280b98cd065e86805aba3769adb97c00604a656df49944b"
+checksum = "c3da1e97f3be66b56cc93bd71518bc33401a9db05917d70b5a9acfd655c76f2e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,11 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = "2.2.0"
+
+
+
+fusillade = "2.3.0"
+
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
@@ -51,7 +55,12 @@ tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 async-trait = "0.1"
 url = { version = "2.4", features = ["serde"] }
 clap = { version = "4.4", features = ["derive", "env"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots-no-provider", "http2", "charset"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls-webpki-roots-no-provider",
+  "http2",
+  "charset",
+] }
 humantime = "2.2.0"
 humantime-serde = "1.1"
 utoipa = { version = "5.0", features = [
@@ -103,12 +112,22 @@ futures = "0.3.31"
 dashmap = { version = "6.1.0", features = ["serde"] }
 moka = { version = "0.12", features = ["future"] }
 # Stripe payment processing - Fixed at rc0 currently as this is the only semi-stable version supporting a modern stripe API
-async-stripe = { version = "1.0.0-rc.0", default-features = false, features = ["rustls-tls-webpki-roots", "rustls-aws-lc-rs"] }
-async-stripe-checkout = { version = "1.0.0-rc.0", features = ["checkout_session"] }
-async-stripe-webhook = { version = "1.0.0-rc.0", features = ["async-stripe-checkout", "deserialize"] }
+async-stripe = { version = "1.0.0-rc.0", default-features = false, features = [
+  "rustls-tls-webpki-roots",
+  "rustls-aws-lc-rs",
+] }
+async-stripe-checkout = { version = "1.0.0-rc.0", features = [
+  "checkout_session",
+] }
+async-stripe-webhook = { version = "1.0.0-rc.0", features = [
+  "async-stripe-checkout",
+  "deserialize",
+] }
 async-stripe-types = { version = "1.0.0-rc.0" }
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
-async-stripe-billing = { version = "1.0.0-rc.0", features = ["billing_portal_session"] }
+async-stripe-billing = { version = "1.0.0-rc.0", features = [
+  "billing_portal_session",
+] }
 sqlx-pool-router = "0.2.0"
 
 [dev-dependencies]

--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -670,28 +670,16 @@ pub async fn retry_failed_batch_requests<P: PoolProvider>(
         }
     }
 
-    // Get all requests for the batch
-    let requests = state
+    // Retry all failed requests for the batch in a single database operation
+    let retried_count = state
         .request_manager
-        .get_batch_requests(fusillade::BatchId(batch_id))
+        .retry_failed_requests_for_batch(fusillade::BatchId(batch_id))
         .await
         .map_err(|e| Error::Internal {
-            operation: format!("get batch requests: {}", e),
+            operation: format!("retry failed requests: {}", e),
         })?;
 
-    // Collect IDs of failed requests
-    let failed_request_ids: Vec<fusillade::RequestId> = requests
-        .iter()
-        .filter_map(|req| {
-            if matches!(req, fusillade::request::AnyRequest::Failed(_)) {
-                Some(req.id())
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    if failed_request_ids.is_empty() {
+    if retried_count == 0 {
         return Err(Error::BadRequest {
             message: "No failed requests to retry in this batch".to_string(),
         });
@@ -699,39 +687,8 @@ pub async fn retry_failed_batch_requests<P: PoolProvider>(
 
     tracing::info!(
         batch_id = %batch_id,
-        failed_count = failed_request_ids.len(),
-        "Retrying failed requests"
-    );
-
-    // Retry the failed requests
-    let results = state
-        .request_manager
-        .retry_failed_requests(failed_request_ids.clone())
-        .await
-        .map_err(|e| Error::Internal {
-            operation: format!("retry failed requests: {}", e),
-        })?;
-
-    // Check for any failures
-    let failed_retries: Vec<_> = results
-        .iter()
-        .enumerate()
-        .filter_map(|(i, r)| r.as_ref().err().map(|e| (i, e)))
-        .collect();
-
-    if !failed_retries.is_empty() {
-        tracing::warn!(
-            batch_id = %batch_id,
-            failed_retry_count = failed_retries.len(),
-            "Some requests failed to retry"
-        );
-    }
-
-    let successful_retries = results.iter().filter(|r| r.is_ok()).count();
-    tracing::info!(
-        batch_id = %batch_id,
-        retried_count = successful_retries,
-        "Successfully retried failed requests"
+        retried_count,
+        "Retried failed requests"
     );
 
     // Fetch updated batch to get latest status


### PR DESCRIPTION
## Summary

- Upgrade fusillade from 2.2.0 to 2.3.0
- Use bulk `retry_failed_requests_for_batch` instead of loading all requests into memory and retrying individually

## Changes in fusillade 2.3.0

- Cascade deletes replaced with SET NULL for better performance on large batch/file deletions
- New `retry_failed_requests_for_batch` method for efficient bulk retry
- Daemon metadata (daemon_id, claimed_at, started_at) properly cleared on bulk retry

See https://github.com/doublewordai/fusillade/releases/tag/fusillade-v2.3.0