### PR TITLE
fix: center tooltips and make model/user cells click-to-copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,7 +2069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2279,9 +2279,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "16.1.2"
+version = "16.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2718b285f58d4dc8ffabb2197a9d2198d08a016bf47726721d94adcfb4d144af"
+checksum = "4dc1911381ccea2c630ce1a29e00acd06bbbcaf0b5f908c844d7bc667f7ef0e8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2883,7 +2883,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3672,7 +3672,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4507,7 +4507,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4545,9 +4545,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5101,7 +5101,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5172,7 +5172,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6018,7 +6018,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6934,7 +6934,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/dashboard/src/components/features/async-requests/AsyncRequests.tsx
+++ b/dashboard/src/components/features/async-requests/AsyncRequests.tsx
@@ -39,7 +39,7 @@ import { ApiExamples } from "../../modals";
 import { useBootstrapContent } from "../../../hooks/use-bootstrap-content";
 import { useOrganizationContext } from "../../../contexts/organization/useOrganizationContext";
 import { useServerPagination } from "../../../hooks/useServerPagination";
-import { formatTimestamp, formatLongDuration } from "../../../utils";
+import { formatTimestamp, formatLongDuration, copyToClipboard } from "../../../utils";
 
 const getStatusColor = (status: string): string => {
   switch (status) {
@@ -72,6 +72,15 @@ function formatCost(cost: number): string {
   return `$${cost.toFixed(2)}`;
 }
 
+const handleCopyCellValue = (
+  e: React.MouseEvent,
+  value: string,
+  label: string,
+) => {
+  e.stopPropagation();
+  void copyToClipboard(value, { successMessage: `Copied ${label}` });
+};
+
 const userColumn: ColumnDef<AsyncRequest> = {
   id: "user",
   header: "User",
@@ -81,7 +90,10 @@ const userColumn: ColumnDef<AsyncRequest> = {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="text-sm text-doubleword-neutral-700 truncate max-w-[180px] block cursor-default">
+          <span
+            onClick={(e) => handleCopyCellValue(e, email, "user")}
+            className="text-sm text-doubleword-neutral-700 truncate max-w-[180px] inline-block align-middle cursor-copy hover:text-doubleword-neutral-900 transition-colors"
+          >
             {email}
           </span>
         </TooltipTrigger>
@@ -117,7 +129,10 @@ function createColumns(
       const displayName = modelDisplayNames?.get(alias) || alias;
       const showTooltip = displayName !== alias;
       const content = (
-        <span className="text-sm text-doubleword-neutral-900 truncate max-w-[220px] block">
+        <span
+          onClick={(e) => handleCopyCellValue(e, alias, "model alias")}
+          className="text-sm text-doubleword-neutral-900 truncate max-w-[220px] inline-block align-middle cursor-copy hover:text-doubleword-neutral-700 transition-colors"
+        >
           {displayName}
         </span>
       );

--- a/dashboard/src/components/features/async-requests/AsyncRequests.tsx
+++ b/dashboard/src/components/features/async-requests/AsyncRequests.tsx
@@ -92,7 +92,7 @@ const userColumn: ColumnDef<AsyncRequest> = {
         <TooltipTrigger asChild>
           <span
             onClick={(e) => handleCopyCellValue(e, email, "user")}
-            className="text-sm text-doubleword-neutral-700 truncate max-w-[180px] inline-block align-middle cursor-copy hover:text-doubleword-neutral-900 transition-colors"
+            className="text-sm text-doubleword-neutral-700 truncate max-w-[180px] inline-block align-middle cursor-pointer hover:text-doubleword-neutral-900 transition-colors"
           >
             {email}
           </span>
@@ -131,7 +131,7 @@ function createColumns(
       const content = (
         <span
           onClick={(e) => handleCopyCellValue(e, alias, "model alias")}
-          className="text-sm text-doubleword-neutral-900 truncate max-w-[220px] inline-block align-middle cursor-copy hover:text-doubleword-neutral-700 transition-colors"
+          className="text-sm text-doubleword-neutral-900 truncate max-w-[220px] inline-block align-middle cursor-pointer hover:text-doubleword-neutral-700 transition-colors"
         >
           {displayName}
         </span>

--- a/dashboard/src/components/features/batches/BatchesTable/columns.tsx
+++ b/dashboard/src/components/features/batches/BatchesTable/columns.tsx
@@ -18,6 +18,7 @@ import {
   formatTimestamp,
   formatLongDuration,
   formatNumber,
+  copyToClipboard,
 } from "../../../../utils";
 import type { Batch, BatchStatus } from "../types";
 
@@ -69,7 +70,13 @@ const userColumn: ColumnDef<Batch> = {
     return (
       <Tooltip delayDuration={300}>
         <TooltipTrigger asChild>
-          <span className="text-sm text-gray-700 truncate max-w-[120px] block cursor-default">
+          <span
+            onClick={(e) => {
+              e.stopPropagation();
+              void copyToClipboard(email, { successMessage: "Copied user" });
+            }}
+            className="text-sm text-gray-700 truncate max-w-[120px] inline-block align-middle cursor-pointer hover:text-gray-900 transition-colors"
+          >
             {email}
           </span>
         </TooltipTrigger>

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "16.1.2" }
+fusillade = { version = "16.1.3" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"


### PR DESCRIPTION
## Summary

On the async requests table:

- Tooltips on the **Model** and **User** columns were anchored off-centre from the visible text. The cell spans used `block`, so the trigger element stretched to the column's max-width and the tooltip centred on that box rather than the text. Switched to `inline-block align-middle` so the trigger hugs the actual text. Truncation behaviour is unchanged.
- Clicking the **Model** cell now copies the alias; clicking the **User** cell copies the email. Uses the shared `copyToClipboard` util + success toast — same pattern as the existing icon-based copy buttons. `stopPropagation` preserves row-click navigation to the detail view on the rest of the row.