### PR TITLE
fix: batch id attribution and completion window filtering

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -365,7 +365,14 @@ jobs:
         run: npx playwright install chromium --only-shell
 
       - name: Install hurl
+        # Pinned: hurl 8.0.0 (2026-04-27) ships an RFC 9535 JSONPath rewrite
+        # that breaks our existing `count` / `nth` patterns on filter results
+        # that yield 0 or 1 items (see tests/perms/{models,users,requests,
+        # transactions}.hurl and tests/authenticated/admin-crud-group.hurl).
+        # Hold at 7.x until the assertions are migrated to RFC 9535 semantics.
         uses: gacts/install-hurl@v1
+        with:
+          version: 7.1.0
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2293,8 +2293,6 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "fusillade"
 version = "16.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39e849d9f14654d290aee187b9dfe3a87f06f35ce3c6b3ca4ecbcde9c2c9d71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2900,7 +2898,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3699,7 +3697,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4536,7 +4534,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.39",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4574,9 +4572,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5130,7 +5128,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5201,7 +5199,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6047,7 +6045,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6973,7 +6971,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2292,7 +2292,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "16.5.1"
+version = "16.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f7881d158dbfdf017cb39d446a472b12a6d0d650b91fd8fb9f1b0170605973"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2898,7 +2900,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3697,7 +3699,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4534,7 +4536,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.39",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4572,9 +4574,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5128,7 +5130,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5199,7 +5201,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6045,7 +6047,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6971,7 +6973,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
 members = ["dwctl"]
 resolver = "2"
+
+# Local dev overrides while iterating on fusillade alongside dwctl.
+# Remove before merging — release flow expects crates.io versions.
+[patch.crates-io]
+fusillade = { path = "../fusillade" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
 [workspace]
 members = ["dwctl"]
 resolver = "2"
-
-# Local dev overrides while iterating on fusillade alongside dwctl.
-# Remove before merging — release flow expects crates.io versions.
-[patch.crates-io]
-fusillade = { path = "../fusillade" }

--- a/dashboard/src/api/control-layer/client.ts
+++ b/dashboard/src/api/control-layer/client.ts
@@ -1559,8 +1559,8 @@ const batchesApi = {
     if (options?.created_after) params.set("created_after", options.created_after);
     if (options?.created_before) params.set("created_before", options.created_before);
     if (options?.active_first) params.set("active_first", "true");
-    if (options?.exclude_completion_window)
-      params.set("exclude_completion_window", options.exclude_completion_window);
+    if (options?.completion_window)
+      params.set("completion_window", options.completion_window);
 
     const response = await fetchAiApi(
       `/ai/v1/batches${params.toString() ? "?" + params.toString() : ""}`,

--- a/dashboard/src/api/control-layer/types.ts
+++ b/dashboard/src/api/control-layer/types.ts
@@ -1232,8 +1232,11 @@ export interface BatchesListQuery {
   created_before?: string;
   /** When true, sort active (non-terminal) batches before terminal ones */
   active_first?: boolean;
-  /** Exclude batches with this completion window (e.g., "1h" to hide async) */
-  exclude_completion_window?: string;
+  /** Comma-separated completion windows to include — typical values: "24h"
+   *  (batch), "1h" (flex), "0s" (realtime tracking). Omit for no filter. The
+   *  dashboard sends "24h" by default so realtime tracking rows don't pollute
+   *  the Batches view. */
+  completion_window?: string;
 }
 
 // ===== BATCH REQUESTS (Custom endpoints beyond OpenAI spec) =====

--- a/dashboard/src/components/features/async-requests/AsyncRequests.tsx
+++ b/dashboard/src/components/features/async-requests/AsyncRequests.tsx
@@ -175,7 +175,9 @@ function createColumns(
               <Icon className="h-4 w-4" />
             </span>
           </TooltipTrigger>
-          <TooltipContent side="top">{tier}</TooltipContent>
+          <TooltipContent side="top">
+            {tier.charAt(0).toUpperCase() + tier.slice(1)}
+          </TooltipContent>
         </Tooltip>
       );
     },
@@ -452,7 +454,7 @@ export function AsyncRequests() {
                       }}
                       className="rounded border-gray-300"
                     />
-                    {tier === "flex" ? "Flex" : "Realtime"}
+                    {tier === "flex" ? "Flex" : "Priority"}
                   </label>
                 ))}
               </PopoverContent>

--- a/dashboard/src/components/features/batches/Batches/Batches.tsx
+++ b/dashboard/src/components/features/batches/Batches/Batches.tsx
@@ -63,6 +63,13 @@ import { useBootstrapContent } from "@/hooks/use-bootstrap-content";
 import { ApiExamples } from "../../../modals";
 import { cn } from "@/lib/utils";
 
+// Window strings forwarded as-is to the backend `completion_window` filter.
+// Flex/async uses the configurable async window (default "1h"); regular batch
+// jobs use "24h". Realtime tracking rows ("0s") are intentionally omitted
+// from the UI selector — they're queryable via the API but live on the Async
+// Requests page in the dashboard.
+const BATCH_COMPLETION_WINDOW = "24h";
+
 /**
  * Props for the Batches component.
  * All modal operations are handled by parent container to prevent
@@ -162,7 +169,13 @@ export function Batches({
 
   // Batch-specific filters
   const [statusFilter, setStatusFilter] = useState<BatchStatus | "all">("all");
-  const [hideAsync, setHideAsync] = useState(false);
+  // Completion-window multi-select. Maps directly to the backend
+  // `completion_window` query param (comma-separated). Default hides the
+  // realtime tracking rows ("0s") and async/flex requests ("1h") that the
+  // Open Responses API creates — those have their own page in Async Requests.
+  const [completionWindowFilter, setCompletionWindowFilter] = useState<
+    string[]
+  >([BATCH_COMPLETION_WINDOW]);
   const [sortActiveFirst, setSortActiveFirst] = useState(true);
   const [dateRange, setDateRange] = useState<
     { from: Date; to: Date } | undefined
@@ -264,6 +277,13 @@ export function Batches({
     enabled: activeTab === "files" || !!batchFileFilter,
   });
 
+  // Empty selection means "no filter" — same UX as AsyncRequests so the user
+  // can't accidentally end up with a query that matches nothing.
+  const completionWindowParam =
+    completionWindowFilter.length > 0
+      ? completionWindowFilter.join(",")
+      : undefined;
+
   // Paginated batches query - include analytics to avoid N+1 requests
   const { data: batchesResponse, isLoading: batchesLoading } = useBatches({
     search: debouncedBatchSearch.trim() || undefined,
@@ -273,7 +293,7 @@ export function Batches({
     created_after: dateRange?.from.toISOString(),
     created_before: dateRange?.to.toISOString(),
     active_first: sortActiveFirst || undefined,
-    exclude_completion_window: hideAsync ? asyncCompletionWindow : undefined,
+    completion_window: completionWindowParam,
     ...batchesPagination.queryParams,
   });
 
@@ -351,6 +371,7 @@ export function Batches({
         created_after: dateRange?.from.toISOString(),
         created_before: dateRange?.to.toISOString(),
         active_first: sortActiveFirst || undefined,
+        completion_window: completionWindowParam,
         limit: batchesPagination.pageSize + 1,
         after: nextCursor,
       };
@@ -365,6 +386,7 @@ export function Batches({
     batchesHasMore,
     batchesPagination.page,
     batchesPagination.pageSize,
+    completionWindowParam,
     debouncedBatchSearch,
     selectedMemberId,
     statusFilter,
@@ -534,7 +556,9 @@ export function Batches({
     getInputFile,
     onRowClick: handleBatchClick,
     showUserColumn,
-    showTypeColumn: !hideAsync,
+    // Always show the type column now — its purpose is to disambiguate the
+    // three completion-window classes when more than one is selected.
+    showTypeColumn: true,
     asyncCompletionWindow,
   });
 
@@ -810,22 +834,60 @@ export function Batches({
                     Active first
                   </label>
                 </div>
-                <div className="flex items-center gap-1.5">
-                  <Switch
-                    id="hide-async"
-                    checked={hideAsync}
-                    onCheckedChange={(checked) => {
-                      setHideAsync(checked);
-                      batchesPagination.handleFirstPage();
-                    }}
-                  />
-                  <label
-                    htmlFor="hide-async"
-                    className="text-sm text-gray-600 cursor-pointer select-none"
-                  >
-                    Batch only
-                  </label>
-                </div>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className="h-9 justify-between font-normal"
+                    >
+                      <div className="flex items-center gap-1.5 truncate">
+                        <Filter className="w-3.5 h-3.5 shrink-0 text-gray-500" />
+                        <span className="truncate">
+                          {completionWindowFilter.length === 0
+                            ? "All windows"
+                            : completionWindowFilter
+                                .map((w) =>
+                                  w === asyncCompletionWindow
+                                    ? "Async"
+                                    : w === BATCH_COMPLETION_WINDOW
+                                      ? "Batch"
+                                      : w,
+                                )
+                                .join(", ")}
+                        </span>
+                      </div>
+                      <ChevronsUpDown className="ml-1 h-3.5 w-3.5 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[160px] p-2" align="start">
+                    {(
+                      [
+                        { window: BATCH_COMPLETION_WINDOW, label: "Batch" },
+                        { window: asyncCompletionWindow, label: "Async" },
+                      ] as const
+                    ).map(({ window, label }) => (
+                      <label
+                        key={window}
+                        className="flex items-center gap-2 px-2 py-1.5 text-sm cursor-pointer rounded hover:bg-gray-50"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={completionWindowFilter.includes(window)}
+                          onChange={() => {
+                            setCompletionWindowFilter((prev) =>
+                              prev.includes(window)
+                                ? prev.filter((w) => w !== window)
+                                : [...prev, window],
+                            );
+                            batchesPagination.handleFirstPage();
+                          }}
+                          className="rounded border-gray-300"
+                        />
+                        {label}
+                      </label>
+                    ))}
+                  </PopoverContent>
+                </Popover>
                 {memberFilterCombobox}
                 <Select
                   value={statusFilter}

--- a/dashboard/src/components/features/batches/Batches/Batches.tsx
+++ b/dashboard/src/components/features/batches/Batches/Batches.tsx
@@ -64,10 +64,10 @@ import { ApiExamples } from "../../../modals";
 import { cn } from "@/lib/utils";
 
 // Window strings forwarded as-is to the backend `completion_window` filter.
-// Flex/async uses the configurable async window (default "1h"); regular batch
-// jobs use "24h". Realtime tracking rows ("0s") are intentionally omitted
-// from the UI selector — they're queryable via the API but live on the Async
-// Requests page in the dashboard.
+// Async uses the configurable async window (default "1h"); regular batch jobs
+// use "24h". Realtime tracking rows ("0s") are intentionally omitted from
+// the UI selector — they're queryable via the API but live on the Responses
+// page in the dashboard.
 const BATCH_COMPLETION_WINDOW = "24h";
 
 /**

--- a/dashboard/src/components/features/batches/BatchesTable/columns.tsx
+++ b/dashboard/src/components/features/batches/BatchesTable/columns.tsx
@@ -11,6 +11,7 @@ import {
   Trash2,
   Box,
   FastForward,
+  Zap,
 } from "lucide-react";
 import { Button } from "../../../ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../../ui/tooltip";
@@ -119,21 +120,24 @@ export const createBatchColumns = (
           header: "Type",
           cell: ({ row }: { row: { original: Batch } }) => {
             const batch = row.original;
-            const isAsync = batch.completion_window === (actions.asyncCompletionWindow ?? "1h");
+            // Three classes today: realtime tracking rows ("0s"), flex/async
+            // ("1h" by default), and regular batches (anything else, typically
+            // "24h"). Anything unrecognised falls into the batch bucket.
+            const asyncWindow = actions.asyncCompletionWindow ?? "1h";
+            const { Icon, label } =
+              batch.completion_window === "0s"
+                ? { Icon: Zap, label: "Realtime" }
+                : batch.completion_window === asyncWindow
+                  ? { Icon: FastForward, label: "Async" }
+                  : { Icon: Box, label: "Batch" };
             return (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="inline-flex text-doubleword-neutral-600">
-                    {isAsync ? (
-                      <FastForward className="h-4 w-4" />
-                    ) : (
-                      <Box className="h-4 w-4" />
-                    )}
+                    <Icon className="h-4 w-4" />
                   </span>
                 </TooltipTrigger>
-                <TooltipContent side="top">
-                  {isAsync ? "Flex" : "Realtime"}
-                </TooltipContent>
+                <TooltipContent side="top">{label}</TooltipContent>
               </Tooltip>
             );
           },

--- a/dashboard/src/components/features/models/catalog/ModelCatalog.tsx
+++ b/dashboard/src/components/features/models/catalog/ModelCatalog.tsx
@@ -1042,6 +1042,7 @@ export const ModelCatalog: React.FC = () => {
         isOpen={apiExamplesModel !== null}
         onClose={() => setApiExamplesModel(null)}
         model={apiExamplesModel}
+        defaultTab="realtime"
       />
     </div>
   );

--- a/dashboard/src/components/features/models/catalog/ModelDetail.tsx
+++ b/dashboard/src/components/features/models/catalog/ModelDetail.tsx
@@ -285,6 +285,7 @@ export const ModelDetail: React.FC = () => {
         isOpen={showApiExamples}
         onClose={() => setShowApiExamples(false)}
         model={model}
+        defaultTab="realtime"
       />
     </div>
   );

--- a/dashboard/src/components/features/models/manage/ModelsContent.tsx
+++ b/dashboard/src/components/features/models/manage/ModelsContent.tsx
@@ -965,6 +965,7 @@ export const ModelsContent: React.FC<ModelsContentProps> = ({
           setApiExamplesModel(null);
         }}
         model={apiExamplesModel}
+        defaultTab="realtime"
       />
 
     </>

--- a/dashboard/src/components/modals/ApiExamples/ApiExamples.tsx
+++ b/dashboard/src/components/modals/ApiExamples/ApiExamples.tsx
@@ -57,9 +57,6 @@ const ApiExamplesModal: React.FC<ApiExamplesModalProps> = ({
 }) => {
   const [selectedLanguage, setSelectedLanguage] = useState<Language>("python");
   const [exampleType, setExampleType] = useState<ExampleType>(defaultTab);
-  const [asyncMethod, setAsyncMethod] = useState<"autobatcher" | "jsonl">(
-    "autobatcher",
-  );
   const [selectedModelId, setSelectedModelId] = useState<string>(
     initialModel?.id || "",
   );
@@ -122,10 +119,13 @@ const ApiExamplesModal: React.FC<ApiExamplesModalProps> = ({
     [allModels],
   );
 
-  // Completion window is determined by tab — async uses configured window
+  // Async window is informational only (shown in the tab aria-label) — the
+  // Async tab now drives an Open Responses + service_tier="flex" snippet
+  // rather than a JSONL workflow with a different completion_window.
   const asyncWindow =
     config?.batches?.async_requests?.completion_window ?? "1h";
-  const completionWindow = exampleType === "async" ? asyncWindow : "24h";
+
+  const isEmbeddingsModel = model?.model_type?.toLowerCase() === "embeddings";
 
   const createApiKeyMutation = useCreateApiKey();
 
@@ -168,9 +168,6 @@ const ApiExamplesModal: React.FC<ApiExamplesModalProps> = ({
     }
   };
 
-  const isEmbeddingsModel =
-    model?.model_type?.toLowerCase() === "embeddings";
-
   const getExampleJsonl = () => {
     const modelAlias = model?.alias || "model-name";
     if (isEmbeddingsModel) {
@@ -202,53 +199,76 @@ const ApiExamplesModal: React.FC<ApiExamplesModalProps> = ({
     return base.endsWith("/v1") ? base : `${base}/v1`;
   };
 
-  const generateAutobatcherCode = (language: Language) => {
+  /** Open Responses snippet with `service_tier="flex"` and `background=True`,
+   *  including a poll loop until the request reaches a terminal state. Used
+   *  for the Async tab — distinct from Batch's JSONL workflow. */
+  const generateAsyncResponsesCode = (language: Language): string => {
     const keyValue = apiKey || "your-api-key-here";
     const modelAlias = model?.alias || "model-name";
+
     if (language === "python") {
-      return `import asyncio
-from autobatcher import AsyncOpenAI
+      return `from openai import OpenAI
+from time import sleep
 
+client = OpenAI(
+    api_key="${keyValue}",
+    base_url="${getBaseUrl()}"
+)
 
-async def main():
-    client = AsyncOpenAI(api_key="${keyValue}")
+resp = client.responses.create(
+    model="${modelAlias}",
+    input="Write a very long novel about otters in space.",
+    service_tier="flex",
+    background=True,
+)
 
-    response = await client.chat.completions.create(
-        model="${modelAlias}",
-        messages=[{"role": "user", "content": "Explain quantum computing"}],
-    )
+while resp.status in {"queued", "in_progress"}:
+    print(f"Current status: {resp.status}")
+    sleep(2)
+    resp = client.responses.retrieve(resp.id)
 
-    print(response.choices[0].message.content)
+print(f"Final status: {resp.status}\\nOutput:\\n{resp.output_text}")`;
+    }
 
-
-asyncio.run(main())`;
-    } else if (language === "javascript") {
+    if (language === "javascript") {
       return `import OpenAI from 'openai';
 
 const client = new OpenAI({
-    baseURL: '${getBaseUrl()}',
-    apiKey: '${keyValue}'
+    apiKey: '${keyValue}',
+    baseURL: '${getBaseUrl()}'
 });
 
-const response = await client.chat.completions.create({
+let resp = await client.responses.create({
     model: '${modelAlias}',
-    messages: [
-        { role: 'user', content: 'Explain quantum computing' }
-    ]
+    input: 'Write a very long novel about otters in space.',
+    service_tier: 'flex',
+    background: true,
 });
 
-console.log(response.choices[0].message.content);`;
-    } else {
-      return `curl ${getBaseUrl()}/chat/completions \\
-  -H "Content-Type: application/json" \\
+while (['queued', 'in_progress'].includes(resp.status)) {
+    console.log(\`Current status: \${resp.status}\`);
+    await new Promise((r) => setTimeout(r, 2000));
+    resp = await client.responses.retrieve(resp.id);
+}
+
+console.log(\`Final status: \${resp.status}\\nOutput:\\n\${resp.output_text}\`);`;
+    }
+
+    // curl
+    return `# Submit a background flex response — capture the id from the response body
+curl ${getBaseUrl()}/responses \\
   -H "Authorization: Bearer ${keyValue}" \\
+  -H "Content-Type: application/json" \\
   -d '{
     "model": "${modelAlias}",
-    "messages": [
-      {"role": "user", "content": "Explain quantum computing"}
-    ]
-  }'`;
-    }
+    "input": "Write a very long novel about otters in space.",
+    "service_tier": "flex",
+    "background": true
+  }'
+
+# Poll until terminal (replace YOUR_RESP_ID with the id returned above)
+curl ${getBaseUrl()}/responses/YOUR_RESP_ID \\
+  -H "Authorization: Bearer ${keyValue}"`;
   };
 
   const generateBatchApiCode = (language: Language) => {
@@ -277,7 +297,7 @@ print(f"File ID: {batch_file.id}")
 batch = client.batches.create(
     input_file_id=batch_file.id,
     endpoint="${batchEndpoint}",
-    completion_window="${completionWindow}"
+    completion_window="24h"
 )
 
 print(f"Batch ID: {batch.id}")
@@ -308,7 +328,7 @@ async function runBatch() {
     const batch = await client.batches.create({
         input_file_id: batchFile.id,
         endpoint: '${batchEndpoint}',
-        completion_window: '${completionWindow}'
+        completion_window: '24h'
     });
 
     console.log('Batch ID:', batch.id);
@@ -333,7 +353,7 @@ curl ${getBaseUrl().replace("/v1", "")}/ai/v1/batches \\
   -d '{
     "input_file_id": "YOUR_FILE_ID",
     "endpoint": "${batchEndpoint}",
-    "completion_window": "${completionWindow}"
+    "completion_window": "24h"
   }'
 
 # Step 3: Check batch status (use the batch ID from step 2)
@@ -386,6 +406,7 @@ client = OpenAI(
     base_url="${getBaseUrl()}"
 )
 
+# Or use client.responses.create(...) if you prefer the Open Responses API
 response = client.chat.completions.create(
     model="${model.alias}",
     messages=[
@@ -439,6 +460,7 @@ const client = new OpenAI({
     baseURL: '${getBaseUrl()}'
 });
 
+// Or use client.responses.create(...) if you prefer the Open Responses API
 const response = await client.chat.completions.create({
     model: '${model.alias}',
     messages: [
@@ -470,7 +492,8 @@ console.log(response.choices[0].message.content);`;
     "documents": ["Paris is the capital of France.", "London is the capital of England."]
   }'`;
     }
-    return `curl ${getBaseUrl()}/chat/completions \\
+    return `# Or POST to ${getBaseUrl()}/responses if you prefer the Open Responses API
+curl ${getBaseUrl()}/chat/completions \\
   -H "Authorization: Bearer ${keyValue}" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -485,15 +508,14 @@ console.log(response.choices[0].message.content);`;
   };
 
   const getCurrentCode = () => {
-    if (isAutobatcher) {
-      return generateAutobatcherCode("python");
-    }
-    if (exampleType === "batch" || exampleType === "async") {
+    if (exampleType === "batch") {
       return generateBatchApiCode(selectedLanguage);
+    }
+    if (exampleType === "async") {
+      return generateAsyncResponsesCode(selectedLanguage);
     }
 
     if (!model) return "";
-
     const modelType = (model.model_type?.toLowerCase() || "chat") as ModelType;
 
     switch (selectedLanguage) {
@@ -547,8 +569,6 @@ console.log(response.choices[0].message.content);`;
     }
   };
 
-  const isAutobatcher = exampleType === "async" && asyncMethod === "autobatcher";
-
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto overflow-x-hidden">
@@ -583,154 +603,95 @@ console.log(response.choices[0].message.content);`;
 
         {model && (
           <div className="w-full overflow-hidden">
-            {/* Example Type Selection — Three tabs + async method selector */}
-            <div className="mb-6">
-              <div className="flex items-center justify-between">
-                <ToggleGroup
-                  type="single"
-                  value={exampleType}
-                  onValueChange={(value) =>
-                    value && setExampleType(value as ExampleType)
-                  }
-                  className="inline-flex"
-                  variant="outline"
-                  size="sm"
-                >
-                  {!isBatchDenied(model) && (
-                    <ToggleGroupItem
-                      value="batch"
-                      aria-label="Batch API (24h)"
-                      className="px-5 py-1.5"
-                    >
-                      Batch
-                    </ToggleGroupItem>
-                  )}
-                  {!isBatchDenied(model) && config?.batches?.async_requests?.enabled && (
-                    <ToggleGroupItem
-                      value="async"
-                      aria-label={`Async API (${asyncWindow})`}
-                      className="px-5 py-1.5"
-                    >
-                      Async
-                    </ToggleGroupItem>
-                  )}
-                  {!isRealtimeDenied(model) && (
-                    <ToggleGroupItem
-                      value="realtime"
-                      aria-label="Realtime API"
-                      className="px-5 py-1.5"
-                    >
-                      Realtime
-                    </ToggleGroupItem>
-                  )}
-                </ToggleGroup>
-
-                {/* Async method selector — inline on the right */}
-                {exampleType === "async" && (
-                  <div className="flex items-center gap-2">
-                    <ToggleGroup
-                      type="single"
-                      value={asyncMethod}
-                      onValueChange={(value) =>
-                        value && setAsyncMethod(value as "autobatcher" | "jsonl")
-                      }
-                      className="inline-flex"
-                      variant="outline"
-                      size="sm"
-                    >
-                      <ToggleGroupItem
-                        value="autobatcher"
-                        aria-label="Autobatcher"
-                        className="px-4 py-1.5"
-                      >
-                        Autobatcher
-                      </ToggleGroupItem>
-                      <ToggleGroupItem
-                        value="jsonl"
-                        aria-label="JSONL"
-                        className="px-4 py-1.5"
-                      >
-                        JSONL
-                      </ToggleGroupItem>
-                    </ToggleGroup>
-                  </div>
+            {/* Tab selector — Batch / Async / Realtime */}
+            <div className="mb-4">
+              <ToggleGroup
+                type="single"
+                value={exampleType}
+                onValueChange={(value) =>
+                  value && setExampleType(value as ExampleType)
+                }
+                className="inline-flex"
+                variant="outline"
+                size="sm"
+              >
+                {!isBatchDenied(model) && (
+                  <ToggleGroupItem
+                    value="batch"
+                    aria-label="Batch API (24h)"
+                    className="px-5 py-1.5"
+                  >
+                    Batch
+                  </ToggleGroupItem>
                 )}
-              </div>
-
-              {/* JSONL example for batch tab or async+jsonl method */}
-              {(exampleType === "batch" || (exampleType === "async" && asyncMethod === "jsonl")) && (
-                <div className="mt-4 space-y-3">
-                  <div className="bg-white border border-gray-200 rounded-lg overflow-hidden max-w-full">
-                    <div className="bg-gray-50 px-4 py-2 border-b border-gray-200 flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <Code className="w-4 h-4 text-gray-600" />
-                        <span className="text-sm font-medium text-gray-700">
-                          batch_requests.jsonl
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <button
-                          onClick={() =>
-                            copyToClipboard(getExampleJsonl(), "jsonl")
-                          }
-                          className="flex items-center gap-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors"
-                        >
-                          <Copy className="w-3 h-3" />
-                          {copiedCode === "jsonl" ? "Copied!" : "Copy"}
-                        </button>
-                        <button
-                          onClick={downloadJsonl}
-                          className="flex items-center gap-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors"
-                        >
-                          <Download className="w-3 h-3" />
-                          Download
-                        </button>
-                      </div>
-                    </div>
-                    <div className="overflow-x-auto max-w-full">
-                      <CodeBlock language="json">
-                        {getExampleJsonl()}
-                      </CodeBlock>
-                    </div>
-                  </div>
-                  {config?.docs_jsonl_url && (
-                    <a
-                      href={config.docs_jsonl_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1"
-                    >
-                      How to create a JSONL file
-                      <ExternalLink className="w-3 h-3" />
-                    </a>
-                  )}
-                </div>
-              )}
+                {!isBatchDenied(model) && config?.batches?.async_requests?.enabled && (
+                  <ToggleGroupItem
+                    value="async"
+                    aria-label={`Async API (${asyncWindow})`}
+                    className="px-5 py-1.5"
+                  >
+                    Async
+                  </ToggleGroupItem>
+                )}
+                {!isRealtimeDenied(model) && (
+                  <ToggleGroupItem
+                    value="realtime"
+                    aria-label="Realtime API"
+                    className="px-5 py-1.5"
+                  >
+                    Realtime
+                  </ToggleGroupItem>
+                )}
+              </ToggleGroup>
             </div>
 
-            {/* Install snippet for autobatcher */}
-            {isAutobatcher && (
-              <div className="bg-white border border-gray-200 rounded-lg overflow-hidden max-w-full mb-3">
-                <div className="bg-gray-50 px-4 py-2 border-b border-gray-200 flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <Code className="w-4 h-4 text-gray-600" />
-                    <span className="text-sm font-medium text-gray-700">
-                      Shell
-                    </span>
+            {/* JSONL preview — only relevant for the Batch JSONL workflow */}
+            {exampleType === "batch" && (
+              <div className="mb-4 space-y-3">
+                <div className="bg-white border border-gray-200 rounded-lg overflow-hidden max-w-full">
+                  <div className="bg-gray-50 px-4 py-2 border-b border-gray-200 flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Code className="w-4 h-4 text-gray-600" />
+                      <span className="text-sm font-medium text-gray-700">
+                        batch_requests.jsonl
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() =>
+                          copyToClipboard(getExampleJsonl(), "jsonl")
+                        }
+                        className="flex items-center gap-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors"
+                      >
+                        <Copy className="w-3 h-3" />
+                        {copiedCode === "jsonl" ? "Copied!" : "Copy"}
+                      </button>
+                      <button
+                        onClick={downloadJsonl}
+                        className="flex items-center gap-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors"
+                      >
+                        <Download className="w-3 h-3" />
+                        Download
+                      </button>
+                    </div>
                   </div>
-                  <button
-                    onClick={() =>
-                      copyToClipboard("pip install autobatcher", "install")
-                    }
-                    className="flex items-center gap-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors"
+                  <div className="overflow-x-auto max-w-full">
+                    <CodeBlock language="json">
+                      {getExampleJsonl()}
+                    </CodeBlock>
+                  </div>
+                </div>
+                {config?.docs_jsonl_url && (
+                  <a
+                    href={config.docs_jsonl_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1"
                   >
-                    <Copy className="w-3 h-3" />
-                    {copiedCode === "install" ? "Copied!" : "Copy"}
-                  </button>
-                </div>
-                <div className="overflow-x-auto max-w-full">
-                  <CodeBlock language="bash">pip install autobatcher</CodeBlock>
-                </div>
+                    How to create a JSONL file
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
+                )}
               </div>
             )}
 
@@ -739,65 +700,57 @@ console.log(response.choices[0].message.content);`;
               <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <Code className="w-4 h-4 text-gray-600" />
-                  {isAutobatcher ? (
-                    <span className="text-sm font-medium text-gray-700">
-                      Python
-                    </span>
-                  ) : (
-                    <>
-                      <Select
-                        value={selectedLanguage}
-                        onValueChange={(value) =>
-                          setSelectedLanguage(value as Language)
-                        }
-                      >
-                        <SelectTrigger
-                          size="sm"
-                          className="h-7 border-0 bg-transparent shadow-none hover:bg-gray-100 focus-visible:ring-0"
-                        >
-                          <SelectValue>
-                            <span className="text-sm font-medium text-gray-700">
-                              {selectedLanguage.charAt(0).toUpperCase() +
-                                selectedLanguage.slice(1)}
-                            </span>
-                          </SelectValue>
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="python">Python</SelectItem>
-                          <SelectItem value="javascript">JavaScript</SelectItem>
-                          <SelectItem value="curl">cURL</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <div className="relative">
-                        <button
-                          onMouseEnter={() => setShowInfoTooltip(true)}
-                          onMouseLeave={() => setShowInfoTooltip(false)}
-                          className="p-1 text-gray-400 hover:text-gray-600 transition-colors"
-                        >
-                          <Info className="w-4 h-4" />
-                        </button>
+                  <Select
+                    value={selectedLanguage}
+                    onValueChange={(value) =>
+                      setSelectedLanguage(value as Language)
+                    }
+                  >
+                    <SelectTrigger
+                      size="sm"
+                      className="h-7 border-0 bg-transparent shadow-none hover:bg-gray-100 focus-visible:ring-0"
+                    >
+                      <SelectValue>
+                        <span className="text-sm font-medium text-gray-700">
+                          {selectedLanguage.charAt(0).toUpperCase() +
+                            selectedLanguage.slice(1)}
+                        </span>
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="python">Python</SelectItem>
+                      <SelectItem value="javascript">JavaScript</SelectItem>
+                      <SelectItem value="curl">cURL</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <div className="relative">
+                    <button
+                      onMouseEnter={() => setShowInfoTooltip(true)}
+                      onMouseLeave={() => setShowInfoTooltip(false)}
+                      className="p-1 text-gray-400 hover:text-gray-600 transition-colors"
+                    >
+                      <Info className="w-4 h-4" />
+                    </button>
 
-                        {showInfoTooltip && (
-                          <div className="absolute left-0 top-full mt-2 w-64 bg-gray-900 text-white text-xs rounded-lg p-3 shadow-lg z-10">
-                            <div className="space-y-2">
-                              <div className="font-medium">
-                                {getInstallationInfo(selectedLanguage)?.title}
-                              </div>
-                              <div className="text-gray-300">
-                                {getInstallationInfo(selectedLanguage)?.description}
-                              </div>
-                              {getInstallationInfo(selectedLanguage)?.command && (
-                                <div className="bg-gray-800 rounded px-2 py-1 font-mono">
-                                  {getInstallationInfo(selectedLanguage)?.command}
-                                </div>
-                              )}
-                            </div>
-                            <div className="absolute -top-1 left-4 w-2 h-2 bg-gray-900 rotate-45"></div>
+                    {showInfoTooltip && (
+                      <div className="absolute left-0 top-full mt-2 w-64 bg-gray-900 text-white text-xs rounded-lg p-3 shadow-lg z-10">
+                        <div className="space-y-2">
+                          <div className="font-medium">
+                            {getInstallationInfo(selectedLanguage)?.title}
                           </div>
-                        )}
+                          <div className="text-gray-300">
+                            {getInstallationInfo(selectedLanguage)?.description}
+                          </div>
+                          {getInstallationInfo(selectedLanguage)?.command && (
+                            <div className="bg-gray-800 rounded px-2 py-1 font-mono">
+                              {getInstallationInfo(selectedLanguage)?.command}
+                            </div>
+                          )}
+                        </div>
+                        <div className="absolute -top-1 left-4 w-2 h-2 bg-gray-900 rotate-45"></div>
                       </div>
-                    </>
-                  )}
+                    )}
+                  </div>
                 </div>
                 <div className="flex items-center gap-2">
                   {!apiKey && (
@@ -900,9 +853,7 @@ console.log(response.choices[0].message.content);`;
               <div className="overflow-x-auto max-w-full">
                 <CodeBlock
                   language={
-                    (isAutobatcher
-                      ? "python"
-                      : getLanguageForHighlighting(selectedLanguage)) as
+                    getLanguageForHighlighting(selectedLanguage) as
                       | "python"
                       | "javascript"
                       | "bash"

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "16.5.1" }
+fusillade = { version = "16.6.0" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -191,6 +191,17 @@ pub async fn build_cascade_batch_state_job<P: sqlx_pool_router::PoolProvider + C
 
 // ---------------------------------------------------------------------------
 
+/// Parse the comma-separated `completion_window` query param into the vec of
+/// values passed to fusillade. Returns `None` (no filter) when the param is
+/// missing or contains only whitespace. Values are forwarded as-is so callers
+/// can match any window string fusillade understands (e.g. `"24h"`, `"1h"`,
+/// `"0s"`, `"7d"`).
+fn parse_completion_window_filter(raw: Option<&str>) -> Option<Vec<String>> {
+    let raw = raw?;
+    let windows: Vec<String> = raw.split(',').map(str::trim).filter(|s| !s.is_empty()).map(String::from).collect();
+    if windows.is_empty() { None } else { Some(windows) }
+}
+
 /// Check if the current user "owns" a batch, considering org context.
 /// Returns true if the batch creator matches the user's ID or their active organization.
 fn is_batch_owner(current_user: &CurrentUser, created_by: &str) -> bool {
@@ -1622,6 +1633,11 @@ pub async fn list_batches<P: PoolProvider>(
         None
     };
 
+    // Parse the comma-separated `completion_window` filter into the list
+    // passed to fusillade. An empty/whitespace-only param is treated as "no
+    // filter" so callers can send `completion_window=` to disable the default.
+    let completion_windows = parse_completion_window_filter(query.completion_window.as_deref());
+
     // Fetch batches with ownership filtering, search, and cursor-based pagination
     let batches = state
         .request_manager
@@ -1635,7 +1651,7 @@ pub async fn list_batches<P: PoolProvider>(
             created_after: query.created_after,
             created_before: query.created_before,
             active_first: query.active_first,
-            exclude_completion_window: query.exclude_completion_window.clone(),
+            completion_windows,
         })
         .await
         .map_err(|e| Error::Internal {

--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -1860,6 +1860,7 @@ pub async fn list_batches<P: PoolProvider>(
 
 #[cfg(test)]
 mod tests {
+    use super::parse_completion_window_filter;
     use crate::api::models::batches::CreateBatchRequest;
     use crate::api::models::users::Role;
     use crate::db::handlers::Credits;
@@ -1872,6 +1873,49 @@ mod tests {
     use sqlx::PgPool;
     use std::collections::HashMap;
     use uuid::Uuid;
+
+    // -------------------------------------------------------------------------
+    // parse_completion_window_filter — pure parsing, no DB needed.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn parse_completion_window_filter_returns_none_when_param_missing() {
+        assert_eq!(parse_completion_window_filter(None), None);
+    }
+
+    #[test]
+    fn parse_completion_window_filter_returns_none_when_param_empty() {
+        assert_eq!(parse_completion_window_filter(Some("")), None);
+    }
+
+    #[test]
+    fn parse_completion_window_filter_returns_none_when_param_whitespace_only() {
+        assert_eq!(parse_completion_window_filter(Some("   \t  ")), None);
+    }
+
+    #[test]
+    fn parse_completion_window_filter_parses_single_value() {
+        assert_eq!(
+            parse_completion_window_filter(Some("24h")),
+            Some(vec!["24h".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_completion_window_filter_parses_comma_separated_values() {
+        assert_eq!(
+            parse_completion_window_filter(Some("24h,1h")),
+            Some(vec!["24h".to_string(), "1h".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_completion_window_filter_trims_and_drops_empty_entries() {
+        assert_eq!(
+            parse_completion_window_filter(Some(" 24h , , 1h ,   ")),
+            Some(vec!["24h".to_string(), "1h".to_string()])
+        );
+    }
 
     #[sqlx::test]
     #[test_log::test]

--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -1895,10 +1895,7 @@ mod tests {
 
     #[test]
     fn parse_completion_window_filter_parses_single_value() {
-        assert_eq!(
-            parse_completion_window_filter(Some("24h")),
-            Some(vec!["24h".to_string()])
-        );
+        assert_eq!(parse_completion_window_filter(Some("24h")), Some(vec!["24h".to_string()]));
     }
 
     #[test]

--- a/dwctl/src/api/models/batches.rs
+++ b/dwctl/src/api/models/batches.rs
@@ -328,9 +328,16 @@ pub struct ListBatchesQuery {
     #[serde(default)]
     pub active_first: bool,
 
-    /// Exclude batches with this completion window (e.g., "1h" to hide async batches).
-    /// Applied server-side for accurate pagination.
-    pub exclude_completion_window: Option<String>,
+    /// Comma-separated completion windows to include. Common values:
+    /// - `24h` — long-running batch jobs
+    /// - `1h` — async flex requests
+    /// - `0s` — realtime tracking rows for the Open Responses API
+    ///
+    /// When omitted the server returns batches with any completion window; the
+    /// dashboard sends `completion_window=24h` by default so realtime tracking
+    /// rows don't pollute the Batches view.
+    #[param(example = "24h,1h")]
+    pub completion_window: Option<String>,
 }
 
 /// Query parameters for batch results

--- a/dwctl/src/responses/jobs.rs
+++ b/dwctl/src/responses/jobs.rs
@@ -27,6 +27,10 @@ use super::store::{self as response_store};
 /// `complete-response` job then transitions it to `"completed"`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateResponseInput {
+    /// Pre-generated batch UUID; becomes the fusillade batch's primary key.
+    /// Must match the `x-fusillade-batch-id` header attached to the proxied
+    /// request so the http_analytics row links back to the same batch.
+    pub batch_id: Uuid,
     /// Pre-generated request UUID; becomes the fusillade request's primary key.
     pub request_id: Uuid,
     /// The full request body as JSON string.
@@ -105,6 +109,7 @@ pub async fn build_create_response_job<P: sqlx_pool_router::PoolProvider + Clone
             );
 
             let batch_input = fusillade::CreateSingleRequestBatchInput {
+                batch_id: input.batch_id,
                 request_id: input.request_id,
                 body: input.body,
                 model: input.model.clone(),
@@ -175,6 +180,8 @@ pub struct CompleteResponseInput {
 
     // Fields below are used only when create-response hasn't run yet and
     // we need to synthesize the row ourselves.
+    /// Pre-generated batch UUID (extracted from `x-fusillade-batch-id`).
+    pub batch_id: Uuid,
     /// Pre-generated request UUID (matches `response_id` minus prefix).
     pub request_id: Uuid,
     /// Original request body (JSON string).
@@ -204,6 +211,7 @@ pub async fn build_complete_response_job<P: sqlx_pool_router::PoolProvider + Clo
         .step(|cx, input: CompleteResponseInput| async move {
             if (200..300).contains(&input.status_code) {
                 let create_ctx = response_store::CreateContext {
+                    batch_id: input.batch_id,
                     request_id: input.request_id,
                     request_body: &input.request_body,
                     model: &input.model,

--- a/dwctl/src/responses/jobs.rs
+++ b/dwctl/src/responses/jobs.rs
@@ -109,7 +109,7 @@ pub async fn build_create_response_job<P: sqlx_pool_router::PoolProvider + Clone
             );
 
             let batch_input = fusillade::CreateSingleRequestBatchInput {
-                batch_id: input.batch_id,
+                batch_id: Some(input.batch_id),
                 request_id: input.request_id,
                 body: input.body,
                 model: input.model.clone(),

--- a/dwctl/src/responses/middleware.rs
+++ b/dwctl/src/responses/middleware.rs
@@ -113,8 +113,13 @@ pub async fn responses_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
         "Routing inference request"
     );
 
-    // Generate the request ID upfront — known before any DB calls or proxying.
+    // Generate the request and batch IDs upfront — known before any DB calls
+    // or proxying. The batch_id is set as `x-fusillade-batch-id` on the
+    // proxied request so analytics_handler can associate the http_analytics
+    // row with this batch (otherwise total_cost / token aggregates in the
+    // Batches view come back empty for realtime tracking rows).
     let request_id = uuid::Uuid::new_v4();
+    let batch_id = uuid::Uuid::new_v4();
     let resp_id = format!("resp_{request_id}");
     let completion_window = match service_tier {
         ServiceTier::Flex => "1h",
@@ -165,6 +170,7 @@ pub async fn responses_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
     };
 
     let batch_input = fusillade::CreateSingleRequestBatchInput {
+        batch_id,
         request_id,
         body: request_value.to_string(),
         model: model.to_string(),
@@ -228,9 +234,10 @@ async fn handle_realtime<P: PoolProvider + Clone + Send + Sync + 'static>(
 ) -> Response {
     let rm = state.request_manager.clone();
 
-    // Capture endpoint before consuming batch_input — needed downstream as a
-    // header so the outlet handler can synthesize the row if create-response
-    // hasn't run yet.
+    // Capture batch_id and endpoint before consuming batch_input — both flow
+    // downstream as request headers (batch_id for analytics association, the
+    // endpoint so the outlet handler can synthesize the row on race).
+    let batch_id = batch_input.batch_id;
     let endpoint_for_header = batch_input.endpoint.clone();
 
     if background {
@@ -245,6 +252,7 @@ async fn handle_realtime<P: PoolProvider + Clone + Send + Sync + 'static>(
         // between proxying and the DB insert still leaves a retryable record.
         // The job resolves attribution and calls create_single_request_batch.
         let job_input = CreateResponseInput {
+            batch_id: batch_input.batch_id,
             request_id: batch_input.request_id,
             body: batch_input.body,
             model: batch_input.model,
@@ -270,6 +278,11 @@ async fn handle_realtime<P: PoolProvider + Clone + Send + Sync + 'static>(
     let mut req = Request::from_parts(parts, Body::from(body_bytes));
     req.headers_mut()
         .insert("x-fusillade-request-id", raw_id.parse().expect("response_id is valid header value"));
+    // x-fusillade-batch-id wires this realtime tracking row up to its
+    // http_analytics row so total_cost / token aggregates show up in the
+    // Batches view (analytics_handler reads this header).
+    req.headers_mut()
+        .insert("x-fusillade-batch-id", batch_id.to_string().parse().expect("batch_id is valid header value"));
     req.headers_mut().insert(
         ONWARDS_RESPONSE_ID_HEADER,
         resp_id.parse().expect("response_id is valid header value"),

--- a/dwctl/src/responses/middleware.rs
+++ b/dwctl/src/responses/middleware.rs
@@ -183,7 +183,7 @@ pub async fn responses_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
     };
 
     match service_tier {
-        ServiceTier::Realtime => handle_realtime(&state, batch_input, &resp_id, model, background, parts, body_bytes, next).await,
+        ServiceTier::Realtime => handle_realtime(&state, batch_input, batch_id, &resp_id, model, background, parts, body_bytes, next).await,
         ServiceTier::Flex => handle_flex(&state, batch_input, &resp_id, model, background).await,
     }
 }
@@ -225,6 +225,7 @@ fn resolve_service_tier(tier: Option<&str>) -> ServiceTier {
 async fn handle_realtime<P: PoolProvider + Clone + Send + Sync + 'static>(
     state: &ResponsesMiddlewareState<P>,
     batch_input: fusillade::CreateSingleRequestBatchInput,
+    batch_id: uuid::Uuid,
     resp_id: &str,
     model: &str,
     background: bool,
@@ -234,12 +235,10 @@ async fn handle_realtime<P: PoolProvider + Clone + Send + Sync + 'static>(
 ) -> Response {
     let rm = state.request_manager.clone();
 
-    // Capture batch_id and endpoint before consuming batch_input — both flow
-    // downstream as request headers (batch_id for analytics association, the
-    // endpoint so the outlet handler can synthesize the row on race). The
-    // middleware always sets `Some(...)`, but the field is optional to keep
-    // fusillade's API friendly for callers that don't need a pre-generated id.
-    let batch_id = batch_input.batch_id.expect("responses middleware always sets Some(batch_id)");
+    // batch_id is passed in explicitly (rather than re-extracted from
+    // batch_input) so the type system enforces its presence — fusillade's
+    // `batch_id` field is `Option<Uuid>` to keep its API friendly for callers
+    // that don't need a pre-generated id, but here we always have one.
     let endpoint_for_header = batch_input.endpoint.clone();
 
     if background {

--- a/dwctl/src/responses/middleware.rs
+++ b/dwctl/src/responses/middleware.rs
@@ -170,7 +170,7 @@ pub async fn responses_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
     };
 
     let batch_input = fusillade::CreateSingleRequestBatchInput {
-        batch_id,
+        batch_id: Some(batch_id),
         request_id,
         body: request_value.to_string(),
         model: model.to_string(),
@@ -236,8 +236,10 @@ async fn handle_realtime<P: PoolProvider + Clone + Send + Sync + 'static>(
 
     // Capture batch_id and endpoint before consuming batch_input — both flow
     // downstream as request headers (batch_id for analytics association, the
-    // endpoint so the outlet handler can synthesize the row on race).
-    let batch_id = batch_input.batch_id;
+    // endpoint so the outlet handler can synthesize the row on race). The
+    // middleware always sets `Some(...)`, but the field is optional to keep
+    // fusillade's API friendly for callers that don't need a pre-generated id.
+    let batch_id = batch_input.batch_id.expect("responses middleware always sets Some(batch_id)");
     let endpoint_for_header = batch_input.endpoint.clone();
 
     if background {
@@ -252,7 +254,7 @@ async fn handle_realtime<P: PoolProvider + Clone + Send + Sync + 'static>(
         // between proxying and the DB insert still leaves a retryable record.
         // The job resolves attribution and calls create_single_request_batch.
         let job_input = CreateResponseInput {
-            batch_id: batch_input.batch_id,
+            batch_id,
             request_id: batch_input.request_id,
             body: batch_input.body,
             model: batch_input.model,

--- a/dwctl/src/responses/middleware.rs
+++ b/dwctl/src/responses/middleware.rs
@@ -283,8 +283,10 @@ async fn handle_realtime<P: PoolProvider + Clone + Send + Sync + 'static>(
     // x-fusillade-batch-id wires this realtime tracking row up to its
     // http_analytics row so total_cost / token aggregates show up in the
     // Batches view (analytics_handler reads this header).
-    req.headers_mut()
-        .insert("x-fusillade-batch-id", batch_id.to_string().parse().expect("batch_id is valid header value"));
+    req.headers_mut().insert(
+        "x-fusillade-batch-id",
+        batch_id.to_string().parse().expect("batch_id is valid header value"),
+    );
     req.headers_mut().insert(
         ONWARDS_RESPONSE_ID_HEADER,
         resp_id.parse().expect("response_id is valid header value"),

--- a/dwctl/src/responses/outlet_handler.rs
+++ b/dwctl/src/responses/outlet_handler.rs
@@ -37,6 +37,11 @@ impl FusilladeOutletHandler {
         Self::header_str(request, "x-fusillade-request-id").and_then(|s| Uuid::parse_str(s).ok())
     }
 
+    /// Extract the raw fusillade batch UUID from `x-fusillade-batch-id`.
+    fn extract_batch_id(request: &RequestData) -> Option<Uuid> {
+        Self::header_str(request, "x-fusillade-batch-id").and_then(|s| Uuid::parse_str(s).ok())
+    }
+
     /// Extract the bearer token from the Authorization header.
     fn extract_api_key(request: &RequestData) -> Option<String> {
         Self::header_str(request, "authorization")
@@ -85,6 +90,18 @@ impl RequestHandler for FusilladeOutletHandler {
                 }
             };
 
+            // Same story for the batch_id — middleware always sets it alongside
+            // request_id. If it's missing, complete-response would synthesize a
+            // row with a fresh batch_id that doesn't match what create-response
+            // used, breaking the analytics join.
+            let batch_id = match Self::extract_batch_id(&request_data) {
+                Some(id) => id,
+                None => {
+                    tracing::warn!(response_id = %response_id, "Missing x-fusillade-batch-id header on response — skipping enqueue");
+                    return;
+                }
+            };
+
             let status_code = response_data.status.as_u16();
             let response_body = response_data
                 .body
@@ -124,6 +141,7 @@ impl RequestHandler for FusilladeOutletHandler {
                     response_id: response_id.clone(),
                     status_code,
                     response_body,
+                    batch_id,
                     request_id,
                     request_body,
                     model,

--- a/dwctl/src/responses/outlet_handler.rs
+++ b/dwctl/src/responses/outlet_handler.rs
@@ -65,15 +65,10 @@ impl RequestHandler for FusilladeOutletHandler {
         let job = self.job.clone();
 
         async move {
-            // Skip batch requests — the daemon handles its own completion.
-            // Batch requests have both x-fusillade-request-id and x-fusillade-batch-id.
-            // Realtime requests only have x-fusillade-request-id (set by the
-            // responses middleware for ID override) and should NOT be skipped.
-            if request_data.headers.contains_key("x-fusillade-batch-id") {
-                return;
-            }
-
-            // Check for the onwards response ID header (set by responses middleware)
+            // Only the responses middleware sets `x-onwards-response-id`, so
+            // its absence means this is either a daemon-driven fusillade batch
+            // request (the daemon handles its own completion) or some other
+            // non-responses traffic — nothing for us to do.
             let response_id = match Self::extract_response_id(&request_data) {
                 Some(id) => id,
                 None => return,

--- a/dwctl/src/responses/store.rs
+++ b/dwctl/src/responses/store.rs
@@ -78,6 +78,7 @@ pub async fn request_exists<P: PoolProvider + Clone>(
 /// Carried by `complete-response` so it can create-then-complete when it
 /// races ahead of `create-response`.
 pub struct CreateContext<'a> {
+    pub batch_id: Uuid,
     pub request_id: Uuid,
     pub request_body: &'a str,
     pub model: &'a str,
@@ -128,6 +129,7 @@ pub async fn complete_response_idempotent<P: PoolProvider + Clone>(
             }
             let created_by = lookup_created_by(dwctl_pool, create_ctx.api_key).await;
             let batch_input = fusillade::CreateSingleRequestBatchInput {
+                batch_id: create_ctx.batch_id,
                 request_id: create_ctx.request_id,
                 body: create_ctx.request_body.to_string(),
                 model: create_ctx.model.to_string(),

--- a/dwctl/src/responses/store.rs
+++ b/dwctl/src/responses/store.rs
@@ -129,7 +129,7 @@ pub async fn complete_response_idempotent<P: PoolProvider + Clone>(
             }
             let created_by = lookup_created_by(dwctl_pool, create_ctx.api_key).await;
             let batch_input = fusillade::CreateSingleRequestBatchInput {
-                batch_id: create_ctx.batch_id,
+                batch_id: Some(create_ctx.batch_id),
                 request_id: create_ctx.request_id,
                 body: create_ctx.request_body.to_string(),
                 model: create_ctx.model.to_string(),


### PR DESCRIPTION
#  Backend (dwctl)                                                                                                                                                                                                                              
   
  - dwctl/src/api/models/batches.rs — ListBatchesQuery.exclude_completion_window: Option<String> replaced with completion_window: Option<String> (comma-separated values, forwarded as-is).                                                    
  - dwctl/src/api/handlers/batches.rs — new parse_completion_window_filter helper splits the param into a Vec<String> and passes it to fusillade::ListBatchesFilter.completion_windows. Empty/whitespace param means "no filter".
  - dwctl/src/responses/middleware.rs — pre-generates batch_id next to request_id, populates the new CreateSingleRequestBatchInput.batch_id field, and inserts x-fusillade-batch-id on the proxied request alongside x-fusillade-request-id so 
  analytics_handler can link the http_analytics row to the batch (this is what restores cost/token aggregates in the Batches view).                                                                                                            
  - dwctl/src/responses/jobs.rs — CreateResponseInput and CompleteResponseInput carry batch_id so the underway job paths use the same id as the middleware/headers.                                                                            
  - dwctl/src/responses/store.rs — CreateContext carries batch_id; the synthesize-on-race path in complete_response_idempotent uses it.                                                                                                        
  - dwctl/src/responses/outlet_handler.rs — extracts x-fusillade-batch-id from request headers and passes it on the enqueued CompleteResponseInput. Bails out with a warning if missing (the middleware always sets both headers together).    
  - Cargo.toml — temporary [patch.crates-io] fusillade = { path = "../fusillade" } for local dev. Remove before merging and bump fusillade to a new (breaking) major version.                                                                  
                                                                  
#  Dashboard                                                                                                                                                                                                                                    
                                                                  
  - dashboard/src/api/control-layer/types.ts + client.ts — BatchesListQuery.exclude_completion_window replaced with completion_window (comma-separated string), sent as ?completion_window=24h,1h.
  - dashboard/.../Batches/Batches.tsx — hideAsync Switch + "Batch only" toggle replaced with a multi-select Popover (mirrors AsyncRequests) offering Batch (24h) and Async (configurable async window, default 1h). Defaults to ["24h"] so
  realtime tracking rows from the Open Responses API don't appear by default. Realtime is intentionally omitted from the UI — still queryable via the API.
  - dashboard/.../BatchesTable/columns.tsx — Type column now distinguishes three classes via icon + tooltip: Zap "Realtime" (0s), FastForward "Async" (async window), Box "Batch" (everything else). Always shown.