### PR TITLE
chore: upgrade fusillade to 2.3.1

### DIFF
--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -22,7 +22,7 @@ axum = { version = "0.8", features = ["multipart"] }
 
 
 
-fusillade = "2.3.0"
+fusillade = "2.3.1"
 
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }


### PR DESCRIPTION
## Summary
- Bump fusillade dependency from 2.3.0 to 2.3.1

## Test plan
- CI will validate the upgrade