### PR TITLE
fix: bump onwards to 0.14.0 for TCP keepalive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3159,9 +3159,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onwards"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f0ee159a3951509052a471d4213bea1f2f4155a5bb3f24a937b61b3bcd2cf4"
+checksum = "7336a32312878ad332bcef96d0c4bd2eb13c16452604b083008da15034b09185"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -74,7 +74,7 @@ jsonwebtoken = "9.0"
 argon2 = "0.5"
 base64 = "0.22"
 bytes = "1.5"
-onwards = "0.13.0"
+onwards = "0.14.0"
 thiserror = "2.0.14"
 axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1627,6 +1627,7 @@ async fn setup_background_services(
             targets: std::collections::HashMap::new(),
             auth: None,
             strict_mode: false,
+            http_pool: None,
         };
         (onwards::target::Targets::from_config(empty_config)?, None)
     };

--- a/dwctl/src/sync/onwards_config.rs
+++ b/dwctl/src/sync/onwards_config.rs
@@ -765,6 +765,7 @@ fn convert_composite_to_target_spec(
                     // For composite models, use the composite model's sanitize_responses setting
                     // This ensures the virtual model's toggle controls all providers
                     sanitize_response: composite.sanitize_responses,
+                    request_timeout_secs: None,
                 }
             }
         })
@@ -872,6 +873,7 @@ fn convert_to_config_file(targets: Vec<OnwardsTarget>, composites: Vec<OnwardsCo
                 response_headers: None,
                 weight: 1, // Default weight for single-provider targets
                 sanitize_response: target.sanitize_responses,
+                request_timeout_secs: None,
             };
 
             (target.alias, TargetSpecOrList::Single(target_spec))
@@ -903,6 +905,7 @@ fn convert_to_config_file(targets: Vec<OnwardsTarget>, composites: Vec<OnwardsCo
         targets: target_specs,
         auth,
         strict_mode,
+        http_pool: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- Bumps `onwards` dependency from 0.13.0 to 0.14.0
- Adds TCP keepalive (60s idle, probes every 15s) on all outbound HTTP connections from the embedded onwards proxy
- Adds new `http_pool` and `request_timeout_secs` fields to struct initializers (set to `None` defaults)

## Context
Long-running LLM requests (5+ min under heavy preemption) produce no return traffic, causing conntrack entries to be evicted after 300s. This breaks NAT/DNAT mappings and creates zombie TCP connections that permanently occupy fusillade concurrency slots. Observed ~900 zombies in production on 2026-02-17.

TCP keepalive probes every 60s keep conntrack entries alive and detect dead connections within ~105s.

## Test plan
- [x] `cargo check` passes
- [ ] `just test rust` passes
- [ ] CI passes