### PR TITLE
fix: show '-' for async request cost when there are no tokens

### DIFF
--- a/dashboard/src/components/features/async-requests/AsyncRequests.tsx
+++ b/dashboard/src/components/features/async-requests/AsyncRequests.tsx
@@ -210,14 +210,17 @@ function createColumns(
     id: "cost",
     header: "Cost",
     cell: ({ row }) => {
-      const cost = row.original.total_cost;
-      if (cost == null) {
+      const { prompt_tokens, completion_tokens, total_cost } = row.original;
+      const noTokens =
+        (prompt_tokens == null && completion_tokens == null) ||
+        (prompt_tokens === 0 && completion_tokens === 0);
+      if (total_cost == null || noTokens) {
         return <span className="text-sm text-doubleword-neutral-600">-</span>;
       }
       return (
         <span className="text-sm text-green-700 font-medium flex items-center gap-1">
           <DollarSign className="w-3 h-3" />
-          {formatCost(cost).slice(1)}
+          {formatCost(total_cost).slice(1)}
         </span>
       );
     },

--- a/dashboard/src/components/features/batches/Batches/Batches.test.tsx
+++ b/dashboard/src/components/features/batches/Batches/Batches.test.tsx
@@ -585,6 +585,24 @@ describe("Batches", () => {
       // Check for in_progress status
       expect(within(container).getByText(/in progress/i)).toBeInTheDocument();
     });
+
+    it("should hide the Completion Window column by default", async () => {
+      const user = userEvent.setup();
+      const { container } = render(<Batches {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
+
+      await user.click(
+        within(container).getByRole("tab", { name: /batches/i }),
+      );
+
+      // No column header with that label should be rendered
+      expect(
+        within(container).queryByRole("columnheader", {
+          name: /completion window/i,
+        }),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("Tab Switching", () => {


### PR DESCRIPTION
## Summary

On the async requests table, the tokens cell renders `-` when prompt/completion are both null or both zero, but the cost cell didn't honor that state and could show `$0.00` for requests that never produced tokens. Align the cost cell to the same no-tokens check so both cells agree.

## Test plan

- [x] `just lint ts`
- [x] `just test ts` (493/493)
- [ ] Manual: on `/async`, rows with no tokens show `-` in both Tokens and Cost; rows with tokens still show their dollar value

🤖 Generated with [Claude Code](https://claude.com/claude-code)