### PR TITLE
fix: cancel shutdown token before axum graceful shutdown

### DIFF
--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1373,6 +1373,11 @@ impl BackgroundServices {
         }
     }
 
+    /// Get a clone of the shutdown token for coordinating early cancellation
+    pub fn shutdown_token(&self) -> tokio_util::sync::CancellationToken {
+        self.shutdown_token.clone()
+    }
+
     /// Gracefully shutdown all background tasks
     pub async fn shutdown(mut self) {
         // Signal all background tasks to shutdown
@@ -2000,6 +2005,16 @@ impl Application {
         // Apply middleware before path matching
         let middleware = middleware::from_fn_with_state(self.app_state, admin_ai_proxy_middleware);
         let service = middleware.layer(self.router);
+
+        // Cancel shutdown token when SIGTERM arrives, BEFORE axum starts waiting
+        // for in-flight connections to close. This lets background services (e.g.,
+        // fusillade daemon) abort in-flight HTTP tasks immediately, allowing
+        // proxy connections to close and axum's graceful shutdown to complete.
+        let shutdown_token = self.bg_services.shutdown_token();
+        let shutdown = async move {
+            shutdown.await;
+            shutdown_token.cancel();
+        };
 
         // Race the server against background task failures (fail-fast)
         let server_error: Option<anyhow::Error> = tokio::select! {


### PR DESCRIPTION
## Summary

- Cancel the `shutdown_token` when SIGTERM arrives, **before** axum starts waiting for in-flight connections to close
- Previously the token was cancelled after axum finished, creating a deadlock: axum waits for connections → connections wait for token → token waits for axum

## What this fixes

- Daemon marks itself `dead` in the DB on shutdown (heartbeat task completes)
- Process exits cleanly within the 30s grace period instead of being SIGKILL'd

## What this does NOT fix (future work)

- Requests still stay in `processing` state after shutdown — they rely on the 10-minute stale timeout for reclaim

## Test plan

- [x] `just lint rust` passes
- [x] `just test rust` passes (815/815)
- [ ] Deploy to staging, trigger rollout restart, confirm daemon marks itself dead within seconds