### PR TITLE
feat: UI pass - fix some inconsistencies, especially around markdown formatting. Move some buttons around, improve some styling,etc.

### DIFF
--- a/dashboard/src/components/features/models/ModelInfo/ModelInfo.tsx
+++ b/dashboard/src/components/features/models/ModelInfo/ModelInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import {
   ArrowLeft,
@@ -11,6 +11,7 @@ import {
   Info,
   Edit,
   Check,
+  Copy,
   GitMerge,
 } from "lucide-react";
 import {
@@ -41,11 +42,7 @@ import { Badge } from "../../../ui/badge";
 import { Button } from "../../../ui/button";
 import { Input } from "../../../ui/input";
 import { Textarea } from "../../../ui/textarea";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "../../../ui/hover-card";
+import { InfoTip } from "../../../ui/info-tip";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../ui/tabs";
 import {
   Select,
@@ -60,6 +57,11 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { Sparkline } from "../../../ui/sparkline";
 import { Markdown } from "../../../ui/markdown";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../../../ui/popover";
 
 // Form schema for alias editing
 const aliasFormSchema = z.object({
@@ -126,9 +128,15 @@ const ModelInfo: React.FC = () => {
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [showApiExamples, setShowApiExamples] = useState(false);
   const [isEditingAlias, setIsEditingAlias] = useState(false);
+  const [aliasTruncated, setAliasTruncated] = useState(false);
+  const [aliasPopoverOpen, setAliasPopoverOpen] = useState(false);
+  const aliasRef = useCallback((el: HTMLHeadingElement | null) => {
+    if (el) setAliasTruncated(el.scrollWidth > el.clientWidth);
+  }, []);
   const [showAccessModal, setShowAccessModal] = useState(false);
   const [isEditingModelDetails, setIsEditingModelDetails] = useState(false);
   const [showPricingModal, setShowPricingModal] = useState(false);
+  const [aliasCopied, setAliasCopied] = useState(false);
 
   // Alias form
   const aliasForm = useForm<z.infer<typeof aliasFormSchema>>({
@@ -369,9 +377,9 @@ const ModelInfo: React.FC = () => {
             >
               <ArrowLeft className="w-5 h-5" />
             </button>
-            <div className="flex-1">
+            <div className="flex-1 min-w-0">
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                <div>
+                <div className="min-w-0">
                   {isEditingAlias ? (
                     <div className="space-y-2">
                       <Form {...aliasForm}>
@@ -426,10 +434,53 @@ const ModelInfo: React.FC = () => {
                       )}
                     </div>
                   ) : (
-                    <div className="flex items-center gap-3">
-                      <h1 className="text-3xl font-bold text-doubleword-neutral-900">
-                        {model.alias}
-                      </h1>
+                    <div className="flex items-center gap-3 min-w-0">
+                      {aliasTruncated ? (
+                        <Popover open={aliasPopoverOpen} onOpenChange={setAliasPopoverOpen}>
+                          <PopoverTrigger asChild>
+                            <h1
+                              ref={aliasRef}
+                              className="text-3xl font-bold text-doubleword-neutral-900 truncate min-w-0 cursor-default"
+                              onMouseEnter={() => setAliasPopoverOpen(true)}
+                              onMouseLeave={() => setAliasPopoverOpen(false)}
+                            >
+                              {model.alias}
+                            </h1>
+                          </PopoverTrigger>
+                          <PopoverContent
+                            side="bottom"
+                            align="start"
+                            className="w-auto max-w-sm px-3 py-2 pointer-events-none"
+                            onOpenAutoFocus={(e) => e.preventDefault()}
+                          >
+                            <p className="text-sm break-all font-medium">{model.alias}</p>
+                          </PopoverContent>
+                        </Popover>
+                      ) : (
+                        <h1
+                          ref={aliasRef}
+                          className="text-3xl font-bold text-doubleword-neutral-900 truncate min-w-0"
+                        >
+                          {model.alias}
+                        </h1>
+                      )}
+                      <button
+                        type="button"
+                        className="shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+                        aria-label="Copy model alias"
+                        onClick={() => {
+                          navigator.clipboard.writeText(model.alias).then(() => {
+                            setAliasCopied(true);
+                            setTimeout(() => setAliasCopied(false), 1500);
+                          });
+                        }}
+                      >
+                        {aliasCopied ? (
+                          <Check className="h-4 w-4 text-green-600" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )}
+                      </button>
                       {/* Status indicator */}
                       {modelProbe && (
                         <div className="flex items-center gap-2">
@@ -480,8 +531,8 @@ const ModelInfo: React.FC = () => {
                       </p>
                     )}
                 </div>
-                <div className="flex items-center justify-center sm:justify-start gap-3">
-                  {canManageGroups && (
+                {canManageGroups && (
+                  <div className="flex items-center justify-center sm:justify-start gap-3">
                     <TabsList className="w-full sm:w-auto">
                       <TabsTrigger
                         value="overview"
@@ -514,8 +565,8 @@ const ModelInfo: React.FC = () => {
                         </TabsTrigger>
                       )}
                     </TabsList>
-                  )}
-                </div>
+                  </div>
+                )}
               </div>
             </div>
           </div>
@@ -602,18 +653,13 @@ const ModelInfo: React.FC = () => {
                           <label className="text-sm text-gray-600">
                             Description
                           </label>
-                          <HoverCard openDelay={100} closeDelay={50}>
-                            <HoverCardTrigger asChild>
-                              <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                            </HoverCardTrigger>
-                            <HoverCardContent className="w-80" sideOffset={5}>
-                              <p className="text-sm text-muted-foreground">
-                                User provided description for the model.
-                                Displayed to all users when viewing the model on
-                                the overview page.
-                              </p>
-                            </HoverCardContent>
-                          </HoverCard>
+                          <InfoTip>
+                            <p className="text-sm text-muted-foreground">
+                              User provided description for the model.
+                              Displayed to all users when viewing the model on
+                              the overview page.
+                            </p>
+                          </InfoTip>
                         </div>
                         <Textarea
                           value={updateData.description}
@@ -667,19 +713,11 @@ const ModelInfo: React.FC = () => {
                                 className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 flex items-center gap-1"
                               >
                                 Vision
-                                <HoverCard openDelay={100} closeDelay={50}>
-                                  <HoverCardTrigger asChild>
-                                    <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                  </HoverCardTrigger>
-                                  <HoverCardContent
-                                    className="w-80"
-                                    sideOffset={5}
-                                  >
-                                    <p className="text-sm text-muted-foreground">
-                                      Enables image upload in the playground.
-                                    </p>
-                                  </HoverCardContent>
-                                </HoverCard>
+                                <InfoTip>
+                                  <p className="text-sm text-muted-foreground">
+                                    Enables image upload in the playground.
+                                  </p>
+                                </InfoTip>
                               </label>
                             </div>
                           </div>
@@ -692,17 +730,12 @@ const ModelInfo: React.FC = () => {
                           <label className="text-sm text-gray-600 font-medium">
                             Response Configuration
                           </label>
-                          <HoverCard openDelay={100} closeDelay={50}>
-                            <HoverCardTrigger asChild>
-                              <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                            </HoverCardTrigger>
-                            <HoverCardContent className="w-80" sideOffset={5}>
-                              <p className="text-sm text-muted-foreground">
-                                Configure how responses from this model are
-                                processed before being returned to clients.
-                              </p>
-                            </HoverCardContent>
-                          </HoverCard>
+                          <InfoTip>
+                            <p className="text-sm text-muted-foreground">
+                              Configure how responses from this model are
+                              processed before being returned to clients.
+                            </p>
+                          </InfoTip>
                         </div>
                         <div className="flex items-center space-x-2">
                           <input
@@ -722,18 +755,13 @@ const ModelInfo: React.FC = () => {
                             className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 flex items-center gap-1"
                           >
                             Sanitize Responses
-                            <HoverCard openDelay={100} closeDelay={50}>
-                              <HoverCardTrigger asChild>
-                                <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                              </HoverCardTrigger>
-                              <HoverCardContent className="w-80" sideOffset={5}>
-                                <p className="text-sm text-muted-foreground">
-                                  Filter out third-party provider fields from
-                                  OpenAI compatible responses to ensure clean,
-                                  standardized API responses.
-                                </p>
-                              </HoverCardContent>
-                            </HoverCard>
+                            <InfoTip>
+                              <p className="text-sm text-muted-foreground">
+                                Filter out third-party provider fields from
+                                OpenAI compatible responses to ensure clean,
+                                standardized API responses.
+                              </p>
+                            </InfoTip>
                           </label>
                         </div>
                       </div>
@@ -744,38 +772,25 @@ const ModelInfo: React.FC = () => {
                           <label className="text-sm text-gray-600 font-medium">
                             Global Rate Limiting
                           </label>
-                          <HoverCard openDelay={100} closeDelay={50}>
-                            <HoverCardTrigger asChild>
-                              <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                            </HoverCardTrigger>
-                            <HoverCardContent className="w-80" sideOffset={5}>
-                              <p className="text-sm text-muted-foreground">
-                                Set system-wide rate limits for this model.
-                                These apply to all users and override individual
-                                API key limits.
-                              </p>
-                            </HoverCardContent>
-                          </HoverCard>
+                          <InfoTip>
+                            <p className="text-sm text-muted-foreground">
+                              Set system-wide rate limits for this model.
+                              These apply to all users and override individual
+                              API key limits.
+                            </p>
+                          </InfoTip>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                           <div>
                             <label className="text-sm text-gray-600 mb-2 flex items-center gap-1">
                               Requests per Second
-                              <HoverCard openDelay={100} closeDelay={50}>
-                                <HoverCardTrigger asChild>
-                                  <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                </HoverCardTrigger>
-                                <HoverCardContent
-                                  className="w-80"
-                                  sideOffset={5}
-                                >
-                                  <p className="text-sm text-muted-foreground">
-                                    Sustained request rate limit. Temporary
-                                    bursts can exceed this up to the burst size.
-                                    Exceeding this limit returns 429 errors.
-                                  </p>
-                                </HoverCardContent>
-                              </HoverCard>
+                              <InfoTip>
+                                <p className="text-sm text-muted-foreground">
+                                  Sustained request rate limit. Temporary
+                                  bursts can exceed this up to the burst size.
+                                  Exceeding this limit returns 429 errors.
+                                </p>
+                              </InfoTip>
                             </label>
                             <Input
                               type="number"
@@ -803,20 +818,12 @@ const ModelInfo: React.FC = () => {
                           <div>
                             <label className="text-sm text-gray-600 mb-2 flex items-center gap-1">
                               Burst Size
-                              <HoverCard openDelay={100} closeDelay={50}>
-                                <HoverCardTrigger asChild>
-                                  <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                </HoverCardTrigger>
-                                <HoverCardContent
-                                  className="w-80"
-                                  sideOffset={5}
-                                >
-                                  <p className="text-sm text-muted-foreground">
-                                    Maximum number of requests allowed in a
-                                    temporary burst above the sustained rate.
-                                  </p>
-                                </HoverCardContent>
-                              </HoverCard>
+                              <InfoTip>
+                                <p className="text-sm text-muted-foreground">
+                                  Maximum number of requests allowed in a
+                                  temporary burst above the sustained rate.
+                                </p>
+                              </InfoTip>
                             </label>
                             <Input
                               type="number"
@@ -843,21 +850,13 @@ const ModelInfo: React.FC = () => {
                           <div>
                             <label className="text-sm text-gray-600 mb-2 flex items-center gap-1">
                               Maximum Concurrent Requests
-                              <HoverCard openDelay={100} closeDelay={50}>
-                                <HoverCardTrigger asChild>
-                                  <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                </HoverCardTrigger>
-                                <HoverCardContent
-                                  className="w-80"
-                                  sideOffset={5}
-                                >
-                                  <p className="text-sm text-muted-foreground">
-                                    Maximum number of requests that can be
-                                    processed concurrently. Exceeding this limit
-                                    returns 429 errors.
-                                  </p>
-                                </HoverCardContent>
-                              </HoverCard>
+                              <InfoTip>
+                                <p className="text-sm text-muted-foreground">
+                                  Maximum number of requests that can be
+                                  processed concurrently. Exceeding this limit
+                                  returns 429 errors.
+                                </p>
+                              </InfoTip>
                             </label>
                             <Input
                               type="number"
@@ -884,22 +883,14 @@ const ModelInfo: React.FC = () => {
                           <div>
                             <label className="text-sm text-gray-600 mb-2 flex items-center gap-1">
                               Per-Daemon Batch Concurrency
-                              <HoverCard openDelay={100} closeDelay={50}>
-                                <HoverCardTrigger asChild>
-                                  <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                </HoverCardTrigger>
-                                <HoverCardContent
-                                  className="w-80"
-                                  sideOffset={5}
-                                >
-                                  <p className="text-sm text-muted-foreground">
-                                    Maximum concurrent batch requests each
-                                    daemon can send to this model. Total
-                                    capacity scales with the number of running
-                                    daemons.
-                                  </p>
-                                </HoverCardContent>
-                              </HoverCard>
+                              <InfoTip>
+                                <p className="text-sm text-muted-foreground">
+                                  Maximum concurrent batch requests each
+                                  daemon can send to this model. Total
+                                  capacity scales with the number of running
+                                  daemons.
+                                </p>
+                              </InfoTip>
                             </label>
                             <Input
                               type="number"
@@ -1033,91 +1024,60 @@ const ModelInfo: React.FC = () => {
                     </div>
                   ) : (
                     <div className="space-y-6">
+                      {canManageGroups && (
                       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                        {canManageGroups && (
                           <div>
                             <div className="flex items-center gap-1 mb-1">
                               <p className="text-sm text-gray-600">Full Name</p>
-                              <HoverCard openDelay={100} closeDelay={50}>
-                                <HoverCardTrigger asChild>
-                                  <Info className="h-3 w-3 text-gray-400 hover:text-gray-600 " />
-                                </HoverCardTrigger>
-                                <HoverCardContent
-                                  className="w-80"
-                                  sideOffset={5}
-                                >
-                                  <p className="text-sm text-muted-foreground">
-                                    The name under which the model is available
-                                    at the upstream endpoint.
-                                  </p>
-                                </HoverCardContent>
-                              </HoverCard>
+                              <InfoTip>
+                                <p className="text-sm text-muted-foreground">
+                                  The name under which the model is available
+                                  at the upstream endpoint.
+                                </p>
+                              </InfoTip>
                             </div>
                             <p className="font-medium">{model.model_name}</p>
                           </div>
-                        )}
-                        {canManageGroups && (
                           <div>
                             <div className="flex items-center gap-1 mb-1">
                               <p className="text-sm text-gray-600">Alias</p>
-                              <HoverCard openDelay={100} closeDelay={50}>
-                                <HoverCardTrigger asChild>
-                                  <Info className="h-3 w-3 text-gray-400 hover:text-gray-600 " />
-                                </HoverCardTrigger>
-                                <HoverCardContent
-                                  className="w-80"
-                                  sideOffset={5}
-                                >
-                                  <p className="text-sm text-muted-foreground">
-                                    The name under which the model will be made
-                                    available in the control layer API.
-                                  </p>
-                                </HoverCardContent>
-                              </HoverCard>
+                              <InfoTip>
+                                <p className="text-sm text-muted-foreground">
+                                  The name under which the model will be made
+                                  available in the control layer API.
+                                </p>
+                              </InfoTip>
                             </div>
                             <p className="font-medium">{model.alias}</p>
                           </div>
-                        )}
-                        {canManageGroups && (
                           <div>
                             <div className="flex items-center gap-1 mb-1">
                               <p className="text-sm text-gray-600">Type</p>
-                              <HoverCard openDelay={100} closeDelay={50}>
-                                <HoverCardTrigger asChild>
-                                  <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                </HoverCardTrigger>
-                                <HoverCardContent
-                                  className="w-80"
-                                  sideOffset={5}
-                                >
-                                  <p className="text-sm text-muted-foreground">
-                                    The type of the model. Determines which
-                                    playground is used.
-                                  </p>
-                                </HoverCardContent>
-                              </HoverCard>
+                              <InfoTip>
+                                <p className="text-sm text-muted-foreground">
+                                  The type of the model. Determines which
+                                  playground is used.
+                                </p>
+                              </InfoTip>
                             </div>
                             <Badge variant="outline">
                               {model.model_type || "UNKNOWN"}
                             </Badge>
                           </div>
-                        )}
                       </div>
+                      )}
                       <div>
                         <div className="flex items-center gap-1 mb-1">
                           <p className="text-sm text-gray-600">Description</p>
-                          <HoverCard openDelay={100} closeDelay={50}>
-                            <HoverCardTrigger asChild>
-                              <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                            </HoverCardTrigger>
-                            <HoverCardContent className="w-80" sideOffset={5}>
+                          {canManageGroups && (
+                            <InfoTip>
                               <p className="text-sm text-muted-foreground">
                                 User provided description for the model.
                                 Displayed to all users when viewing the model on
                                 the overview page.
                               </p>
-                            </HoverCardContent>
-                          </HoverCard>
+                            </InfoTip>
+                          )}
                         </div>
                         {model.description ? (
                           <Markdown className="text-sm text-gray-700">
@@ -1181,20 +1141,12 @@ const ModelInfo: React.FC = () => {
                                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 flex items-center gap-1"
                                   >
                                     Vision
-                                    <HoverCard openDelay={100} closeDelay={50}>
-                                      <HoverCardTrigger asChild>
-                                        <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                      </HoverCardTrigger>
-                                      <HoverCardContent
-                                        className="w-80"
-                                        sideOffset={5}
-                                      >
-                                        <p className="text-sm text-muted-foreground">
-                                          Enables image upload in the
-                                          playground.
-                                        </p>
-                                      </HoverCardContent>
-                                    </HoverCard>
+                                    <InfoTip>
+                                      <p className="text-sm text-muted-foreground">
+                                        Enables image upload in the
+                                        playground.
+                                      </p>
+                                    </InfoTip>
                                   </label>
                                 </div>
                               </div>
@@ -1210,23 +1162,16 @@ const ModelInfo: React.FC = () => {
                               <p className="text-sm text-gray-600">
                                 Pricing Tariffs
                               </p>
-                              <HoverCard openDelay={100} closeDelay={50}>
-                                <HoverCardTrigger asChild>
-                                  <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                </HoverCardTrigger>
-                                <HoverCardContent
-                                  className="w-80"
-                                  sideOffset={5}
-                                >
+                              {canManageGroups && (
+                                <InfoTip>
                                   <p className="text-sm text-muted-foreground">
                                     Pricing tiers for different API key
                                     purposes. Set different rates for realtime,
-                                    batch, and playground usage.
-                                    {canManageGroups &&
-                                      ` Click "Manage Tariffs" to configure pricing.`}
+                                    batch, and playground usage. Click "Manage
+                                    Tariffs" to configure pricing.
                                   </p>
-                                </HoverCardContent>
-                              </HoverCard>
+                                </InfoTip>
+                              )}
                             </div>
                             {canManageGroups && (
                               <Button
@@ -1310,41 +1255,25 @@ const ModelInfo: React.FC = () => {
                               <p className="text-sm text-gray-600">
                                 Rate Limiting & Capacity
                               </p>
-                              <HoverCard openDelay={100} closeDelay={50}>
-                                <HoverCardTrigger asChild>
-                                  <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                </HoverCardTrigger>
-                                <HoverCardContent
-                                  className="w-80"
-                                  sideOffset={5}
-                                >
-                                  <p className="text-sm text-muted-foreground">
-                                    Rate limits control request throughput.
-                                    Capacity limits control concurrent requests.
-                                  </p>
-                                </HoverCardContent>
-                              </HoverCard>
+                              <InfoTip>
+                                <p className="text-sm text-muted-foreground">
+                                  Rate limits control request throughput.
+                                  Capacity limits control concurrent requests.
+                                </p>
+                              </InfoTip>
                             </div>
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                               <div>
                                 <p className="text-xs text-gray-500 mb-1 flex items-center gap-1">
                                   Requests per Second
-                                  <HoverCard openDelay={100} closeDelay={50}>
-                                    <HoverCardTrigger asChild>
-                                      <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                    </HoverCardTrigger>
-                                    <HoverCardContent
-                                      className="w-80"
-                                      sideOffset={5}
-                                    >
-                                      <p className="text-sm text-muted-foreground">
-                                        Sustained request rate limit. Temporary
-                                        bursts can exceed this up to the burst
-                                        size. Exceeding this limit returns 429
-                                        errors.
-                                      </p>
-                                    </HoverCardContent>
-                                  </HoverCard>
+                                  <InfoTip>
+                                    <p className="text-sm text-muted-foreground">
+                                      Sustained request rate limit. Temporary
+                                      bursts can exceed this up to the burst
+                                      size. Exceeding this limit returns 429
+                                      errors.
+                                    </p>
+                                  </InfoTip>
                                 </p>
                                 <p className="font-medium">
                                   {model.requests_per_second
@@ -1355,21 +1284,13 @@ const ModelInfo: React.FC = () => {
                               <div>
                                 <p className="text-xs text-gray-500 mb-1 flex items-center gap-1">
                                   Burst Size
-                                  <HoverCard openDelay={100} closeDelay={50}>
-                                    <HoverCardTrigger asChild>
-                                      <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                    </HoverCardTrigger>
-                                    <HoverCardContent
-                                      className="w-80"
-                                      sideOffset={5}
-                                    >
-                                      <p className="text-sm text-muted-foreground">
-                                        Maximum number of requests allowed in a
-                                        temporary burst above the sustained
-                                        rate.
-                                      </p>
-                                    </HoverCardContent>
-                                  </HoverCard>
+                                  <InfoTip>
+                                    <p className="text-sm text-muted-foreground">
+                                      Maximum number of requests allowed in a
+                                      temporary burst above the sustained
+                                      rate.
+                                    </p>
+                                  </InfoTip>
                                 </p>
                                 <p className="font-medium">
                                   {model.burst_size
@@ -1380,21 +1301,13 @@ const ModelInfo: React.FC = () => {
                               <div>
                                 <p className="text-xs text-gray-500 mb-1 flex items-center gap-1">
                                   Maximum Concurrent Requests
-                                  <HoverCard openDelay={100} closeDelay={50}>
-                                    <HoverCardTrigger asChild>
-                                      <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                    </HoverCardTrigger>
-                                    <HoverCardContent
-                                      className="w-80"
-                                      sideOffset={5}
-                                    >
-                                      <p className="text-sm text-muted-foreground">
-                                        Maximum number of requests that can be
-                                        processed concurrently. Exceeding this
-                                        limit returns 429 errors.
-                                      </p>
-                                    </HoverCardContent>
-                                  </HoverCard>
+                                  <InfoTip>
+                                    <p className="text-sm text-muted-foreground">
+                                      Maximum number of requests that can be
+                                      processed concurrently. Exceeding this
+                                      limit returns 429 errors.
+                                    </p>
+                                  </InfoTip>
                                 </p>
                                 <p className="font-medium">
                                   {model.capacity
@@ -1405,22 +1318,14 @@ const ModelInfo: React.FC = () => {
                               <div>
                                 <p className="text-xs text-gray-500 mb-1 flex items-center gap-1">
                                   Per-Daemon Batch Concurrency
-                                  <HoverCard openDelay={100} closeDelay={50}>
-                                    <HoverCardTrigger asChild>
-                                      <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
-                                    </HoverCardTrigger>
-                                    <HoverCardContent
-                                      className="w-80"
-                                      sideOffset={5}
-                                    >
-                                      <p className="text-sm text-muted-foreground">
-                                        Maximum concurrent batch requests each
-                                        daemon can send to this model. Total
-                                        capacity scales with the number of
-                                        running daemons.
-                                      </p>
-                                    </HoverCardContent>
-                                  </HoverCard>
+                                  <InfoTip>
+                                    <p className="text-sm text-muted-foreground">
+                                      Maximum concurrent batch requests each
+                                      daemon can send to this model. Total
+                                      capacity scales with the number of
+                                      running daemons.
+                                    </p>
+                                  </InfoTip>
                                 </p>
                                 <p className="font-medium">
                                   {model.batch_capacity
@@ -1493,16 +1398,11 @@ const ModelInfo: React.FC = () => {
                           <p className="text-sm text-gray-600">
                             Total Requests
                           </p>
-                          <HoverCard openDelay={100} closeDelay={50}>
-                            <HoverCardTrigger asChild>
-                              <Info className="h-3 w-3 text-gray-400 hover:text-gray-600 " />
-                            </HoverCardTrigger>
-                            <HoverCardContent className="w-40" sideOffset={5}>
-                              <p className="text-xs text-muted-foreground">
-                                Total requests made to this model
-                              </p>
-                            </HoverCardContent>
-                          </HoverCard>
+                          <InfoTip className="w-40">
+                            <p className="text-xs text-muted-foreground">
+                              Total requests made to this model
+                            </p>
+                          </InfoTip>
                         </div>
                         <p className="text-xl font-bold text-gray-900">
                           {model.metrics.total_requests.toLocaleString()}
@@ -1511,16 +1411,11 @@ const ModelInfo: React.FC = () => {
                       <div>
                         <div className="flex items-center gap-1 mb-1">
                           <p className="text-sm text-gray-600">Avg Latency</p>
-                          <HoverCard openDelay={100} closeDelay={50}>
-                            <HoverCardTrigger asChild>
-                              <Info className="h-3 w-3 text-gray-400 hover:text-gray-600 " />
-                            </HoverCardTrigger>
-                            <HoverCardContent className="w-40" sideOffset={5}>
-                              <p className="text-xs text-muted-foreground">
-                                Average response time across all requests
-                              </p>
-                            </HoverCardContent>
-                          </HoverCard>
+                          <InfoTip className="w-40">
+                            <p className="text-xs text-muted-foreground">
+                              Average response time across all requests
+                            </p>
+                          </InfoTip>
                         </div>
                         <p className="text-xl font-bold text-gray-900">
                           {model.metrics.avg_latency_ms
@@ -1533,26 +1428,21 @@ const ModelInfo: React.FC = () => {
                       <div>
                         <div className="flex items-center gap-1 mb-1">
                           <p className="text-sm text-gray-600">Total Tokens</p>
-                          <HoverCard openDelay={100} closeDelay={50}>
-                            <HoverCardTrigger asChild>
-                              <Info className="h-3 w-3 text-gray-400 hover:text-gray-600 " />
-                            </HoverCardTrigger>
-                            <HoverCardContent className="w-48" sideOffset={5}>
-                              <div className="text-xs text-muted-foreground">
-                                <p>
-                                  Input:{" "}
-                                  {model.metrics.total_input_tokens.toLocaleString()}
-                                </p>
-                                <p>
-                                  Output:{" "}
-                                  {model.metrics.total_output_tokens.toLocaleString()}
-                                </p>
-                                <p className="mt-1 font-medium">
-                                  Total tokens processed
-                                </p>
-                              </div>
-                            </HoverCardContent>
-                          </HoverCard>
+                          <InfoTip className="w-48">
+                            <div className="text-xs text-muted-foreground">
+                              <p>
+                                Input:{" "}
+                                {model.metrics.total_input_tokens.toLocaleString()}
+                              </p>
+                              <p>
+                                Output:{" "}
+                                {model.metrics.total_output_tokens.toLocaleString()}
+                              </p>
+                              <p className="mt-1 font-medium">
+                                Total tokens processed
+                              </p>
+                            </div>
+                          </InfoTip>
                         </div>
                         <p className="text-xl font-bold text-gray-900">
                           {(
@@ -1569,16 +1459,11 @@ const ModelInfo: React.FC = () => {
                       <div>
                         <div className="flex items-center gap-1 mb-1">
                           <p className="text-sm text-gray-600">Last Active</p>
-                          <HoverCard openDelay={100} closeDelay={50}>
-                            <HoverCardTrigger asChild>
-                              <Info className="h-3 w-3 text-gray-400 hover:text-gray-600 " />
-                            </HoverCardTrigger>
-                            <HoverCardContent className="w-36" sideOffset={5}>
-                              <p className="text-xs text-muted-foreground">
-                                Last request received
-                              </p>
-                            </HoverCardContent>
-                          </HoverCard>
+                          <InfoTip className="w-36">
+                            <p className="text-xs text-muted-foreground">
+                              Last request received
+                            </p>
+                          </InfoTip>
                         </div>
                         <p className="text-xl font-bold text-gray-900">
                           {model.metrics.last_active_at

--- a/dashboard/src/components/features/models/Models/Models.tsx
+++ b/dashboard/src/components/features/models/Models/Models.tsx
@@ -32,7 +32,7 @@ import {
 import { Label } from "../../../ui/label";
 import { Switch } from "../../../ui/switch";
 import { ModelsContent } from "./ModelsContent";
-import { SupportRequestModal, CreateVirtualModelModal } from "../../../modals";
+import { CreateVirtualModelModal } from "../../../modals";
 import { useEndpoints, useGroups } from "@/api/control-layer/hooks";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useServerPagination } from "@/hooks/useServerPagination";
@@ -40,7 +40,6 @@ import { useServerPagination } from "@/hooks/useServerPagination";
 const Models: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { hasPermission } = useAuthorization();
-  const [isSupportModalOpen, setIsSupportModalOpen] = useState(false);
   const [isCreateVirtualModalOpen, setIsCreateVirtualModalOpen] =
     useState(false);
   const canManageGroups = hasPermission("manage-groups");
@@ -123,19 +122,11 @@ const Models: React.FC = () => {
       <Tabs value={viewMode} onValueChange={handleTabChange}>
         {/* Header */}
         <div className="mb-6">
-          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
-            <div className="flex items-baseline gap-3">
-              <h1 className="text-2xl md:text-3xl font-bold text-doubleword-neutral-900">
-                Models
-              </h1>
-              <button
-                onClick={() => setIsSupportModalOpen(true)}
-                className="text-sm text-blue-600 hover:text-blue-700"
-              >
-                Request a model
-              </button>
-            </div>
-            <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <h1 className="text-2xl md:text-3xl font-bold text-doubleword-neutral-900">
+              Models
+            </h1>
+            <div className="flex flex-col md:flex-row items-stretch md:items-center gap-2 md:gap-3">
               {/* Search - most frequently used */}
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4 z-10 pointer-events-none" />
@@ -144,27 +135,27 @@ const Models: React.FC = () => {
                   placeholder="Search models..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-10 w-40 sm:w-48 md:w-64"
+                  className="pl-10 w-full md:w-48 lg:w-64"
                   aria-label="Search models"
                 />
               </div>
 
               {/* View mode tabs - only for platform managers */}
               {canManageGroups && (
-                <TabsList className="w-full sm:w-auto">
+                <TabsList className="w-full md:w-auto">
                   <TabsTrigger
                     value="grid"
-                    className="flex items-center gap-2 flex-1 sm:flex-initial"
+                    className="flex items-center gap-2 flex-1 md:flex-initial"
                   >
                     <LayoutGrid className="h-4 w-4" />
-                    <span className="hidden sm:inline">Grid</span>
+                    <span className="hidden md:inline">Grid</span>
                   </TabsTrigger>
                   <TabsTrigger
                     value="status"
-                    className="flex items-center gap-2 flex-1 sm:flex-initial"
+                    className="flex items-center gap-2 flex-1 md:flex-initial"
                   >
                     <Activity className="h-4 w-4" />
-                    <span className="hidden sm:inline">Status</span>
+                    <span className="hidden md:inline">Status</span>
                   </TabsTrigger>
                 </TabsList>
               )}
@@ -180,7 +171,7 @@ const Models: React.FC = () => {
                       aria-label="Filter models"
                     >
                       <SlidersHorizontal className="h-4 w-4" />
-                      <span className="hidden sm:inline">Filter</span>
+                      <span className="hidden md:inline">Filter</span>
                       <ChevronDown className="h-3 w-3 opacity-50" />
                       {(filterProvider !== "all" ||
                         filterGroups.length > 0 ||
@@ -368,7 +359,7 @@ const Models: React.FC = () => {
                       aria-label="Model actions"
                     >
                       <MoreHorizontal className="h-4 w-4" />
-                      <span className="hidden sm:inline ml-1.5">Actions</span>
+                      <span className="hidden md:inline ml-1.5">Actions</span>
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
@@ -403,12 +394,6 @@ const Models: React.FC = () => {
           onClearFilters={handleClearFilters}
         />
       </Tabs>
-
-      <SupportRequestModal
-        isOpen={isSupportModalOpen}
-        onClose={() => setIsSupportModalOpen(false)}
-        defaultSubject="Model/Feature Request"
-      />
 
       <CreateVirtualModelModal
         isOpen={isCreateVirtualModalOpen}

--- a/dashboard/src/components/layout/Sidebar/AppSidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar/AppSidebar.tsx
@@ -212,6 +212,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const { data: config, isLoading: configLoading } = useConfig();
   const { isFeatureEnabled } = useSettings();
   const isDemoMode = isFeatureEnabled("demo");
+  const [isSupportModalOpen, setIsSupportModalOpen] = useState(false);
 
   // Fetch balance and transactions
   const { data: balance = 0 } = useUserBalance(user?.id || "");
@@ -274,7 +275,15 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                   <div className="hidden md:block w-px h-4 bg-border"></div>
                 </>
               )}
+              <button
+                onClick={() => setIsSupportModalOpen(true)}
+                className="hidden md:block text-muted-foreground hover:text-primary transition-colors font-medium"
+              >
+                Request a model
+              </button>
               {config?.docs_url && (
+                <>
+                  <div className="hidden md:block w-px h-4 bg-border"></div>
                 <a
                   href={config.docs_url}
                   target="_blank"
@@ -285,12 +294,19 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                   <span className="sm:hidden">Docs</span>
                   <ExternalLink className="w-3 h-3" />
                 </a>
+                </>
               )}
             </div>
           </header>
           <main className="flex-1">{children}</main>
         </SidebarInset>
       </div>
+
+      <SupportRequestModal
+        isOpen={isSupportModalOpen}
+        onClose={() => setIsSupportModalOpen(false)}
+        defaultSubject="Model/Feature Request"
+      />
     </SidebarProvider>
   );
 }

--- a/dashboard/src/components/ui/info-tip.tsx
+++ b/dashboard/src/components/ui/info-tip.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { Info } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "./popover";
+
+interface InfoTipProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * A mobile-friendly info tooltip that shows on hover (desktop) and tap (mobile).
+ * Uses Popover internally instead of HoverCard to support touch devices.
+ */
+export function InfoTip({ children, className = "w-80" }: InfoTipProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center"
+          onPointerEnter={(e) => {
+            if (e.pointerType === "mouse") setOpen(true);
+          }}
+          onPointerLeave={(e) => {
+            if (e.pointerType === "mouse") setOpen(false);
+          }}
+        >
+          <Info className="h-3 w-3 text-gray-400 hover:text-gray-600" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className={`${className} px-3 py-2`}
+        sideOffset={5}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/dashboard/src/components/ui/markdown.test.tsx
+++ b/dashboard/src/components/ui/markdown.test.tsx
@@ -29,7 +29,24 @@ describe("Markdown Component", () => {
     it("should use normal spacing in normal mode", () => {
       const { container } = render(<Markdown>Paragraph</Markdown>);
       const paragraph = container.querySelector("p");
-      expect(paragraph).toHaveClass("mb-2");
+      expect(paragraph).toHaveClass("mb-3");
+    });
+  });
+
+  describe("Headings", () => {
+    it("should render headings with distinct sizes", () => {
+      const markdown = "# H1\n\n## H2\n\n### H3\n\n#### H4";
+      const { container } = render(<Markdown>{markdown}</Markdown>);
+
+      const h1 = container.querySelector("h1");
+      const h2 = container.querySelector("h2");
+      const h3 = container.querySelector("h3");
+      const h4 = container.querySelector("h4");
+
+      expect(h1).toHaveClass("text-xl", "font-semibold");
+      expect(h2).toHaveClass("text-lg", "font-semibold");
+      expect(h3).toHaveClass("text-base", "font-semibold");
+      expect(h4).toHaveClass("text-sm", "font-semibold");
     });
   });
 
@@ -48,39 +65,13 @@ describe("Markdown Component", () => {
         expect(listItems[2]).toHaveTextContent("Item 3");
       });
 
-      it("should NOT render p tags inside list items", () => {
-        const markdown = "- Item 1\n- Item 2\n- Item 3";
-        const { container } = render(<Markdown>{markdown}</Markdown>);
-        const listItems = container.querySelectorAll("li");
-
-        // Check that each list item does NOT contain a p tag
-        listItems.forEach((li) => {
-          const pTags = li.querySelectorAll("p");
-          expect(pTags).toHaveLength(0);
-        });
-      });
-
-      it("should render list items as direct text children", () => {
-        const markdown =
-          "- Visual Agent: Description here\n- Visual Coding: More text";
-        const { container } = render(<Markdown>{markdown}</Markdown>);
-        const listItems = container.querySelectorAll("li");
-
-        expect(listItems[0].innerHTML).not.toContain("<p>");
-        expect(listItems[1].innerHTML).not.toContain("<p>");
-        expect(listItems[0]).toHaveTextContent(
-          "Visual Agent: Description here",
-        );
-        expect(listItems[1]).toHaveTextContent("Visual Coding: More text");
-      });
-
       it("should apply correct classes to ul", () => {
         const markdown = "- Item 1";
         const { container } = render(<Markdown>{markdown}</Markdown>);
         const ul = container.querySelector("ul");
 
         expect(ul).toHaveClass("list-disc");
-        expect(ul).toHaveClass("list-inside");
+        expect(ul).toHaveClass("pl-5");
       });
 
       it("should use compact spacing for ul in compact mode", () => {
@@ -104,46 +95,45 @@ describe("Markdown Component", () => {
         expect(listItems).toHaveLength(3);
       });
 
-      it("should NOT render p tags inside ordered list items", () => {
-        const markdown = "1. First item\n2. Second item";
-        const { container } = render(<Markdown>{markdown}</Markdown>);
-        const listItems = container.querySelectorAll("li");
-
-        listItems.forEach((li) => {
-          const pTags = li.querySelectorAll("p");
-          expect(pTags).toHaveLength(0);
-        });
-      });
-
       it("should apply correct classes to ol", () => {
         const markdown = "1. Item 1";
         const { container } = render(<Markdown>{markdown}</Markdown>);
         const ol = container.querySelector("ol");
 
         expect(ol).toHaveClass("list-decimal");
-        expect(ol).toHaveClass("list-inside");
+        expect(ol).toHaveClass("pl-5");
       });
     });
   });
 
   describe("Code", () => {
-    it("should render inline code", () => {
+    it("should render inline code with inline styling", () => {
       const markdown = "This is `inline code` text";
       const { container } = render(<Markdown>{markdown}</Markdown>);
       const code = container.querySelector("code");
 
       expect(code).toBeInTheDocument();
       expect(code).toHaveTextContent("inline code");
+      expect(code).toHaveClass("bg-gray-100", "font-mono");
     });
 
-    it("should render code blocks without language", () => {
+    it("should render fenced code blocks without language", () => {
       const markdown = "```\ncode block\n```";
+      const { container } = render(<Markdown>{markdown}</Markdown>);
+      const pre = container.querySelector("pre");
+
+      expect(pre).toBeInTheDocument();
+      expect(pre).toHaveClass("bg-gray-900");
+    });
+
+    it("should not render inline code as a block", () => {
+      const markdown = "Use `const x = 1` in your code";
       const { container } = render(<Markdown>{markdown}</Markdown>);
       const pre = container.querySelector("pre");
       const code = container.querySelector("code");
 
-      expect(pre).toBeInTheDocument();
-      expect(code).toBeInTheDocument();
+      expect(pre).not.toBeInTheDocument();
+      expect(code).toHaveClass("bg-gray-100");
     });
   });
 
@@ -160,8 +150,32 @@ describe("Markdown Component", () => {
     });
   });
 
+  describe("Tables", () => {
+    it("should render tables with proper structure", () => {
+      const markdown =
+        "| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |";
+      const { container } = render(<Markdown>{markdown}</Markdown>);
+
+      expect(container.querySelector("table")).toBeInTheDocument();
+      expect(container.querySelector("thead")).toHaveClass("bg-gray-50");
+      expect(container.querySelectorAll("th")).toHaveLength(2);
+      expect(container.querySelectorAll("td")).toHaveLength(4);
+    });
+  });
+
+  describe("Blockquotes", () => {
+    it("should render blockquotes with styling", () => {
+      const markdown = "> This is a quote";
+      const { container } = render(<Markdown>{markdown}</Markdown>);
+      const blockquote = container.querySelector("blockquote");
+
+      expect(blockquote).toBeInTheDocument();
+      expect(blockquote).toHaveClass("border-l-2", "italic");
+    });
+  });
+
   describe("Complex Content", () => {
-    it("should render mixed content without p tags in list items", () => {
+    it("should render mixed content correctly", () => {
       const markdown = `# Title
 
 Paragraph text here.
@@ -174,36 +188,9 @@ Another paragraph.`;
 
       const { container } = render(<Markdown>{markdown}</Markdown>);
 
-      // Check list items don't have p tags
-      const listItems = container.querySelectorAll("li");
-      listItems.forEach((li) => {
-        expect(li.querySelectorAll("p")).toHaveLength(0);
-      });
-
-      // Check paragraphs outside lists still render
-      const paragraphs = container.querySelectorAll("p");
-      expect(paragraphs.length).toBeGreaterThan(0);
-    });
-
-    it("should handle nested content in lists correctly", () => {
-      const markdown = `Key Enhancements:
-
-- Visual Agent: Operates PC/mobile GUIs—recognizes elements, understands functions, invokes tools, completes tasks.
-- Visual Coding Boost: Generates Draw.io/HTML/CSS/JS from images/videos.
-- Advanced Spatial Perception: Judges object positions, viewpoints, and occlusions.`;
-
-      const { container } = render(<Markdown>{markdown}</Markdown>);
-      const listItems = container.querySelectorAll("li");
-
-      expect(listItems).toHaveLength(3);
-
-      // Ensure no p tags in any list item
-      listItems.forEach((li) => {
-        const pTags = li.querySelectorAll("p");
-        expect(pTags).toHaveLength(0);
-        // Check that the text content is directly in the li
-        expect(li.innerHTML).not.toContain("<p>");
-      });
+      expect(container.querySelector("h1")).toHaveTextContent("Title");
+      expect(container.querySelectorAll("li")).toHaveLength(3);
+      expect(container.querySelectorAll("p").length).toBeGreaterThan(0);
     });
   });
 
@@ -215,8 +202,7 @@ Another paragraph.`;
       const wrapper = container.firstChild;
 
       expect(wrapper).toHaveClass("custom-class");
-      expect(wrapper).toHaveClass("prose");
-      expect(wrapper).toHaveClass("prose-sm");
+      expect(wrapper).toHaveClass("max-w-none");
     });
   });
 });

--- a/dashboard/src/components/ui/markdown.tsx
+++ b/dashboard/src/components/ui/markdown.tsx
@@ -2,6 +2,9 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CodeBlock } from "./code-block";
 
+const SUPPORTED_LANGUAGES = ["python", "javascript", "bash", "json"] as const;
+type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
 interface MarkdownProps {
   children: string;
   className?: string;
@@ -17,79 +20,144 @@ export function Markdown({
   className = "",
   compact = false,
 }: MarkdownProps) {
+  const spacing = compact
+    ? { block: "mb-1", list: "mb-1 space-y-0.5", code: "p-2 text-xs" }
+    : { block: "mb-3", list: "mb-3 space-y-1", code: "p-3 text-sm" };
+
   return (
-    <div className={`prose prose-sm max-w-none ${className}`}>
+    <div className={`max-w-none text-sm text-gray-700 ${className}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
+          h1: ({ children }) => (
+            <h1
+              className={`text-xl font-semibold text-gray-900 ${spacing.block} first:mt-0 mt-6`}
+            >
+              {children}
+            </h1>
+          ),
+          h2: ({ children }) => (
+            <h2
+              className={`text-lg font-semibold text-gray-900 ${spacing.block} first:mt-0 mt-5`}
+            >
+              {children}
+            </h2>
+          ),
+          h3: ({ children }) => (
+            <h3
+              className={`text-base font-semibold text-gray-900 ${spacing.block} first:mt-0 mt-4`}
+            >
+              {children}
+            </h3>
+          ),
+          h4: ({ children }) => (
+            <h4
+              className={`text-sm font-semibold text-gray-900 ${spacing.block} first:mt-0 mt-3`}
+            >
+              {children}
+            </h4>
+          ),
           p: ({ children, node }) => {
-            // Check if this paragraph contains a code block
-            // Code blocks should not be wrapped in <p> tags (invalid HTML)
-            const hasCodeBlock = node?.children?.some(
+            const hasBlock = node?.children?.some(
               (child: any) =>
                 child.type === "element" &&
-                child.tagName === "code" &&
-                !child.properties?.inline,
+                (child.tagName === "pre" || child.tagName === "code"),
             );
-
-            // If it contains a code block, return children unwrapped
-            if (hasCodeBlock) {
-              return <>{children}</>;
-            }
-
+            if (hasBlock) return <>{children}</>;
             return (
-              <p className={compact ? "mb-1 last:mb-0" : "mb-2 last:mb-0"}>
-                {children}
-              </p>
+              <p className={`${spacing.block} last:mb-0`}>{children}</p>
             );
           },
           ul: ({ children }) => (
-            <ul
-              className={`list-disc list-inside ${compact ? "mb-1 space-y-0.5" : "mb-2 space-y-1"}`}
-            >
-              {children}
-            </ul>
+            <ul className={`list-disc pl-5 ${spacing.list}`}>{children}</ul>
           ),
           ol: ({ children }) => (
-            <ol
-              className={`list-decimal list-inside ${compact ? "mb-1 space-y-0.5" : "mb-2 space-y-1"}`}
-            >
+            <ol className={`list-decimal pl-5 ${spacing.list}`}>
               {children}
             </ol>
           ),
-          li: ({ children }) => {
-            // ReactMarkdown wraps list item content in <p> tags by default
-            // We need to extract the content to prevent unwanted line breaks
-            return <li className="ml-0">{children}</li>;
-          },
-          code: ({ inline, className, children, ...props }: any) => {
-            const match = /language-(\w+)/.exec(className || "");
-            const language = match?.[1];
-            const supportedLanguages = ["python", "javascript", "bash", "json"];
+          li: ({ children }) => (
+            <li className="pl-1 [&>ul]:mb-0 [&>ol]:mb-0 [&>ul]:mt-1 [&>ol]:mt-1">
+              {children}
+            </li>
+          ),
+          blockquote: ({ children }) => (
+            <blockquote className="border-l-2 border-gray-300 pl-4 my-3 text-gray-600 italic">
+              {children}
+            </blockquote>
+          ),
+          table: ({ children }) => (
+            <div className="my-3 overflow-x-auto rounded-md border border-gray-200">
+              <table className="min-w-full text-sm">{children}</table>
+            </div>
+          ),
+          thead: ({ children }) => (
+            <thead className="bg-gray-50 border-b border-gray-200">
+              {children}
+            </thead>
+          ),
+          tbody: ({ children }) => <tbody>{children}</tbody>,
+          tr: ({ children }) => (
+            <tr className="border-b border-gray-100 last:border-0">
+              {children}
+            </tr>
+          ),
+          th: ({ children }) => (
+            <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              {children}
+            </th>
+          ),
+          td: ({ children }) => (
+            <td className="px-3 py-2 text-gray-700">{children}</td>
+          ),
+          hr: () => <hr className="my-4 border-gray-200" />,
+          // Block code: extract language and content from the AST node
+          // This handles both fenced blocks with and without a language tag
+          pre: ({ node }: any) => {
+            const codeNode = node?.children?.[0];
+            if (codeNode?.tagName === "code") {
+              const codeClassName =
+                (codeNode.properties?.className as string[])?.[0] || "";
+              const match = /language-(\w+)/.exec(codeClassName);
+              const language = match?.[1];
+              const text = (codeNode.children?.[0] as any)?.value || "";
+              const content = text.replace(/\n$/, "");
 
-            return !inline &&
-              language &&
-              supportedLanguages.includes(language) ? (
-              <CodeBlock
-                language={language as "python" | "javascript" | "bash" | "json"}
-              >
-                {String(children).replace(/\n$/, "")}
-              </CodeBlock>
-            ) : !inline ? (
-              <pre
-                className={`bg-gray-900 text-gray-100 rounded overflow-x-auto ${compact ? "p-2 text-xs" : "p-3 text-sm"}`}
-              >
-                <code>{children}</code>
-              </pre>
-            ) : (
-              <code
-                className={`bg-gray-100 px-1 py-0.5 rounded ${compact ? "text-xs" : "text-sm"}`}
-                {...props}
-              >
-                {children}
-              </code>
-            );
+              if (
+                language &&
+                SUPPORTED_LANGUAGES.includes(language as SupportedLanguage)
+              ) {
+                return (
+                  <div className="my-2 rounded-md overflow-hidden">
+                    <CodeBlock language={language as SupportedLanguage}>
+                      {content}
+                    </CodeBlock>
+                  </div>
+                );
+              }
+
+              return (
+                <div className="my-2 rounded-md overflow-hidden">
+                  <pre
+                    className={`bg-gray-900 text-gray-100 overflow-x-auto ${spacing.code}`}
+                  >
+                    <code>{content}</code>
+                  </pre>
+                </div>
+              );
+            }
+
+            return <pre>{(node?.children || []).map((c: any) => c.value)}</pre>;
           },
+          // Inline code only — block code is handled by pre above
+          code: ({ children, ...props }: any) => (
+            <code
+              className="bg-gray-100 text-gray-800 px-1.5 py-0.5 rounded text-[0.85em] font-mono"
+              {...props}
+            >
+              {children}
+            </code>
+          ),
           a: ({ children, href }) => (
             <a
               href={href}
@@ -99,6 +167,9 @@ export function Markdown({
             >
               {children}
             </a>
+          ),
+          strong: ({ children }) => (
+            <strong className="font-semibold text-gray-900">{children}</strong>
           ),
         }}
       >


### PR DESCRIPTION
## Summary

- Rewrite `Markdown` component with proper rendering for headings, tables, blockquotes, code blocks, and inline code — fixes react-markdown v10 inline detection bug
- Create `InfoTip` component replacing HoverCard info icons with mobile-friendly Popovers using `pointerType` detection (hover on desktop, tap on mobile)
- Hide PM-facing info copy from non-PM users on the model detail page
- Add copy-to-clipboard button for model alias on the detail page
- Add scrollable max-height to description popover on model cards
- Move "Request a model" button from models page to global sidebar
- Improve responsive breakpoints and card layout on models page

## Context

Stacked on #734. This PR contains all dashboard-only UX improvements.

The Markdown component was using `prose` classes from `@tailwindcss/typography` which isn't installed, so all styling was no-ops. The rewrite uses explicit component overrides for every element type. The `pre` component now handles all block code via AST node inspection, fixing fenced blocks without language tags that were incorrectly rendered as inline code in react-markdown v10.

The HoverCard-based info icons didn't work on mobile (hover-only). The new `InfoTip` component uses a controlled Popover with `pointerType` checks — `"mouse"` triggers hover behavior, touch triggers tap-to-toggle.

## Test plan

- [ ] Verify `just lint ts` and `just test ts` pass (384/384 tests)
- [ ] On desktop: info icons show on hover, dismiss on mouse leave
- [ ] On mobile: info icons show on tap, dismiss on tap outside
- [ ] Non-PM users don't see info icons on Description and Pricing Tariffs sections
- [ ] Model alias copy button works on detail page
- [ ] Markdown renders headings, tables, blockquotes, code blocks correctly
- [ ] Description popover on model cards scrolls when content is long
- [ ] "Request a model" appears in sidebar, not on models page