### PR TITLE
fix: filter stale daemons from running count in model info

### DIFF
--- a/dashboard/src/components/features/models/ModelInfo/ModelInfo.tsx
+++ b/dashboard/src/components/features/models/ModelInfo/ModelInfo.tsx
@@ -176,7 +176,12 @@ const ModelInfo: React.FC = () => {
     { status: "running" },
     { enabled: canManageGroups },
   );
-  const runningDaemonCount = daemonsData?.daemons.length ?? 0;
+  const runningDaemonCount =
+    daemonsData?.daemons.filter((d) => {
+      if (d.status !== "running" || !d.last_heartbeat) return false;
+      const timeSinceHeartbeat = Date.now() - d.last_heartbeat * 1000;
+      return timeSinceHeartbeat <= d.config.heartbeat_interval_ms * 2;
+    }).length ?? 0;
 
   const loading = modelLoading || endpointLoading;
   const error = modelError


### PR DESCRIPTION
## Summary
- The model info page showed "542 daemons running" when only a handful were actually alive — the rest had stale heartbeats
- Applied the same heartbeat staleness check used on the System page: a daemon is only counted as running if its last heartbeat is within 2x its heartbeat interval
- `runningDaemonCount` now filters by both `status === "running"` and heartbeat freshness

## Test plan
- [x] `just lint ts` passes
- [x] `just test ts` passes (373/373)
- [ ] Verify model info page shows correct daemon count in production