### PR TITLE
fix: lock aggregation call to one per user concurrently

### DIFF
--- a/.sqlx/query-48bcfd6f31e4585474b3d898aa77f1f6cb3fa4b8008a7d891704f75b707bc8fe.json
+++ b/.sqlx/query-48bcfd6f31e4585474b3d898aa77f1f6cb3fa4b8008a7d891704f75b707bc8fe.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pg_try_advisory_xact_lock(hashtext('agg_user_batches_' || $1))",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_try_advisory_xact_lock",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "48bcfd6f31e4585474b3d898aa77f1f6cb3fa4b8008a7d891704f75b707bc8fe"
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevented deadlocks during concurrent batch transaction aggregation by using PostgreSQL advisory locks.

- Used `pg_try_advisory_xact_lock` with per-user locking to serialize aggregation calls
- If lock cannot be acquired, aggregation is skipped gracefully since it's a lazy optimization
- Lock is transaction-scoped and automatically released, preventing resource leaks
- Read queries remain functional with slightly stale data when aggregation is deferred

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused concurrency fix using standard PostgreSQL advisory lock patterns. The implementation correctly uses transaction-level locks, handles lock acquisition failures gracefully, and maintains data correctness even when aggregation is skipped. The lock key is properly scoped per-user with a unique prefix to avoid collisions.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| dwctl/src/db/handlers/credits.rs | Added per-user advisory lock to prevent concurrent aggregation deadlocks; implementation is clean and handles lock contention gracefully |

</details>



<sub>Last reviewed commit: ee39dd3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->