### PR TITLE
feat: add OpenAPI docs for Responses API

### DIFF
--- a/dwctl/src/openapi/ai.rs
+++ b/dwctl/src/openapi/ai.rs
@@ -141,15 +141,17 @@ fn get_model() {}
     summary = "Create response",
     description = "Creates a model response for the given input.
 
-The Responses API is OpenAI's unified API that supersedes Chat Completions for advanced use cases. It provides enhanced capabilities including:
+This endpoint implements the Open Responses compatible API, providing enhanced capabilities including:
 
-- **Reasoning models** with controllable effort levels via `reasoning_effort`
-- **Multimodal support** via `modalities` parameter
+- **Reasoning models** with controllable effort via `reasoning` parameter
 - **Stateful conversations** via `previous_response_id` for maintaining context across turns
 - **Flexible input** - accepts either a string or array of messages
-- **Structured instructions** - separate `instructions` and `input` fields for cleaner semantics
+- **Text output configuration** via `text` parameter for structured outputs
+- **Context window management** via `truncation` parameter
 
-Set `stream: true` to receive partial responses as server-sent events.",
+Set `stream: true` to receive partial responses as server-sent events.
+
+[Open Responses API Reference →](https://www.openresponses.org/reference)",
     request_body = extra_types::ResponseRequest,
     responses(
         (status = 200, description = "Response generated successfully. When streaming, returns a series of SSE events.", body = extra_types::ResponseObject),
@@ -289,15 +291,15 @@ Use embeddings for:
 Use these endpoints to discover which models you have access to and their capabilities."),
         (name = "responses-api", description = "Create model responses with enhanced capabilities.
 
-The Responses API is OpenAI's unified API that supersedes Chat Completions for advanced use cases:
+Open Responses compatible endpoint providing advanced features:
 
-- **Reasoning models** — Control computational effort with `reasoning_effort` parameter
-- **Multimodal support** — Generate text, audio, or other modalities via `modalities`
+- **Reasoning models** — Control computational effort with `reasoning` parameter
 - **Stateful conversations** — Maintain context across turns with `previous_response_id`
 - **Flexible input** — Use simple strings or full message arrays
-- **Structured instructions** — Separate system instructions from user input
+- **Text output configuration** — Structured outputs via `text` parameter
+- **Context management** — Handle overflow with `truncation` parameter
 
-[Learn more about the Responses API →](https://platform.openai.com/docs/api-reference/responses)"),
+[Open Responses API Reference →](https://www.openresponses.org/reference)"),
     ),
     info(
         title = "AI API",

--- a/dwctl/src/openapi/extra_types.rs
+++ b/dwctl/src/openapi/extra_types.rs
@@ -624,6 +624,22 @@ pub struct ResponseRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
 
+    /// Include encrypted reasoning content for rehydration on subsequent requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include: Option<String>,
+
+    /// Text output configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<serde_json::Value>,
+
+    /// Reasoning configuration for controlling reasoning behavior.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<serde_json::Value>,
+
+    /// How to handle context window overflow ("auto" or "disabled").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation: Option<String>,
+
     /// Whether to store this response for future reference.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = false)]
@@ -656,6 +672,7 @@ pub struct ResponseRequest {
     "id": "resp-abc123",
     "object": "response",
     "created_at": 1703187200,
+    "completed_at": 1703187205,
     "model": "gpt-4o",
     "status": "completed",
     "output": [{
@@ -667,7 +684,9 @@ pub struct ResponseRequest {
         "prompt_tokens": 10,
         "completion_tokens": 25,
         "total_tokens": 35
-    }
+    },
+    "temperature": 0.7,
+    "top_p": 1.0
 }))]
 pub struct ResponseObject {
     /// A unique identifier for the response.
@@ -682,6 +701,10 @@ pub struct ResponseObject {
     #[schema(example = 1703187200)]
     pub created_at: i64,
 
+    /// The Unix timestamp of when the response was completed.
+    #[schema(example = 1703187205)]
+    pub completed_at: i64,
+
     /// The model used for generating the response.
     #[schema(example = "gpt-4o")]
     pub model: String,
@@ -694,8 +717,15 @@ pub struct ResponseObject {
     pub output: Vec<ResponseItem>,
 
     /// Usage statistics for the response request.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub usage: Option<Usage>,
+    pub usage: Usage,
+
+    /// The temperature used for sampling (echoed from request).
+    #[schema(example = 0.7)]
+    pub temperature: f32,
+
+    /// The nucleus sampling parameter used (echoed from request).
+    #[schema(example = 1.0)]
+    pub top_p: f32,
 
     /// Developer-defined tags and values.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

Add comprehensive OpenAPI documentation for the `POST /v1/responses` endpoint following the existing pattern used for chat completions and embeddings.

## Changes

- **New types in `extra_types.rs`**:
  - `ResponseRequest` - Request body with all Responses API parameters
  - `ResponseObject` - Response body with output items and status
  - `ResponseInput` - Flexible input enum (string or messages)
  - `ResponseItem` - Output item structure

- **Updated `ai.rs`**:
  - Added `create_response()` stub handler with comprehensive docs
  - Registered new types in OpenAPI components
  - Added handler to paths
  - Created new "responses-api" tag

## Testing

- [x] `cargo check --workspace` passes
- [x] `cargo build -p dwctl` succeeds
- [x] All types compile with proper serde/utoipa annotations
- [x] Follows existing patterns from chat completions

## Documentation

Design doc: `docs/plans/2026-02-17-responses-api-openapi-design.md`

The Responses API is already supported by the onwards routing layer. This PR adds OpenAPI documentation to match the comprehensive coverage we have for other endpoints.

Refs: https://platform.openai.com/docs/api-reference/responses