### PR TITLE
feat!: email is now its own config, rather than a property of native_auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,4 +322,4 @@ credits:
    `openssl rand -base64 32` to generate a secure random key.
 3. Make sure user registration is enabled or disabled, as per your requirements.
 4. Make sure the CORS settings are correct for your frontend.
-5. If using native auth, configure SMTP email transport for password resets (the default `file` transport is only suitable for development/testing). Update `auth.native.email.type` to `smtp` and provide your SMTP credentials.
+5. If using native auth, configure SMTP email transport for password resets (the default `file` transport is only suitable for development/testing). Update `email.type` to `smtp` and provide your SMTP credentials.

--- a/config.yaml
+++ b/config.yaml
@@ -149,22 +149,7 @@ auth:
       cookie_name: "dwctl_session"
       cookie_secure: true
       cookie_same_site: "strict"
-    # Email configuration for password resets and notifications
-    email:
-      # Email transport - either 'file' (for development) or 'smtp' (for production)
-      type: file
-      path: "./emails" # Directory for file-based email (when type=file)
-      # For SMTP (production), use:
-      # type: smtp
-      # host: "smtp.example.com"
-      # port: 587
-      # username: "noreply@example.com"
-      # password: "your-smtp-password"
-      # use_tls: true
-      from_email: "noreply@example.com"
-      from_name: "Control Layer"
-      password_reset:
-        token_expiry: "30m" # How long reset tokens are valid
+    password_reset_token_duration: "30m"
 
   # Proxy header authentication
   # Accepts user identity from HTTP headers set by an upstream authentication proxy
@@ -214,6 +199,18 @@ auth:
       max_age: 3600 # Cache preflight requests for 1 hour
       # exposed_headers: []  # Optional: Custom headers to expose to browser (e.g., ["X-Incomplete", "X-Last-Line"])
 
+# Email configuration for password resets and notifications
+email:
+  # Email transport - either 'file' (for development) or 'smtp' (for production)
+  type: file
+  path: "./emails" # Directory for file-based email (when type=file)
+  # For SMTP (production), use:
+  # type: smtp
+  # host: "smtp.example.com"
+  # port: 587
+  # username: "noreply@example.com"
+  # password: "your-smtp-password"
+  # use_tls: true
 # Credits configuration
 credits:
   # Initial credits given to standard users when they are created

--- a/dwctl/src/api/handlers/auth.rs
+++ b/dwctl/src/api/handlers/auth.rs
@@ -1503,7 +1503,7 @@ mod tests {
         config.auth.native.enabled = true;
 
         // Save the email path before moving config
-        let email_path = if let crate::config::EmailTransportConfig::File { path } = &config.auth.native.email.transport {
+        let email_path = if let crate::config::EmailTransportConfig::File { path } = &config.email.transport {
             path.clone()
         } else {
             panic!("Expected File transport in test config");

--- a/dwctl/src/db/handlers/api_keys.rs
+++ b/dwctl/src/db/handlers/api_keys.rs
@@ -1866,6 +1866,7 @@ mod tests {
             payment: None,
             sample_files: Default::default(),
             limits: Default::default(),
+            email: Default::default(),
         };
         crate::seed_database(&config.model_sources, &pool).await.unwrap();
 

--- a/dwctl/src/db/handlers/password_reset_tokens.rs
+++ b/dwctl/src/db/handlers/password_reset_tokens.rs
@@ -148,7 +148,7 @@ impl<'c> PasswordResetTokens<'c> {
     pub async fn create_for_user(&mut self, user_id: UserId, config: &Config) -> Result<(String, PasswordResetToken)> {
         let raw_token = password::generate_reset_token();
         let expires_at = Utc::now()
-            + chrono::Duration::from_std(config.auth.native.email.password_reset.token_expiry).unwrap_or(chrono::Duration::minutes(30));
+            + chrono::Duration::from_std(config.auth.native.password_reset_token_duration).unwrap_or(chrono::Duration::minutes(30));
 
         let request = PasswordResetTokenCreateRequest {
             user_id,

--- a/dwctl/src/email.rs
+++ b/dwctl/src/email.rs
@@ -46,7 +46,7 @@ enum EmailTransport {
 
 impl EmailService {
     pub fn new(config: &Config) -> Result<Self, Error> {
-        let email_config = &config.auth.native.email;
+        let email_config = &config.email;
 
         let transport = match &email_config.transport {
             crate::config::EmailTransportConfig::Smtp {

--- a/dwctl/src/test/utils.rs
+++ b/dwctl/src/test/utils.rs
@@ -125,12 +125,6 @@ pub fn create_test_config() -> crate::config::Config {
         auth: crate::config::AuthConfig {
             native: NativeAuthConfig {
                 enabled: false,
-                email: crate::config::EmailConfig {
-                    transport: crate::config::EmailTransportConfig::File {
-                        path: temp_dir.to_string_lossy().to_string(),
-                    },
-                    ..Default::default()
-                },
                 password: PasswordConfig {
                     min_length: 8,
                     max_length: 64,
@@ -170,6 +164,12 @@ pub fn create_test_config() -> crate::config::Config {
                 ..Default::default()
             },
             leader_election: LeaderElectionConfig { enabled: false },
+            ..Default::default()
+        },
+        email: crate::config::EmailConfig {
+            transport: crate::config::EmailTransportConfig::File {
+                path: temp_dir.to_string_lossy().to_string(),
+            },
             ..Default::default()
         },
         sample_files: crate::sample_files::SampleFilesConfig::default(),


### PR DESCRIPTION
move email config out to top level
move password_reset struct back to auth.native as auth.native.password_reset_token_duration