### PR TITLE
fix: omit Secure attribute from cookies when cookie_secure is false

### DIFF
--- a/dwctl/src/api/handlers/auth.rs
+++ b/dwctl/src/api/handlers/auth.rs
@@ -348,7 +348,11 @@ pub async fn login<P: PoolProvider>(State(state): State<AppState<P>>, Json(reque
 #[tracing::instrument(skip_all)]
 pub async fn logout<P: PoolProvider>(State(state): State<AppState<P>>) -> Result<LogoutResponse, Error> {
     // Create expired cookie to clear session
-    let secure = if state.config.auth.native.session.cookie_secure { "; Secure" } else { "" };
+    let secure = if state.config.auth.native.session.cookie_secure {
+        "; Secure"
+    } else {
+        ""
+    };
     let cookie = format!(
         "{}=; Path=/; HttpOnly{}; SameSite=Strict; Max-Age=0",
         state.config.auth.native.session.cookie_name, secure


### PR DESCRIPTION
## Summary

- When `cookie_secure` is set to `false`, the `Set-Cookie` header was emitting `Secure=false`. Per the [HTTP spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#secure), `Secure` is a boolean flag — its mere presence causes browsers to treat the cookie as secure-only, regardless of value. `Secure=false` is not valid syntax and browsers interpret it the same as `Secure`, preventing the cookie from being set over plain HTTP.
- Also fixes the logout handler which hardcoded `; Secure` regardless of the `cookie_secure` config setting.

## Test plan

- Set `cookie_secure: false` in `config.yaml`
- Login and verify the `Set-Cookie` response header does **not** contain `Secure`
- Set `cookie_secure: true` and verify `; Secure` is present
- Verify logout cookie also respects the setting