### PR TITLE
feat: wire fusillade deadline-priority injection into batch_daemon config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,9 +2279,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c9a97a27f728b9ee4ab7bfaa175593975b6b0f6387d57c4d2cd98d192d7b43"
+checksum = "8ed776b8441c0f148458bd4fe4a441b30a562f680a41bd728acf29a0e3ec63fa"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/config.yaml
+++ b/config.yaml
@@ -397,6 +397,14 @@ background_services:
       - /v1/completions
       - /v1/responses
 
+    # Inject a `priority` field into outbound request bodies, set to the Unix
+    # timestamp of the batch SLA deadline (smaller = more urgent). Requires
+    # inference backends configured for lower-priority-first scheduling
+    # (vLLM's default priority queue; SGLang with
+    # `--schedule-low-priority-values-first`). Backends without priority
+    # scheduling enabled simply ignore the field.
+    # inject_deadline_priority: false
+
   # Batch completion notifications (emails + webhooks)
   # notifications:
   #   poll_interval: 30s                # How often to poll for completed batches

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "15.0.0" }
+fusillade = { version = "15.1.0" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1178,6 +1178,15 @@ pub struct DaemonConfig {
     /// 0.0 = pure user-fairness, 1.0 = pure deadline urgency. Default: 0.5.
     #[serde(default = "default_urgency_weight", deserialize_with = "deserialize_urgency_weight")]
     pub urgency_weight: f64,
+
+    /// When true, the daemon injects a `priority` field into each outbound
+    /// request body equal to the Unix timestamp (seconds) of the batch SLA
+    /// deadline. Smaller values = more urgent. Requires inference backends
+    /// configured with lower-priority-first scheduling (vLLM's default
+    /// priority queue; SGLang launched with
+    /// `--schedule-low-priority-values-first`). Default: false.
+    #[serde(default)]
+    pub inject_deadline_priority: bool,
 }
 
 fn default_urgency_weight() -> f64 {
@@ -1240,6 +1249,7 @@ impl Default for DaemonConfig {
             purge_throttle_ms: 100,
             streamable_endpoints: Vec::new(),
             urgency_weight: default_urgency_weight(),
+            inject_deadline_priority: false,
         }
     }
 }
@@ -1294,6 +1304,7 @@ impl DaemonConfig {
             purge_throttle_ms: self.purge_throttle_ms,
             streamable_endpoints: self.streamable_endpoints.clone(),
             urgency_weight: self.urgency_weight,
+            inject_deadline_priority: self.inject_deadline_priority,
             ..Default::default()
         }
     }

--- a/dwctl/src/test/sla.rs
+++ b/dwctl/src/test/sla.rs
@@ -153,6 +153,7 @@ async fn test_route_at_claim_time_escalation(pool: PgPool) {
         purge_throttle_ms: 100,
         streamable_endpoints: vec![],
         urgency_weight: 0.0,
+        inject_deadline_priority: false,
     };
 
     config.background_services.onwards_sync.enabled = true;
@@ -414,6 +415,7 @@ async fn test_no_escalation_when_not_near_expiry(pool: PgPool) {
         purge_throttle_ms: 100,
         streamable_endpoints: vec![],
         urgency_weight: 0.0,
+        inject_deadline_priority: false,
     };
 
     config.background_services.onwards_sync.enabled = true;


### PR DESCRIPTION
## Summary

- Bumps `fusillade` to 15.1.0
- Exposes the new `inject_deadline_priority` option on the `batch_daemon` config block (defaults to `false`)
- Forwards it through `to_fusillade_config_with_limits`
- Documents the option in `config.yaml`

When enabled, the batch daemon injects a `priority` field into each outbound request body equal to the Unix timestamp of the batch's SLA deadline. Smaller values = more urgent. Inference backends configured for lower-priority-first scheduling (vLLM's default priority queue, or SGLang launched with `--schedule-low-priority-values-first`) will preempt less-urgent work; backends without priority scheduling silently ignore the field.

Pairs with:

- [doublewordai/fusillade#213](https://github.com/doublewordai/fusillade/pull/213) — implements the injection (released as fusillade 15.1.0)
- [doublewordai/shenron#173](https://github.com/doublewordai/shenron/pull/173) — flips all SGLang/vLLM workers on piccolo + chiaotzu to lower-first semantics (released as shenron v0.30.0)

## Roll-out

Safe to merge with the default `false`. To enable in prod, set `batch_daemon.inject_deadline_priority: true` (or the equivalent `DWCTL_*` env override) via the internal repo's values once shenron v0.30.0 is confirmed rolled out on every node.

## Test plan

- [x] `cargo check` + `cargo clippy` clean
- [x] Full Rust test suite passes locally (had to use `--test-threads=4` because the default parallelism saturated my local Postgres' 100-connection cap; CI is unaffected)
- [ ] Verify CI passes