### PR TITLE
docs: add data retention delete policy proposal

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -424,6 +424,16 @@ background_services:
   #     max_concurrent_sends: 20        # Max parallel outbound HTTP requests
   #     channel_capacity: 200           # Internal send/result channel buffer size
 
+  # Artifact retention policy for user-facing batch artefacts.
+  # Files API uploads can still set their own expires_after values explicitly.
+  retention:
+    enabled: true
+    sweep_interval: 10m
+    batch_size: 100
+    # Optional default TTL applied to batch-related artefacts when no explicit
+    # file expiry is provided. Example values: 7d, 30d. Set to null to disable.
+    batch_artifacts_default_ttl: null
+
   # Leader election - coordinates which instance runs leader-only services
   # When disabled, all instances run as leader (useful for single-instance deployments)
   leader_election:

--- a/docs/data-retention-delete-policy.md
+++ b/docs/data-retention-delete-policy.md
@@ -2,11 +2,11 @@
 
 ## Goal
 
-Introduce a clear retention policy for user-facing artefacts so that soft deletes become real data cleanup after an optional time-to-live, without treating all data the same.
+Introduce a clear retention policy for user-facing artifacts so that soft deletes become real data cleanup after an optional time-to-live, without treating all data the same.
 
 The main intent is:
 
-- Clean up processing artefacts that should not live forever.
+- Clean up processing artifacts that should not live forever.
 - Keep analytics and durable account data out of this policy by default.
 - Make retention understandable as a product and operations concept, not just a table-by-table implementation detail.
 
@@ -25,17 +25,17 @@ That is useful for safety, but it is not yet a complete retention policy. We wan
 
 ## Core Idea
 
-Treat retention as a policy on **artefact groups**, not individual tables.
+Treat retention as a policy on **artifact groups**, not individual tables.
 
 This keeps the model simple:
 
-- User-facing artefacts can have an optional TTL.
-- Processing data inherits the lifecycle of the artefact it belongs to.
+- User-facing artifacts can have an optional TTL.
+- Processing data inherits the lifecycle of the artifact it belongs to.
 - Analytics and durable user/account records are excluded unless we explicitly opt them in later.
 
 ## Proposed Retention Groups
 
-### 1. Batch Artefacts
+### 1. Batch Artifacts
 
 This group covers user-facing batch objects and the files attached to them.
 
@@ -50,11 +50,13 @@ Policy:
 
 - May have an optional TTL.
 - Can also be deleted explicitly by a user.
-- Once eligible for deletion, these artefacts are soft-deleted first and then cleaned up by the existing deletion path.
+- Once eligible for deletion, these artifacts are soft-deleted first and then cleaned up by the existing deletion path.
 
-### 2. Batch Processing Data
+### 2. Batch Content And Processing Data
 
-This group covers internal processing state that exists only to execute or render batch work.
+This group covers the request-level data that belongs to a batch.
+
+That includes both execution state and customer-facing content.
 
 Examples:
 
@@ -64,10 +66,16 @@ Examples:
 Policy:
 
 - Should not have an independent user-facing TTL.
-- Should inherit the lifecycle of the parent batch artefact.
-- When the parent artefact is deleted or expires, this data is cleaned up as part of the same lifecycle.
+- Should inherit the lifecycle of the parent batch artifact.
+- When the parent batch artifact is deleted or expires, this data is cleaned up as part of the same lifecycle.
 
-This is the key simplification: we avoid situations where a batch still exists but its internal request state has disappeared on a separate schedule.
+Reasoning:
+
+- Request templates contain customer prompts and other submitted batch content.
+- Requests contain the responses and execution record for that same batch content.
+- Even if some of this data is internal from an implementation point of view, it still belongs to the same batch lifecycle from a retention point of view.
+
+This is the key simplification: we avoid situations where a batch still exists but its request content or internal request state has disappeared on a separate schedule.
 
 ### 3. Analytics Data
 
@@ -84,7 +92,7 @@ Policy:
 
 Reasoning:
 
-- Analytics serves a different purpose from user-facing artefacts.
+- Analytics serves a different purpose from user-facing artifacts.
 - It is useful for reporting, billing, operational analysis, and historical usage views.
 - If we ever want analytics retention, that should be a separate policy with separate discussion.
 
@@ -107,34 +115,36 @@ Policy:
 
 The policy should be easy to explain:
 
-1. A user-facing artefact may optionally be created with a TTL.
-2. When that TTL expires, the artefact becomes eligible for deletion.
+1. A user-facing artifact may optionally be created with a TTL.
+2. When that TTL expires, the artifact becomes eligible for deletion.
 3. Deletion first removes it from active user-facing views.
-4. Internal processing rows tied to that artefact are then cleaned up through the existing background deletion path.
+4. Internal processing rows tied to that artifact are then cleaned up through the existing background deletion path.
 
 This means retention behaves like:
 
-- **Batch/file artefacts**: configurable and optionally expiring
-- **Requests/templates**: inherited cleanup
+- **Batch/file artifacts**: configurable and optionally expiring
+- **Requests/templates**: inherited cleanup within the same batch lifecycle
 - **Analytics/user data**: retained
 
 ## Default Behavior
 
-The default should be conservative.
+The default should be conservative and explicit.
 
 Suggested default:
 
-- No TTL unless explicitly set for a user-facing artefact.
-- Batch processing data is still cleaned up when its parent artefact is deleted.
+- There is a system-wide default TTL for batch artifacts, but it is config-driven.
+- In `main`, that default should be `null`.
+- A `null` default means the artifact does not expire unless a TTL is set explicitly.
+- Batch content and processing data is still cleaned up when its parent artifact is deleted.
 - Analytics remains untouched.
 
-This avoids surprising data loss while still giving us a clean way to apply retention where it makes sense.
+This avoids surprising data loss while still giving us a clean way to apply retention where it makes sense. It also makes the platform default visible instead of leaving retention behavior implicit.
 
 ## Product/Operator Mental Model
 
 The policy should read like a small set of decisions:
 
-- Do we allow expiry for this kind of artefact?
+- Do we allow expiry for this kind of artifact?
 - If yes, what is the default TTL?
 - What is the maximum allowed TTL?
 - What happens to child processing data?
@@ -145,7 +155,7 @@ That is much easier to reason about than exposing raw table behavior.
 
 At a high level, the configuration should express:
 
-- Which artefact groups support TTL
+- Which artifact groups support TTL
 - Default TTL for those groups
 - Maximum TTL for those groups
 - Which groups inherit parent deletion
@@ -155,12 +165,12 @@ Illustrative example:
 
 ```yaml
 retention:
-  batch_artefacts:
+  batch_artifacts:
     default_ttl: null
     max_ttl: 90d
     action: delete
 
-  batch_processing:
+  batch_content_and_processing:
     mode: inherit_parent
 
   analytics:
@@ -181,7 +191,7 @@ This approach gives us:
 - Simpler cleanup rules for requests and templates.
 - Clear protection for analytics and durable account data.
 
-It also aligns with the principle that user-visible artefacts should define the lifecycle, while internal processing data should follow behind them.
+It also aligns with the principle that user-visible artifacts should define the lifecycle, while related request content and internal processing data should follow behind them.
 
 ## Open Questions
 
@@ -190,17 +200,17 @@ These are the decisions worth discussing with others before implementation:
 1. Should batch/file TTL start from creation time or from terminal state?
 
 Recommended direction:
-Use terminal state where possible, so a long-running artefact does not expire while still active.
+Use terminal state where possible, so a long-running artifact does not expire while still active.
 
-2. Should there be a global default TTL for batch artefacts, or should TTL be opt-in only?
+2. What should the global default TTL for batch artifacts be?
 
 Recommended direction:
-Start opt-in only.
+There should be a global default TTL that is config-driven, with `null` in `main`.
 
 3. Should input files and output/error files share one policy, or should outputs have a different default?
 
 Recommended direction:
-Start with one batch artefact policy unless there is a clear operational need to split them.
+Start with one batch artifact policy unless there is a clear operational need to split them.
 
 4. Should analytics retention be discussed separately?
 
@@ -211,8 +221,8 @@ Yes. Keep it out of this change.
 
 The first version should stay narrow:
 
-- Add retention policy for batch-related user-facing artefacts.
-- Make requests and request templates inherit deletion from those artefacts.
+- Add retention policy for batch-related user-facing artifacts.
+- Make requests and request templates inherit deletion from those artifacts as part of the same batch lifecycle.
 - Leave analytics and durable user/account data alone.
 
 That gives us a meaningful cleanup policy without turning this into a broad data-governance project.

--- a/docs/data-retention-delete-policy.md
+++ b/docs/data-retention-delete-policy.md
@@ -1,0 +1,218 @@
+# Data Retention On Delete Policy
+
+## Goal
+
+Introduce a clear retention policy for user-facing artefacts so that soft deletes become real data cleanup after an optional time-to-live, without treating all data the same.
+
+The main intent is:
+
+- Clean up processing artefacts that should not live forever.
+- Keep analytics and durable account data out of this policy by default.
+- Make retention understandable as a product and operations concept, not just a table-by-table implementation detail.
+
+## What Problem We Are Solving
+
+Today, deletion is partly split across two concepts:
+
+- User-facing delete actions perform soft deletes.
+- A background purge path eventually removes some processing rows.
+
+That is useful for safety, but it is not yet a complete retention policy. We want a clearer answer to:
+
+- Which kinds of data are meant to expire?
+- When should they expire?
+- Which data should explicitly not be touched?
+
+## Core Idea
+
+Treat retention as a policy on **artefact groups**, not individual tables.
+
+This keeps the model simple:
+
+- User-facing artefacts can have an optional TTL.
+- Processing data inherits the lifecycle of the artefact it belongs to.
+- Analytics and durable user/account records are excluded unless we explicitly opt them in later.
+
+## Proposed Retention Groups
+
+### 1. Batch Artefacts
+
+This group covers user-facing batch objects and the files attached to them.
+
+Examples:
+
+- Batch records
+- Input files
+- Output files
+- Error files
+
+Policy:
+
+- May have an optional TTL.
+- Can also be deleted explicitly by a user.
+- Once eligible for deletion, these artefacts are soft-deleted first and then cleaned up by the existing deletion path.
+
+### 2. Batch Processing Data
+
+This group covers internal processing state that exists only to execute or render batch work.
+
+Examples:
+
+- Requests
+- Request templates
+
+Policy:
+
+- Should not have an independent user-facing TTL.
+- Should inherit the lifecycle of the parent batch artefact.
+- When the parent artefact is deleted or expires, this data is cleaned up as part of the same lifecycle.
+
+This is the key simplification: we avoid situations where a batch still exists but its internal request state has disappeared on a separate schedule.
+
+### 3. Analytics Data
+
+This group covers usage and operational analytics.
+
+Examples:
+
+- `http_analytics`
+
+Policy:
+
+- Excluded from this retention policy by default.
+- No automatic cleanup tied to batch/file deletion.
+
+Reasoning:
+
+- Analytics serves a different purpose from user-facing artefacts.
+- It is useful for reporting, billing, operational analysis, and historical usage views.
+- If we ever want analytics retention, that should be a separate policy with separate discussion.
+
+### 4. Durable User Data
+
+This group covers identity and account-level records.
+
+Examples:
+
+- Users
+- Organization membership
+- Other durable account records
+
+Policy:
+
+- Out of scope for this proposal.
+- Continue to use existing deletion and scrubbing rules.
+
+## Deletion Model
+
+The policy should be easy to explain:
+
+1. A user-facing artefact may optionally be created with a TTL.
+2. When that TTL expires, the artefact becomes eligible for deletion.
+3. Deletion first removes it from active user-facing views.
+4. Internal processing rows tied to that artefact are then cleaned up through the existing background deletion path.
+
+This means retention behaves like:
+
+- **Batch/file artefacts**: configurable and optionally expiring
+- **Requests/templates**: inherited cleanup
+- **Analytics/user data**: retained
+
+## Default Behavior
+
+The default should be conservative.
+
+Suggested default:
+
+- No TTL unless explicitly set for a user-facing artefact.
+- Batch processing data is still cleaned up when its parent artefact is deleted.
+- Analytics remains untouched.
+
+This avoids surprising data loss while still giving us a clean way to apply retention where it makes sense.
+
+## Product/Operator Mental Model
+
+The policy should read like a small set of decisions:
+
+- Do we allow expiry for this kind of artefact?
+- If yes, what is the default TTL?
+- What is the maximum allowed TTL?
+- What happens to child processing data?
+
+That is much easier to reason about than exposing raw table behavior.
+
+## Suggested Policy Shape
+
+At a high level, the configuration should express:
+
+- Which artefact groups support TTL
+- Default TTL for those groups
+- Maximum TTL for those groups
+- Which groups inherit parent deletion
+- Which groups are always retained
+
+Illustrative example:
+
+```yaml
+retention:
+  batch_artefacts:
+    default_ttl: null
+    max_ttl: 90d
+    action: delete
+
+  batch_processing:
+    mode: inherit_parent
+
+  analytics:
+    mode: retain
+
+  durable_user_data:
+    mode: retain
+```
+
+The important point is not the exact schema. The important point is that the policy is grouped by meaning, not by storage detail.
+
+## Why This Shape
+
+This approach gives us:
+
+- A clean story for customers and operators.
+- A predictable lifecycle for batches and related files.
+- Simpler cleanup rules for requests and templates.
+- Clear protection for analytics and durable account data.
+
+It also aligns with the principle that user-visible artefacts should define the lifecycle, while internal processing data should follow behind them.
+
+## Open Questions
+
+These are the decisions worth discussing with others before implementation:
+
+1. Should batch/file TTL start from creation time or from terminal state?
+
+Recommended direction:
+Use terminal state where possible, so a long-running artefact does not expire while still active.
+
+2. Should there be a global default TTL for batch artefacts, or should TTL be opt-in only?
+
+Recommended direction:
+Start opt-in only.
+
+3. Should input files and output/error files share one policy, or should outputs have a different default?
+
+Recommended direction:
+Start with one batch artefact policy unless there is a clear operational need to split them.
+
+4. Should analytics retention be discussed separately?
+
+Recommended direction:
+Yes. Keep it out of this change.
+
+## Recommended First Scope
+
+The first version should stay narrow:
+
+- Add retention policy for batch-related user-facing artefacts.
+- Make requests and request templates inherit deletion from those artefacts.
+- Leave analytics and durable user/account data alone.
+
+That gives us a meaningful cleanup policy without turning this into a broad data-governance project.

--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -153,7 +153,14 @@ fn to_batch_response_enriched(batch: fusillade::Batch, creator_email: Option<&st
 
     // Build user-facing metadata: filter out internal dw_* keys.
     // Keep request_source, created_by_email, context_name, context_type for backwards compat.
-    let internal_keys = ["dw_source_id", "dw_source_name", "dw_sync_id", "dw_external_key", "created_by"];
+    let internal_keys = [
+        "dw_source_id",
+        "dw_source_name",
+        "dw_sync_id",
+        "dw_external_key",
+        "created_by",
+        crate::retention::RETENTION_TTL_METADATA_KEY,
+    ];
     let mut metadata: HashMap<String, String> = raw_metadata
         .into_iter()
         .filter(|(k, _)| !internal_keys.contains(&k.as_str()))
@@ -498,11 +505,21 @@ pub async fn create_batch<P: PoolProvider>(
     // Strip reserved keys that are injected server-side during response enrichment
     // to prevent user-supplied values from colliding with system fields.
     let mut metadata_map = req.metadata.unwrap_or_default();
-    for key in &["created_by_email", "context_name", "context_type", "request_source", "created_by"] {
+    for key in &[
+        "created_by_email",
+        "context_name",
+        "context_type",
+        "request_source",
+        "created_by",
+        crate::retention::RETENTION_TTL_METADATA_KEY,
+    ] {
         metadata_map.remove(*key);
     }
     metadata_map.insert("request_source".to_string(), request_source.to_string());
     metadata_map.insert("created_by".to_string(), current_user.id.to_string());
+    if let Some(ttl_seconds) = crate::retention::default_batch_artifact_ttl_seconds(&config) {
+        metadata_map.insert(crate::retention::RETENTION_TTL_METADATA_KEY.to_string(), ttl_seconds.to_string());
+    }
     let metadata = serde_json::to_value(metadata_map).ok();
 
     // Create batch input — created_by uses org ID when in org context for ownership scoping

--- a/dwctl/src/api/handlers/files.rs
+++ b/dwctl/src/api/handlers/files.rs
@@ -435,6 +435,7 @@ fn create_file_stream(
     uploaded_by: Option<String>,
     req_ctx: FileRequestContext,
     api_key_id: Option<uuid::Uuid>,
+    default_expires_after_seconds: Option<i64>,
 ) -> FileStreamResult {
     let FileRequestContext {
         endpoint,
@@ -514,6 +515,9 @@ fn create_file_stream(
                 "file" => {
                     // Extract filename from the field
                     metadata.filename = field.file_name().map(|s| s.to_string());
+                    if metadata.expires_after_seconds.is_none() {
+                        metadata.expires_after_seconds = default_expires_after_seconds;
+                    }
 
                     // Send metadata before processing file content
                     if tx.send(fusillade::FileStreamItem::Metadata(metadata.clone())).await.is_err() {
@@ -899,6 +903,7 @@ pub async fn upload_file<P: PoolProvider>(
             allowed_url_paths: config.batches.allowed_url_paths.clone(),
         },
         Some(api_key_id),
+        crate::retention::default_batch_artifact_ttl_seconds(&config),
     );
 
     // Create file via request manager with streaming

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1428,6 +1428,47 @@ pub struct BackgroundServicesConfig {
     pub notifications: NotificationsConfig,
     /// Configuration for connection sync workers (file ingestion, batch activation)
     pub sync_workers: SyncWorkersConfig,
+    /// Configuration for artifact retention and delete sweeps
+    pub retention: RetentionConfig,
+}
+
+/// Artifact retention sweep configuration.
+///
+/// Controls how batch artifacts are assigned default TTLs and how often the
+/// system scans for due deletions.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct RetentionConfig {
+    /// Enable retention sweeps (default: true).
+    /// When disabled, no automatic deletion occurs even if artifact TTLs are set.
+    pub enabled: bool,
+    /// How often to scan for expired artifacts (default: 10m).
+    #[serde(with = "humantime_serde")]
+    pub sweep_interval: Duration,
+    /// Maximum number of batches/files to process per sweep pass (default: 100).
+    pub batch_size: i64,
+    /// Default TTL applied to batch artifacts when no explicit file expiry is
+    /// provided. `null` means "no control-layer default".
+    #[serde(default, with = "humantime_serde::option")]
+    pub batch_artifacts_default_ttl: Option<Duration>,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            sweep_interval: Duration::from_secs(600),
+            batch_size: 100,
+            batch_artifacts_default_ttl: None,
+        }
+    }
+}
+
+impl RetentionConfig {
+    /// Default batch artifact TTL in whole seconds, if configured.
+    pub fn batch_artifacts_default_ttl_seconds(&self) -> Option<i64> {
+        self.batch_artifacts_default_ttl.and_then(|ttl| i64::try_from(ttl.as_secs()).ok())
+    }
 }
 
 /// Database pool metrics sampling configuration.
@@ -3051,6 +3092,59 @@ background_services:
 
             let config = Config::load(&args)?;
             assert_eq!(config.background_services.batch_daemon.urgency_weight, 0.5);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_retention_default_ttl_yaml_override() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "test.yaml",
+                r#"
+secret_key: "test-secret-key"
+background_services:
+  retention:
+    batch_artifacts_default_ttl: 7d
+"#,
+            )?;
+
+            let args = Args {
+                config: "test.yaml".into(),
+                validate: false,
+            };
+
+            let config = Config::load(&args)?;
+            assert_eq!(
+                config.background_services.retention.batch_artifacts_default_ttl,
+                Some(Duration::from_secs(7 * 24 * 60 * 60))
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_retention_default_ttl_null() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "test.yaml",
+                r#"
+secret_key: "test-secret-key"
+background_services:
+  retention:
+    batch_artifacts_default_ttl: null
+"#,
+            )?;
+
+            let args = Args {
+                config: "test.yaml".into(),
+                validate: false,
+            };
+
+            let config = Config::load(&args)?;
+            assert_eq!(config.background_services.retention.batch_artifacts_default_ttl, None);
 
             Ok(())
         });

--- a/dwctl/src/connections/sync.rs
+++ b/dwctl/src/connections/sync.rs
@@ -468,6 +468,7 @@ pub(crate) async fn run_ingest_file<P: PoolProvider + Clone + Send + Sync + 'sta
     // Spawn producer task: reads from S3, parses JSONL, sends templates
     let external_key = input.external_key.clone();
     let connection_id = input.connection_id;
+    let config = state.config.snapshot();
     let producer = tokio::spawn(async move {
         use futures::StreamExt;
 
@@ -484,6 +485,8 @@ pub(crate) async fn run_ingest_file<P: PoolProvider + Clone + Send + Sync + 'sta
             source_external_key: Some(external_key.clone()),
             ..Default::default()
         };
+        let mut metadata = metadata;
+        crate::retention::apply_default_file_ttl(&mut metadata, &config);
 
         if tx.send(FileStreamItem::Metadata(metadata)).await.is_err() {
             return (0i32, 0i32, Vec::new());
@@ -1055,13 +1058,21 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
         tracing::info!(batch_id = %existing, "Reusing batch from previous attempt");
         existing
     } else {
-        let metadata = serde_json::json!({
+        let mut metadata = serde_json::json!({
             "request_source": "sync",
             "dw_source_id": input.connection_id.to_string(),
             "dw_source_name": connection_name,
             "dw_sync_id": input.sync_id.to_string(),
             "dw_external_key": external_key,
         });
+        if let Some(ttl_seconds) = crate::retention::default_batch_artifact_ttl_seconds(&state.config.snapshot())
+            && let Some(obj) = metadata.as_object_mut()
+        {
+            obj.insert(
+                crate::retention::RETENTION_TTL_METADATA_KEY.to_string(),
+                serde_json::Value::String(ttl_seconds.to_string()),
+            );
+        }
 
         let batch_input = fusillade::BatchInput {
             file_id: fusillade::FileId(input.file_id),

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -159,6 +159,7 @@ mod openapi;
 mod payment_providers;
 mod probes;
 mod request_logging;
+mod retention;
 pub mod sample_files;
 mod static_assets;
 mod sync;
@@ -1816,6 +1817,7 @@ async fn setup_background_services(
     // Create shared model capacity limits map for daemon coordination
     // This is populated by onwards config sync and read by fusillade daemon
     let model_capacity_limits = Arc::new(dashmap::DashMap::new());
+    let fusillade_retention_pool = fusillade_pools.write().clone();
 
     // Start onwards integration for proxying AI requests (if enabled)
     #[cfg_attr(not(test), allow(unused_variables))]
@@ -1978,6 +1980,22 @@ async fn setup_background_services(
                 Ok(())
             });
         }
+
+        {
+            let retention_pool = fusillade_retention_pool.clone();
+            let retention_request_manager = request_manager.clone();
+            let retention_shared_config = shared_config.clone();
+            let retention_shutdown = shutdown_token.clone();
+            background_tasks.spawn("retention-sweeper", async move {
+                retention::run_retention_loop(
+                    retention_pool,
+                    retention_request_manager,
+                    retention_shared_config,
+                    retention_shutdown,
+                )
+                .await
+            });
+        }
     } else {
         // Normal leader election
         is_leader = false;
@@ -2017,6 +2035,8 @@ async fn setup_background_services(
         let leader_election_request_manager_gain = request_manager.clone();
         let leader_election_config = config.clone();
         let leader_election_flag = is_leader_flag.clone();
+        let leader_election_retention_pool = fusillade_retention_pool.clone();
+        let leader_election_shared_config = shared_config.clone();
 
         // Store daemon handle for cleanup on leadership loss
         let daemon_handle: Arc<tokio::sync::Mutex<Option<tokio::task::JoinHandle<fusillade::Result<()>>>>> =
@@ -2044,6 +2064,8 @@ async fn setup_background_services(
                     let request_manager = leader_election_request_manager_gain.clone();
                     let daemon_handle = daemon_handle_gain.clone();
                     let leadership_shutdown = leadership_shutdown_gain.clone();
+                    let retention_pool = leader_election_retention_pool.clone();
+                    let retention_shared_config = leader_election_shared_config.clone();
                     async move {
                         // Wait for the server to be fully up before starting probes
                         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -2078,6 +2100,7 @@ async fn setup_background_services(
                         match config.background_services.batch_daemon.enabled {
                             DaemonEnabled::Leader => {
                                 let handle = request_manager
+                                    .clone()
                                     .run(session_token.clone())
                                     .map_err(|e| anyhow::anyhow!("Failed to start fusillade daemon: {}", e))?;
 
@@ -2109,6 +2132,24 @@ async fn setup_background_services(
                                 .await;
                             });
                             tracing::info!("Batch completion poller started on elected leader");
+                        }
+
+                        {
+                            let retention_request_manager = request_manager.clone();
+                            let retention_session_token = session_token.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = retention::run_retention_loop(
+                                    retention_pool,
+                                    retention_request_manager,
+                                    retention_shared_config,
+                                    retention_session_token,
+                                )
+                                .await
+                                {
+                                    tracing::error!(error = %e, "Retention sweeper failed");
+                                }
+                            });
+                            tracing::info!("Retention sweeper started on elected leader");
                         }
 
                         Ok(())

--- a/dwctl/src/retention.rs
+++ b/dwctl/src/retention.rs
@@ -1,0 +1,332 @@
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use anyhow::Context;
+use fusillade::Storage;
+use fusillade::manager::DaemonStorage;
+use sqlx::{FromRow, PgPool};
+use sqlx_pool_router::PoolProvider;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::{Config, SharedConfig, config::RetentionConfig};
+
+/// Internal batch metadata key storing artifact retention TTL in whole seconds.
+pub(crate) const RETENTION_TTL_METADATA_KEY: &str = "dw_retention_ttl_seconds";
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct SweepSummary {
+    pub deleted_batches: usize,
+    pub deleted_files: usize,
+    pub purged_rows: u64,
+}
+
+#[derive(Debug, FromRow)]
+struct DueBatchRow {
+    id: Uuid,
+    file_id: Option<Uuid>,
+    output_file_id: Option<Uuid>,
+    error_file_id: Option<Uuid>,
+}
+
+#[derive(Debug, FromRow)]
+struct DueFileRow {
+    id: Uuid,
+}
+
+/// Returns the configured default batch artifact TTL in seconds, if any.
+pub(crate) fn default_batch_artifact_ttl_seconds(config: &Config) -> Option<i64> {
+    config.background_services.retention.batch_artifacts_default_ttl_seconds()
+}
+
+/// Apply the configured default batch artifact TTL to a file metadata payload
+/// when the request did not provide an explicit expiry.
+pub(crate) fn apply_default_file_ttl(metadata: &mut fusillade::FileMetadata, config: &Config) {
+    if metadata.expires_after_seconds.is_none() {
+        metadata.expires_after_seconds = default_batch_artifact_ttl_seconds(config);
+    }
+}
+
+/// Runs a single retention sweep pass.
+pub(crate) async fn run_retention_pass<P: PoolProvider + Clone>(
+    fusillade_pool: &PgPool,
+    request_manager: &Arc<fusillade::PostgresRequestManager<P, fusillade::ReqwestHttpClient>>,
+    retention: &RetentionConfig,
+) -> anyhow::Result<SweepSummary> {
+    let batch_size = retention.batch_size.max(1);
+
+    let due_batches: Vec<DueBatchRow> = sqlx::query_as(
+        r#"
+        SELECT
+            b.id,
+            b.file_id,
+            b.output_file_id,
+            b.error_file_id
+        FROM batches b
+        WHERE b.deleted_at IS NULL
+          AND COALESCE(b.completed_at, b.failed_at, b.cancelled_at) IS NOT NULL
+          AND b.metadata IS NOT NULL
+          AND (b.metadata ->> $1) IS NOT NULL
+          AND (b.metadata ->> $1) ~ '^[0-9]+$'
+          AND COALESCE(b.completed_at, b.failed_at, b.cancelled_at)
+              + make_interval(secs => (b.metadata ->> $1)::BIGINT) <= NOW()
+        ORDER BY COALESCE(b.completed_at, b.failed_at, b.cancelled_at) ASC, b.id ASC
+        LIMIT $2
+        "#,
+    )
+    .bind(RETENTION_TTL_METADATA_KEY)
+    .bind(batch_size)
+    .fetch_all(fusillade_pool)
+    .await
+    .context("query due batches for retention sweep")?;
+
+    let due_files: Vec<DueFileRow> = sqlx::query_as(
+        r#"
+        SELECT f.id
+        FROM files f
+        LEFT JOIN batches bi ON bi.file_id = f.id AND bi.deleted_at IS NULL
+        LEFT JOIN batches bo ON bo.output_file_id = f.id AND bo.deleted_at IS NULL
+        LEFT JOIN batches be ON be.error_file_id = f.id AND be.deleted_at IS NULL
+        WHERE f.deleted_at IS NULL
+          AND f.expires_at IS NOT NULL
+          AND f.expires_at <= NOW()
+          AND bi.id IS NULL
+          AND bo.id IS NULL
+          AND be.id IS NULL
+        ORDER BY f.expires_at ASC, f.id ASC
+        LIMIT $1
+        "#,
+    )
+    .bind(batch_size)
+    .fetch_all(fusillade_pool)
+    .await
+    .context("query due standalone files for retention sweep")?;
+
+    let mut summary = SweepSummary::default();
+    let mut files_to_delete = HashSet::new();
+
+    for batch in due_batches {
+        request_manager
+            .delete_batch(fusillade::BatchId(batch.id))
+            .await
+            .with_context(|| format!("soft-delete expired batch {}", batch.id))?;
+        summary.deleted_batches += 1;
+
+        files_to_delete.extend([batch.file_id, batch.output_file_id, batch.error_file_id].into_iter().flatten());
+    }
+
+    files_to_delete.extend(due_files.into_iter().map(|f| f.id));
+
+    for file_id in files_to_delete {
+        request_manager
+            .delete_file(fusillade::FileId(file_id))
+            .await
+            .with_context(|| format!("soft-delete expired file {}", file_id))?;
+        summary.deleted_files += 1;
+    }
+
+    if summary.deleted_batches > 0 || summary.deleted_files > 0 {
+        summary.purged_rows = request_manager
+            .purge_orphaned_rows(batch_size)
+            .await
+            .context("purge orphaned fusillade rows after retention sweep")?;
+    }
+
+    Ok(summary)
+}
+
+/// Periodic retention sweep loop.
+pub(crate) async fn run_retention_loop<P: PoolProvider + Clone + Send + Sync + 'static>(
+    fusillade_pool: PgPool,
+    request_manager: Arc<fusillade::PostgresRequestManager<P, fusillade::ReqwestHttpClient>>,
+    shared_config: SharedConfig,
+    shutdown: CancellationToken,
+) -> anyhow::Result<()> {
+    loop {
+        let config = shared_config.snapshot();
+        let retention = config.background_services.retention.clone();
+        let interval = retention.sweep_interval;
+
+        if retention.enabled {
+            let summary = run_retention_pass(&fusillade_pool, &request_manager, &retention).await?;
+            if summary.deleted_batches > 0 || summary.deleted_files > 0 || summary.purged_rows > 0 {
+                tracing::info!(
+                    deleted_batches = summary.deleted_batches,
+                    deleted_files = summary.deleted_files,
+                    purged_rows = summary.purged_rows,
+                    "Retention sweep completed"
+                );
+            }
+        }
+
+        tokio::select! {
+            _ = tokio::time::sleep(normalize_interval(interval)) => {},
+            _ = shutdown.cancelled() => return Ok(()),
+        }
+    }
+}
+
+fn normalize_interval(interval: Duration) -> Duration {
+    if interval.is_zero() { Duration::from_secs(60) } else { interval }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, Utc};
+    use sqlx::PgPool;
+    use sqlx::postgres::PgConnectOptions;
+
+    use crate::{config::Config, test::utils::create_test_app_state_with_fusillade};
+
+    async fn create_fusillade_pool(pool: &PgPool) -> PgPool {
+        let base_opts: PgConnectOptions = pool.connect_options().as_ref().clone();
+        sqlx::postgres::PgPoolOptions::new()
+            .max_connections(4)
+            .min_connections(0)
+            .connect_with(base_opts.options([("search_path", "fusillade")]))
+            .await
+            .expect("Failed to create fusillade pool")
+    }
+
+    #[sqlx::test]
+    async fn test_apply_default_file_ttl_respects_existing_expiry(pool: PgPool) {
+        let mut config = Config::default();
+        config.background_services.retention.batch_artifacts_default_ttl = Some(Duration::from_secs(600));
+
+        let mut metadata = fusillade::FileMetadata {
+            expires_after_seconds: Some(60),
+            ..Default::default()
+        };
+
+        super::apply_default_file_ttl(&mut metadata, &config);
+        assert_eq!(metadata.expires_after_seconds, Some(60));
+
+        let mut metadata_without_expiry = fusillade::FileMetadata::default();
+        super::apply_default_file_ttl(&mut metadata_without_expiry, &config);
+        assert_eq!(metadata_without_expiry.expires_after_seconds, Some(600));
+
+        drop(pool);
+    }
+
+    #[sqlx::test]
+    async fn test_retention_sweep_deletes_due_batch_and_files(pool: PgPool) {
+        let mut config = Config::default();
+        config.background_services.retention.batch_size = 100;
+        let state = create_test_app_state_with_fusillade(pool.clone(), config.clone()).await;
+        let fusillade_pool = create_fusillade_pool(&pool).await;
+
+        let input_file_id = Uuid::new_v4();
+        let output_file_id = Uuid::new_v4();
+        let error_file_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+        let template_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let metadata = serde_json::json!({
+            super::RETENTION_TTL_METADATA_KEY: "0"
+        });
+
+        sqlx::query(
+            r#"
+            INSERT INTO fusillade.files (id, name, purpose, status, size_bytes, size_finalized, created_at, updated_at, expires_at)
+            VALUES ($1, 'input.jsonl', 'batch', 'processed', 1, TRUE, NOW() - INTERVAL '2 hours', NOW(), NOW() - INTERVAL '1 hour'),
+                   ($2, 'output.jsonl', 'batch_output', 'processed', 1, TRUE, NOW() - INTERVAL '2 hours', NOW(), NOW() - INTERVAL '1 hour'),
+                   ($3, 'error.jsonl', 'batch_error', 'processed', 1, TRUE, NOW() - INTERVAL '2 hours', NOW(), NOW() - INTERVAL '1 hour')
+            "#,
+        )
+        .bind(input_file_id)
+        .bind(output_file_id)
+        .bind(error_file_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            r#"
+            INSERT INTO fusillade.request_templates (id, file_id, model, api_key, endpoint, path, body, custom_id, method, created_at, updated_at)
+            VALUES ($1, $2, 'test-model', 'test-key', 'http://test', '/v1/chat/completions', '{}', 'req-0', 'POST', NOW(), NOW())
+            "#,
+        )
+        .bind(template_id)
+        .bind(input_file_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            r#"
+            INSERT INTO fusillade.batches (
+                id, created_by, file_id, endpoint, completion_window, expires_at, created_at,
+                total_requests, completed_at, metadata, output_file_id, error_file_id
+            )
+            VALUES (
+                $1, $2, $3, '/v1/chat/completions', '24h', NOW() + INTERVAL '24 hours',
+                NOW() - INTERVAL '2 hours', 1, NOW() - INTERVAL '1 hour', $4, $5, $6
+            )
+            "#,
+        )
+        .bind(batch_id)
+        .bind(Uuid::new_v4().to_string())
+        .bind(input_file_id)
+        .bind(metadata)
+        .bind(output_file_id)
+        .bind(error_file_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            r#"
+            INSERT INTO fusillade.requests (
+                id, batch_id, template_id, endpoint, method, path, body, model, api_key,
+                state, response_status, response_body, response_size, created_at, updated_at, completed_at
+            )
+            VALUES (
+                $1, $2, $3, 'http://test', 'POST', '/v1/chat/completions', '{}', 'test-model', 'test-key',
+                'completed', 200, '{}', 2, NOW() - INTERVAL '2 hours', NOW(), NOW() - INTERVAL '1 hour'
+            )
+            "#,
+        )
+        .bind(request_id)
+        .bind(batch_id)
+        .bind(template_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let summary = super::run_retention_pass(&fusillade_pool, &state.request_manager, &config.background_services.retention)
+            .await
+            .unwrap();
+
+        assert_eq!(summary.deleted_batches, 1);
+        assert_eq!(summary.deleted_files, 3);
+        assert!(summary.purged_rows >= 2);
+
+        let deleted_at: Option<DateTime<Utc>> = sqlx::query_scalar("SELECT deleted_at FROM fusillade.batches WHERE id = $1")
+            .bind(batch_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(deleted_at.is_some());
+
+        let file_delete_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM fusillade.files WHERE id = ANY($1) AND deleted_at IS NOT NULL")
+                .bind(vec![input_file_id, output_file_id, error_file_id])
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(file_delete_count, 3);
+
+        let remaining_requests: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM fusillade.requests WHERE batch_id = $1")
+            .bind(batch_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining_requests, 0);
+
+        let remaining_templates: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM fusillade.request_templates WHERE file_id = $1")
+            .bind(input_file_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining_templates, 0);
+    }
+}


### PR DESCRIPTION
## Summary

This PR moves the retention proposal into an initial implementation for batch-facing artefacts.

It adds a configurable retention policy for artefacts we expect to clean up after a reasonable period, while leaving durable product data such as `http_analytics` and user records alone.

## What Changed

- Added `background_services.retention` config with:
  - `enabled`
  - `sweep_interval`
  - `batch_size`
  - `batch_artifacts_default_ttl`
- Applied a default file TTL to batch-related uploads when the caller does not explicitly provide `expires_after`.
- Applied the same default TTL to files created by the sync pipeline.
- Stamped batch-linked artefacts with an internal retention TTL marker so grouped clean-up can happen off batch lifecycle rather than per-table ad hoc rules.
- Added a leader-scoped retention sweeper that:
  - finds terminal batches whose retention window has elapsed
  - soft-deletes those batches
  - soft-deletes linked files
  - deletes standalone expired files that are no longer referenced by active batches
  - calls Fusillade orphan purging to hard-delete `requests` and `request_templates`
- Hid the internal retention metadata from batch API responses.
- Added config parsing tests and retention sweep tests.

## Intended Policy Shape

- Batch request artefacts should be cleaned up as a group.
- `requests`, `request_templates`, and Fusillade file artefacts are the first retention-managed set.
- Batch retention is configured separately from other data classes.
- `http_analytics`, user data, and other durable business records are intentionally out of scope here.

## Config Example

```yaml
background_services:
  retention:
    enabled: true
    sweep_interval: 10m
    batch_size: 100
    batch_artifacts_default_ttl: 7d
```

`batch_artifacts_default_ttl: null` means the control layer does not inject a default TTL.

## Notes

- Explicit `expires_after[...]` values from the OpenAI-compatible Files API still win when supplied.
- The retention TTL stored on batches is internal metadata and is stripped from user-facing responses.
- The sweeper only runs on the leader path, matching the rest of the batch/background lifecycle.

## Verification

- `cargo check -p dwctl`
- `cargo fmt --all`

`cargo test -p dwctl retention` is currently blocked by the repo's SQLx test setup because unrelated query macros require either `DATABASE_URL` or an up-to-date prepared query cache.
