### PR TITLE
fix: bump fusillade to 16.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2279,9 +2279,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "16.1.0"
+version = "16.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1136ed4d715ebd552525787ee1405d492cba8ba3c02720152eec49056aa33655"
+checksum = "2718b285f58d4dc8ffabb2197a9d2198d08a016bf47726721d94adcfb4d144af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6934,7 +6934,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "16.1.0" }
+fusillade = { version = "16.1.2" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/dwctl/src/api/handlers/deployments.rs
+++ b/dwctl/src/api/handlers/deployments.rs
@@ -841,24 +841,21 @@ pub async fn get_deployed_model<P: PoolProvider>(
 
     for &include in &all_includes {
         match include {
-            "groups" => {
+            "groups"
                 // Only users with Groups::ReadAll can include groups
-                if can_read_groups {
+                if can_read_groups => {
                     include_groups = true;
                 }
-            }
-            "metrics" => {
+            "metrics"
                 // Only users with Analytics::ReadAll can include metrics
-                if can_read_metrics {
+                if can_read_metrics => {
                     include_metrics = true;
                 }
-            }
-            "endpoints" => {
+            "endpoints"
                 // Model endpoints is priviliged information for admins
-                if can_read_all_models {
+                if can_read_all_models => {
                     include_endpoints = true;
                 }
-            }
             "status" => {
                 // Status is allowed for all users
                 include_status = true;

--- a/dwctl/src/sync/endpoint_sync.rs
+++ b/dwctl/src/sync/endpoint_sync.rs
@@ -612,7 +612,7 @@ where
 
     // --- 4. Create new deployments, error if conflicts found ---
     let system_user_id = uuid::Uuid::nil();
-    for (model_name, alias) in create_model_names.into_iter().zip(create_aliases.into_iter()) {
+    for (model_name, alias) in create_model_names.into_iter().zip(create_aliases) {
         if conflict_create_aliases.contains(&alias) {
             return Err(SyncError::AliasConflicts {
                 conflicts: vec![AliasConflict {


### PR DESCRIPTION
## Summary

Upgrade `fusillade` from `16.1.0` → `16.1.2`.

## Test plan

- [x] `just lint rust` (clean; only pre-existing `useless_conversion` warnings unrelated to this bump)
- [x] `just lint ts`
- [x] `cargo test -p dwctl --lib api::handlers::batch_requests` (5/5)
- [x] `cargo test -p dwctl --lib api::handlers::batches` (30/30)
- [x] `cargo test -p dwctl --lib api::handlers::files` (50/50, with `--test-threads=4` to avoid test-harness Postgres pool exhaustion)
- [x] `cargo test -p dwctl --lib api::handlers::inference_endpoints` (46/46)
- [x] `just test ts` (493/493)