### PR TITLE
fix: document dynamo nvext.agent_hints.priority injection path

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -397,12 +397,11 @@ background_services:
       - /v1/completions
       - /v1/responses
 
-    # Inject a `priority` field into outbound request bodies, set to the Unix
-    # timestamp of the batch SLA deadline (smaller = more urgent). Requires
-    # inference backends configured for lower-priority-first scheduling
-    # (vLLM's default priority queue; SGLang with
-    # `--schedule-low-priority-values-first`). Backends without priority
-    # scheduling enabled simply ignore the field.
+    # Inject a deadline-derived priority hint into outbound request bodies at
+    # `nvext.agent_hints.priority` (NVIDIA Dynamo's unified priority extension;
+    # i32, higher = more important; Dynamo normalizes per backend). The value
+    # is the negated Unix timestamp of the batch SLA deadline so earlier
+    # deadlines produce larger numbers.
     # inject_deadline_priority: false
 
   # Batch completion notifications (emails + webhooks)

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1179,12 +1179,12 @@ pub struct DaemonConfig {
     #[serde(default = "default_urgency_weight", deserialize_with = "deserialize_urgency_weight")]
     pub urgency_weight: f64,
 
-    /// When true, the daemon injects a `priority` field into each outbound
-    /// request body equal to the Unix timestamp (seconds) of the batch SLA
-    /// deadline. Smaller values = more urgent. Requires inference backends
-    /// configured with lower-priority-first scheduling (vLLM's default
-    /// priority queue; SGLang launched with
-    /// `--schedule-low-priority-values-first`). Default: false.
+    /// When true, the daemon injects a deadline-derived priority hint into
+    /// each outbound request body at `nvext.agent_hints.priority` (NVIDIA
+    /// Dynamo's unified priority extension; `i32`, where higher values mean
+    /// "more important" at the API layer and Dynamo normalizes per backend).
+    /// The injected value is the negated Unix timestamp of the batch SLA
+    /// deadline so earlier deadlines produce larger numbers. Default: false.
     #[serde(default)]
     pub inject_deadline_priority: bool,
 }


### PR DESCRIPTION
Updates the `inject_deadline_priority` docstring (in `dwctl/src/config.rs` and `config.yaml`) so it matches what the code actually does after the fusillade 15.1.1 bump (#982).

8.37.0's docs described the previous behaviour: top-level `priority` field, smaller = more urgent (vLLM convention). The actual behaviour with fusillade 15.1.1 is `nvext.agent_hints.priority`, larger = more urgent (NVIDIA Dynamo's unified priority extension; Dynamo normalizes per backend).

Also re-triggers release-please so 8.37.1 ships with the corrected fusillade.