### PR TITLE
fix: make logs less verbose with span info, still keep traceId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwctl"
-version = "5.0.3"
+version = "6.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3314,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "outlet"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95108e61364885ef15285280920cb7d15651597d3b824b726c43c8aef7133172"
+checksum = "5d484da44ecf98edcf2664301db1a2109baf78f108727997f590b5485bad22d7"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
Log lines were very long with new tracing span info, but we still need some way to link them to tempo, so use a custom line formatter to ensure the trace IDs are still printed. I have no idea why this needed me to write a function and there wans't a native way to do it? or there was and I was just incapable of finding it