### PR TITLE
chore(deps): bump fusillade to 5.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,9 +1817,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "5.4.4"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac96069e68a8509b4ea981feba468b3a04418ce3e8bba0e54608c80cb443d927"
+checksum = "d8a5de4869dbe1f0faa5dfe3acbdcc18115ca893c7c72c88032b61f7ca9fab32"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version="5.4.4" }
+fusillade = { version="5.5.0" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"


### PR DESCRIPTION
## Summary

- Bumps `fusillade` from 5.4.4 to 5.5.0

### What's in fusillade 5.5.0

- **Comprehensive daemon metrics** (fusillade #144): 16 new metrics across heartbeat, cancellation polling, purge, claim cycle, dispatch, request completion, and stale reclaim subsystems
- **Timeout failure reason** (fusillade #146): Splits timeouts out of `NetworkError` into a dedicated `Timeout` variant, visible as `reason="timeout"` in metrics

No code changes needed in control-layer — all new metrics are emitted automatically by fusillade's daemon loop.

## Test plan
- [x] `cargo check` passes (pre-existing sqlx errors on main unrelated to this change)
- [ ] Deploy to staging, verify new `fusillade_*` metrics appear in Prometheus