### PR TITLE
feat: Revamp models catalog with family grouping and pricing toggle

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,69 +1,192 @@
-# React + TypeScript + Vite
+# Doubleword Dashboard
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The web frontend for the Doubleword Control Layer (`dwctl`). It is a
+[React 19](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/)
+[Vite](https://vitejs.dev/) single-page app that talks to the `dwctl` admin API
+at `/admin/api/v1/*` and the AI proxy at `/ai/v1/*`.
 
-Currently, two official plugins are available:
+Root-level documentation lives in
+[`../CLAUDE.md`](../CLAUDE.md) and [`../README.md`](../README.md); this file
+focuses on things specific to `dashboard/`.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Prerequisites
 
-## Expanding the ESLint configuration
+- Node.js 20+
+- [`pnpm`](https://pnpm.io/) 10+
+- A running backend. Either:
+  - a local `dwctl` (see the root README for `cargo run` + `just db-*`
+    instructions), **or**
+  - demo mode, which mocks the entire API via MSW (see
+    [Demo mode](#demo-mode)).
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+## Quick start
 
-```js
-export default tseslint.config([
-  globalIgnores(["dist"]),
-  {
-    files: ["**/*.{ts,tsx}"],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
+```bash
+pnpm install
+pnpm dev           # Vite dev server on http://localhost:5173
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+By default the dev server proxies `/admin/api/*` and `/ai/*` to a local
+`dwctl` on `http://localhost:8080`. See `vite.config.ts` for the full proxy
+config; override via `DWCTL_URL` in a `.env.local` if your backend runs
+elsewhere.
 
-```js
-// eslint.config.js
-import reactX from "eslint-plugin-react-x";
-import reactDom from "eslint-plugin-react-dom";
+## Scripts
 
-export default tseslint.config([
-  globalIgnores(["dist"]),
-  {
-    files: ["**/*.{ts,tsx}"],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs["recommended-typescript"],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
+| Script                | What it does                                                               |
+| --------------------- | -------------------------------------------------------------------------- |
+| `pnpm dev`            | Start Vite in dev mode with HMR.                                           |
+| `pnpm build`          | Type-check (`tsc -b tsconfig.app.json`) then build production assets.      |
+| `pnpm preview`        | Serve the production build locally.                                        |
+| `pnpm lint`           | Run the full ESLint config.                                                |
+| `pnpm test`           | Run Vitest in watch mode.                                                  |
+| `pnpm test run`       | Run Vitest once (what CI does).                                            |
+| `pnpm test:e2e`       | Run the Playwright E2E suite (see `e2e/`).                                 |
+| `pnpm test:e2e:ui`    | Open Playwright in UI mode.                                                |
+| `pnpm test:e2e:headed`| Run Playwright with a visible browser.                                     |
+
+The top-level `just` recipes wrap these for CI parity:
+
+```bash
+just lint ts        # eslint
+just lint ts --fix  # eslint --fix
+just test ts        # pnpm test run
+just ci ts          # lint + test + build
 ```
+
+## Project layout
+
+```
+src/
+├── api/control-layer/     # typed API client, React Query hooks, MSW mocks
+├── components/
+│   ├── features/          # route-level screens (models, batches, usage, ...)
+│   ├── layout/            # shell, sidebar, topbar
+│   ├── modals/            # dialog / drawer components
+│   ├── common/            # shared cross-feature components
+│   └── ui/                # primitive components (wrappers around Radix)
+├── contexts/              # auth, organization, and settings context providers
+├── hooks/                 # reusable hooks (debounce, pagination, ...)
+├── lib/                   # integrations (telemetry, ...)
+├── utils/                 # pure helpers (formatters, authorization, money, ...)
+├── App.tsx                # route table (lazy-loaded via `lazyWithRetry`)
+└── main.tsx               # entry point
+```
+
+### API layer
+
+`src/api/control-layer/` is the single source of truth for backend access:
+
+- `types.ts` — generated-style TypeScript interfaces mirroring the `dwctl`
+  admin API.
+- `client.ts` — a thin fetch wrapper with auth handling and error mapping.
+- `hooks.ts` — React Query hooks (`useModels`, `useGroups`, `useBatches`, ...).
+  Always add new features through a hook here so caching, invalidation, and
+  demo-mode mocking stay consistent.
+- `mocks/` — MSW handlers + JSON fixtures used for demo mode and most tests.
+
+### Features
+
+Each top-level route lives under `src/components/features/<feature>/`. Features
+are lazy-loaded from `App.tsx` so each becomes its own chunk. A feature
+typically looks like:
+
+```
+features/<feature>/
+├── index.ts               # public barrel
+├── <Feature>.tsx          # main screen
+├── <Feature>.test.tsx     # integration test (render + MSW)
+└── sub-components / hooks specific to this feature
+```
+
+## Authentication & roles
+
+Auth state is held in `contexts/auth/`; permissions are checked via
+`useAuthorization()` (`src/utils/authorization.ts`). The role model is
+additive:
+
+- **StandardUser** — baseline; all signed-in users have it.
+- **PlatformManager** — admin surfaces (users, groups, models, settings).
+- **RequestViewer** — request logs and analytics.
+
+Always gate admin UI with `hasPermission(...)` rather than inspecting roles
+directly.
+
+## Demo mode
+
+Demo mode swaps the live API for [MSW](https://mswjs.io/) handlers so you can
+explore the product without a backend. Three ways to enable it:
+
+1. `?flags=demo` query parameter (e.g. `http://localhost:5173/?flags=demo`).
+2. Settings page toggle (persisted to `localStorage` under `app-settings`).
+3. Directly set `features.demo: true` on the `app-settings` key in
+   `localStorage`.
+
+Mock data lives in `src/api/control-layer/mocks/` (`models.json`, `users.json`,
+etc.). `demoState.ts` owns stateful operations (adding a user to a group,
+etc.) so those interactions survive a page refresh.
+
+Feature flags today:
+
+| Flag          | Purpose                                  |
+| ------------- | ---------------------------------------- |
+| `demo`        | Enable demo mode with mock data.         |
+| `use_billing` | Enable billing / cost management UI.     |
+
+Flags compose: `?flags=demo,use_billing`.
+
+## Styling & design
+
+- [Tailwind CSS 4](https://tailwindcss.com/) with the `doubleword-*` color
+  palette defined in `tailwind.config.js`.
+- Space Grotesk type family.
+- Primitive components (`components/ui/`) are thin wrappers around
+  [Radix UI](https://www.radix-ui.com/); prefer composing these over adding
+  new one-off components.
+- Keep interactive color signals subtle (the codebase leans on layout and
+  hierarchy, not vibrant fills).
+- Animations should be user-triggered and subtle (`transition-colors`,
+  `transition-transform`). No autoplay.
+- Always keep mobile responsiveness in mind; tables default to horizontal
+  scroll with a sticky header row.
+
+## Testing conventions
+
+We use [Vitest](https://vitest.dev/) + [Testing Library](https://testing-library.com/)
+and MSW for HTTP mocking.
+
+- Co-locate tests: `Component.tsx` ↔ `Component.test.tsx`.
+- Scope queries to the component under test: destructure `{ container }` from
+  `render(...)` and use `within(container).getByRole(...)` rather than
+  `screen.*`. The exception is portal-rendered content (modals, dropdown
+  menus, popovers) — those live at the document root and must be queried via
+  `screen`.
+- Select elements by accessible roles / labels, not CSS classes or tag names.
+- Prefer `waitFor`/`findBy` over `tokio`-style `sleep`; assert the pre-state,
+  trigger the change, then assert the post-state so you test the whole flow.
+
+Fast feedback loop for a single file:
+
+```bash
+pnpm test run path/to/Component.test.tsx
+```
+
+Playwright tests live in `e2e/` and currently cover a small set of smoke
+flows; unit / integration tests are the primary safety net.
+
+## Contributing
+
+Before pushing anything to a PR:
+
+```bash
+pnpm lint
+pnpm test run
+pnpm build
+```
+
+The build step also type-checks via `tsc -b`, which catches things ESLint
+won't. CI runs `just ci ts` which is equivalent.
+
+For larger patterns (repository conventions, role model, request flow,
+pooling, database), see [`../CLAUDE.md`](../CLAUDE.md) — it is the canonical
+reference and is kept in sync with reality.

--- a/dashboard/src/components/features/models/catalog/ModelCatalog.test.tsx
+++ b/dashboard/src/components/features/models/catalog/ModelCatalog.test.tsx
@@ -1,0 +1,178 @@
+import { render, waitFor, within, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+import { ReactNode } from "react";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterEach,
+  afterAll,
+  vi,
+} from "vitest";
+import { ModelCatalog } from "./ModelCatalog";
+import { handlers } from "../../../../api/control-layer/mocks/handlers";
+import { SettingsProvider } from "../../../../contexts/settings/SettingsContext";
+
+vi.mock("../../../../utils/authorization", () => ({
+  useAuthorization: vi.fn(() => ({
+    userRoles: ["StandardUser"],
+    hasPermission: vi.fn(() => false),
+    canAccessRoute: vi.fn(() => true),
+  })),
+}));
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+  server.resetHandlers();
+  sessionStorage.clear();
+  localStorage.clear();
+});
+afterAll(() => server.close());
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <SettingsProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    </SettingsProvider>
+  );
+}
+
+describe("ModelCatalog", () => {
+  it("renders the heading and featured releases", async () => {
+    const { container } = render(<ModelCatalog />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(
+        within(container).getByRole("heading", { name: /^models$/i }),
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(
+        within(container).getByRole("heading", { name: /featured releases/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("collapses variants behind a family row by default", async () => {
+    const { container } = render(<ModelCatalog />, {
+      wrapper: createWrapper(),
+    });
+
+    const familyRow = await waitFor(() =>
+      within(container).getByRole("button", {
+        name: /expand qwen 3\.5 variants/i,
+      }),
+    );
+
+    expect(familyRow).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("expands a family when the chevron is clicked", async () => {
+    const { container } = render(<ModelCatalog />, {
+      wrapper: createWrapper(),
+    });
+
+    const expandButton = await waitFor(() =>
+      within(container).getByRole("button", {
+        name: /expand qwen 3\.5 variants/i,
+      }),
+    );
+
+    fireEvent.click(expandButton);
+
+    await waitFor(() => {
+      expect(
+        within(container).getByRole("button", {
+          name: /collapse qwen 3\.5 variants/i,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("exposes the async / batch pricing toggle", async () => {
+    const { container } = render(<ModelCatalog />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(
+        within(container).getByRole("heading", { name: /^models$/i }),
+      ).toBeInTheDocument();
+    });
+
+    const asyncTab = within(container).getByRole("tab", {
+      name: /async pricing/i,
+    });
+    const batchTab = within(container).getByRole("tab", {
+      name: /batch pricing/i,
+    });
+
+    expect(asyncTab).toHaveAttribute("aria-selected", "true");
+    expect(batchTab).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.click(batchTab);
+
+    expect(asyncTab).toHaveAttribute("aria-selected", "false");
+    expect(batchTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("shows provider and capability filter dropdowns", async () => {
+    const { container } = render(<ModelCatalog />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(
+        within(container).getByLabelText(/filter by provider/i),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(container).getByLabelText(/filter by capability/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty state message when no models are returned", async () => {
+    server.use(
+      http.get("/admin/api/v1/models", () => {
+        return HttpResponse.json({ data: [], total: 0 });
+      }),
+    );
+
+    const { container } = render(<ModelCatalog />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(
+        within(container).getByText(/no models available/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("supports fuzzy search via the search input", async () => {
+    const { container } = render(<ModelCatalog />, {
+      wrapper: createWrapper(),
+    });
+
+    const input = await waitFor(() =>
+      within(container).getByLabelText(/search models/i),
+    );
+
+    fireEvent.change(input, { target: { value: "qwen" } });
+    expect(input).toHaveValue("qwen");
+  });
+});

--- a/dashboard/src/components/features/models/catalog/ModelCatalog.tsx
+++ b/dashboard/src/components/features/models/catalog/ModelCatalog.tsx
@@ -4,6 +4,7 @@ import {
   Search,
   ChevronDown,
   ChevronUp,
+  ChevronRight,
   ArrowUpDown,
   X,
   Check,
@@ -14,12 +15,17 @@ import {
   Braces,
   Code,
   Copy,
+  ArrowRight,
+  Sparkles,
+  Zap,
+  Trophy,
 } from "lucide-react";
 import { useModels, useGroups, useProviderDisplayConfigs } from "../../../../api/control-layer";
 import type {
   Model,
   ModelDisplayCategory,
   ModelSortField,
+  ModelTariff,
   SortDirection,
 } from "../../../../api/control-layer/types";
 import { useAuthorization, copyToClipboard } from "../../../../utils";
@@ -32,10 +38,8 @@ import {
 import { isPlaygroundDenied } from "../../../../utils/modelAccess";
 import { IntelligenceBars, EmbeddingScore } from "../IntelligenceIndicator";
 import { Input } from "../../../ui/input";
-import { Badge } from "../../../ui/badge";
 import { Button } from "../../../ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../../../ui/popover";
-
 import {
   Table,
   TableBody,
@@ -57,6 +61,13 @@ import {
 import { Skeleton } from "../../../ui/skeleton";
 import { ApiExamples } from "../../../modals";
 import { CatalogIcon } from "./CatalogIcon";
+import {
+  aggregateFamilies,
+  getFormatBadges,
+  pickTariffForContext,
+  type AggregatedFamily,
+  type PricingContext,
+} from "./modelFamily";
 
 
 const EVERYONE_GROUP_ID = "00000000-0000-0000-0000-000000000000";
@@ -75,8 +86,26 @@ const CAPABILITY_CONFIG: Record<
   vision: { icon: Eye, label: "Vision / image input", color: "text-gray-400" },
   reasoning: { icon: Brain, label: "Reasoning", color: "text-gray-400" },
   embeddings: { icon: Layers, label: "Text embeddings", color: "text-gray-400" },
-  enhanced_structured_generation: { icon: Braces, label: "Enhanced structured generation", color: "text-gray-400" },
+  enhanced_structured_generation: {
+    icon: Braces,
+    label: "Enhanced structured generation",
+    color: "text-gray-400",
+  },
+  code: { icon: Code, label: "Code generation", color: "text-gray-400" },
 };
+
+/**
+ * Filter options for the Capabilities dropdown. We expose a curated list
+ * instead of every capability the backend reports because users think about
+ * modalities ("I need a vision model") more than implementation-level flags.
+ */
+const FILTERABLE_CAPABILITIES: Array<{ key: string; label: string }> = [
+  { key: "vision", label: "Vision" },
+  { key: "reasoning", label: "Reasoning" },
+  { key: "code", label: "Code" },
+  { key: "enhanced_structured_generation", label: "Structured output" },
+  { key: "embeddings", label: "Embeddings" },
+];
 
 const DEFAULT_SORT_DIRECTIONS: Partial<Record<ModelSortField, SortDirection>> = {
   alias: "asc",
@@ -86,43 +115,32 @@ const DEFAULT_SORT_DIRECTIONS: Partial<Record<ModelSortField, SortDirection>> = 
   price_from: "asc",
 };
 
+const NEW_CUTOFF_MONTHS = 3;
+
 function formatReleaseDate(dateStr: string): string {
   const date = new Date(dateStr + "T00:00:00");
   return date.toLocaleDateString("en-US", { month: "short", year: "numeric" });
 }
 
-function getCheapestInputPrice(tariffs: Model["tariffs"]): string | null {
-  if (!tariffs) return null;
-  const visible = getUserFacingTariffs(tariffs);
-  if (visible.length === 0) return null;
-  let cheapest = Infinity;
-  for (const t of visible) {
-    const price = parseFloat(t.input_price_per_token);
-    if (price < cheapest) cheapest = price;
-  }
-  if (!isFinite(cheapest)) return null;
-  return formatTariffPrice(String(cheapest));
+function getCheapestInputPriceValue(
+  tariffs: ModelTariff[] | undefined | null,
+  context: PricingContext,
+): number | null {
+  const tariff = pickTariffForContext(tariffs, context);
+  if (!tariff) return null;
+  const v = parseFloat(tariff.input_price_per_token);
+  return Number.isFinite(v) ? v : null;
 }
 
-function getCheapestInputPriceValue(tariffs: Model["tariffs"]): number | null {
-  if (!tariffs) return null;
-  const visible = getUserFacingTariffs(tariffs);
-  if (visible.length === 0) return null;
-  let cheapest = Infinity;
-  for (const t of visible) {
-    const price = parseFloat(t.input_price_per_token);
-    if (price < cheapest) cheapest = price;
-  }
-  return Number.isFinite(cheapest) ? cheapest : null;
+function formatPricePerMillion(pricePerToken: string | number): string {
+  return formatTariffPrice(pricePerToken);
 }
 
 /** Derive display capabilities from model type + backend capabilities. */
 function getDisplayCapabilities(model: Model): string[] {
   const caps: string[] = [];
-  // Implicit capability from model type
   if (model.model_type === "CHAT") caps.push("text");
   else if (model.model_type === "EMBEDDINGS") caps.push("embeddings");
-  // Explicit capabilities from backend (vision, reasoning, etc.)
   if (model.capabilities) {
     for (const c of model.capabilities) {
       if (c !== "text" && c !== "embeddings" && !caps.includes(c)) {
@@ -154,7 +172,10 @@ function CapabilityIcons({ capabilities }: { capabilities: string[] }) {
         return (
           <Tooltip key={cap}>
             <TooltipTrigger asChild>
-              <Icon className={`w-4 h-4 ${config.color}`} />
+              <Icon
+                aria-label={config.label}
+                className={`w-4 h-4 ${config.color}`}
+              />
             </TooltipTrigger>
             <TooltipContent side="top" className="text-xs">
               {config.label}
@@ -202,435 +223,582 @@ function SortButton({
   );
 }
 
-function PricingTiers({ tariffs }: { tariffs: Model["tariffs"] }) {
-  if (!tariffs) return null;
-  const tiers = getUserFacingTariffs(tariffs);
-  if (tiers.length === 0) return null;
-
+/**
+ * Dark-themed cost tooltip that shows the input / output breakdown for every
+ * user-facing tariff belonging to a specific variant.
+ */
+function CostHoverCard({
+  tariffs,
+  children,
+}: {
+  tariffs: ModelTariff[];
+  children: React.ReactNode;
+}) {
+  const visible = getUserFacingTariffs(tariffs);
+  if (visible.length === 0) return <>{children}</>;
   return (
-    <div className="flex gap-4 flex-wrap">
-      {tiers.map((t) => (
-        <div key={t.id} className="bg-gray-50 rounded-lg px-4 py-2.5">
-          <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-1">
-            {getTariffDisplayName(t.api_key_purpose, t.completion_window)}
+    <HoverCard openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardContent
+        side="bottom"
+        align="start"
+        className="w-auto p-3 bg-doubleword-neutral-900 text-gray-100 border-doubleword-neutral-800"
+      >
+        <div className="space-y-1.5 min-w-[220px]">
+          <p className="text-[10px] uppercase tracking-wide text-gray-400 pb-1">
+            Per 1M tokens · input / output
           </p>
-          <p className="text-sm tabular-nums">
-            {formatTariffPrice(t.input_price_per_token)}/M in
-            <span className="text-gray-400 mx-1">&middot;</span>
-            {formatTariffPrice(t.output_price_per_token)}/M out
-          </p>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function ExpandedContent({ model }: { model: Model }) {
-  const summary = model.metadata?.extra?.summary ?? null;
-  const useCases = model.metadata?.extra?.use_cases ?? [];
-
-  return (
-    <div className="px-2 py-4 space-y-4">
-      {summary && (
-        <p className="text-sm text-gray-600 max-w-3xl">{summary}</p>
-      )}
-
-      {model.tariffs && model.tariffs.length > 0 && (
-        <PricingTiers tariffs={model.tariffs} />
-      )}
-
-      {useCases.length > 0 && (
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-xs text-gray-500">Best for:</span>
-          {useCases.map((item) => (
-            <Badge
-              key={item}
-              variant="secondary"
-              className="text-xs font-normal"
+          {visible.map((t) => (
+            <div
+              key={t.id}
+              className="flex items-baseline justify-between gap-4 text-xs tabular-nums"
             >
-              {item}
-            </Badge>
+              <span className="text-gray-400">
+                {getTariffDisplayName(t.api_key_purpose, t.completion_window)}
+              </span>
+              <span className="font-medium">
+                {formatTariffPrice(t.input_price_per_token)}
+                <span className="text-gray-500 mx-1">·</span>
+                {formatTariffPrice(t.output_price_per_token)}
+              </span>
+            </div>
           ))}
         </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function FormatBadges({ model }: { model: Model }) {
+  const badges = getFormatBadges(model);
+  if (badges.length === 0) return null;
+  return (
+    <>
+      {badges.map((b) => (
+        <span
+          key={b}
+          className="inline-flex items-center shrink-0 rounded-full bg-gray-100 text-gray-600 px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase"
+        >
+          {b}
+        </span>
+      ))}
+    </>
+  );
+}
+
+function NewBadge() {
+  return (
+    <span className="inline-flex items-center shrink-0 rounded-full bg-blue-100 text-blue-800 px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
+      New
+    </span>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Featured                                  */
+/* -------------------------------------------------------------------------- */
+
+interface FeaturedCardSpec {
+  key: "smartest" | "new_fp8" | "most_efficient";
+  label: string;
+  icon: React.FC<{ className?: string }>;
+  model: Model;
+}
+
+/**
+ * Pick up to three headline models for the Featured Releases strip.
+ *
+ * - "Smartest": highest intelligence_index overall.
+ * - "New FP8": newest FP8 quantization release (falls back to any new release).
+ * - "Most Efficient": cheapest async input price with a non-zero intelligence
+ *   score, so we don't just highlight the cheapest embedding model.
+ */
+function selectFeaturedModels(
+  models: Model[],
+  newCutoff: string,
+): FeaturedCardSpec[] {
+  const generation = models.filter(
+    (m) => getCatalogTabForModel(m) === "generation",
+  );
+  if (generation.length === 0) return [];
+
+  const cards: FeaturedCardSpec[] = [];
+  const used = new Set<string>();
+
+  const smartest = [...generation]
+    .filter((m) => m.metadata?.intelligence_index != null)
+    .sort(
+      (a, b) =>
+        (b.metadata?.intelligence_index ?? 0) -
+        (a.metadata?.intelligence_index ?? 0),
+    )[0];
+  if (smartest) {
+    cards.push({
+      key: "smartest",
+      label: "Smartest",
+      icon: Trophy,
+      model: smartest,
+    });
+    used.add(smartest.id);
+  }
+
+  const newFp8 = [...generation]
+    .filter(
+      (m) =>
+        !used.has(m.id) &&
+        (m.metadata?.quantization?.toUpperCase() === "FP8" ||
+          /FP8/i.test(m.alias)) &&
+        m.metadata?.released_at &&
+        m.metadata.released_at >= newCutoff,
+    )
+    .sort((a, b) =>
+      (b.metadata?.released_at ?? "").localeCompare(a.metadata?.released_at ?? ""),
+    )[0];
+  if (newFp8) {
+    cards.push({
+      key: "new_fp8",
+      label: "New FP8",
+      icon: Sparkles,
+      model: newFp8,
+    });
+    used.add(newFp8.id);
+  }
+
+  const mostEfficient = [...generation]
+    .filter(
+      (m) =>
+        !used.has(m.id) &&
+        (m.metadata?.intelligence_index ?? 0) > 0 &&
+        getCheapestInputPriceValue(m.tariffs, "async") != null,
+    )
+    .sort((a, b) => {
+      const ap = getCheapestInputPriceValue(a.tariffs, "async") ?? Infinity;
+      const bp = getCheapestInputPriceValue(b.tariffs, "async") ?? Infinity;
+      return ap - bp;
+    })[0];
+  if (mostEfficient) {
+    cards.push({
+      key: "most_efficient",
+      label: "Most Efficient",
+      icon: Zap,
+      model: mostEfficient,
+    });
+  }
+
+  return cards;
+}
+
+function FeaturedReleases({
+  models,
+  newCutoff,
+}: {
+  models: Model[];
+  newCutoff: string;
+}) {
+  const navigate = useNavigate();
+  const cards = useMemo(
+    () => selectFeaturedModels(models, newCutoff),
+    [models, newCutoff],
+  );
+  if (cards.length === 0) return null;
+
+  return (
+    <section aria-labelledby="featured-releases-heading" className="mb-6">
+      <h2
+        id="featured-releases-heading"
+        className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2"
+      >
+        Featured Releases
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        {cards.map((card) => {
+          const { model } = card;
+          const Icon = card.icon;
+          const provider = model.metadata?.provider ?? "";
+          const intelligence = model.metadata?.intelligence_index;
+          const destination = isPlaygroundDenied(model)
+            ? `/models/${model.id}`
+            : `/playground?model=${encodeURIComponent(model.id)}`;
+          return (
+            <button
+              key={card.key}
+              type="button"
+              onClick={() => navigate(destination)}
+              className="group flex flex-col items-start text-left rounded-lg border bg-white px-4 py-3 hover:border-doubleword-neutral-400 hover:shadow-sm transition-all"
+              aria-label={`${card.label}: ${model.display_name || model.alias}`}
+            >
+              <div className="flex w-full items-center justify-between gap-2">
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-50 text-blue-700 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide">
+                  <Icon className="w-3 h-3" />
+                  {card.label}
+                </span>
+                <ArrowRight className="w-4 h-4 text-gray-300 group-hover:text-gray-500 transition-colors" />
+              </div>
+              <div className="mt-3 min-w-0 w-full">
+                <p className="text-base font-semibold text-doubleword-neutral-900 truncate">
+                  {model.display_name || model.alias.split("/").pop()}
+                </p>
+                <p className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <span className="truncate">{provider || "\u2014"}</span>
+                  {intelligence != null && (
+                    <>
+                      <span className="text-gray-300">&middot;</span>
+                      <Brain className="w-3 h-3" aria-hidden="true" />
+                      <span className="tabular-nums">
+                        {Math.round(intelligence)}
+                      </span>
+                    </>
+                  )}
+                </p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                    Rows                                    */
+/* -------------------------------------------------------------------------- */
+
+function CopyAliasButton({ alias }: { alias: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="shrink-0 p-0.5 text-gray-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-gray-600 transition-all"
+          aria-label={copied ? "Copied" : `Copy model ID ${alias}`}
+          onClick={async (e) => {
+            e.stopPropagation();
+            if (await copyToClipboard(alias)) {
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            }
+          }}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-green-600" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span className="font-mono text-xs">{alias}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function RowActions({
+  model,
+  onApiClick,
+}: {
+  model: Model;
+  onApiClick: () => void;
+}) {
+  const navigate = useNavigate();
+  const playgroundAvailable = !isPlaygroundDenied(model);
+  return (
+    <div className="flex items-center justify-end gap-1.5 max-[699px]:gap-1">
+      {playgroundAvailable && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/playground?model=${encodeURIComponent(model.id)}`);
+          }}
+          className="text-xs h-7 px-2.5 border-blue-200 text-blue-700 hover:bg-blue-50 hover:text-blue-800 max-[699px]:px-2"
+        >
+          <span className="max-[699px]:hidden">Try it &rarr;</span>
+          <span className="hidden max-[699px]:inline">Try</span>
+        </Button>
       )}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={(e) => {
+          e.stopPropagation();
+          onApiClick();
+        }}
+        className="text-xs h-7 px-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 max-[699px]:px-1.5"
+      >
+        <Code className="h-3.5 w-3.5" />
+        <span className="hidden ml-1 max-[699px]:inline lg:inline">API</span>
+      </Button>
     </div>
   );
 }
 
-function ModelRow({
-  model,
-  providerLabel,
-  providerIcon,
-  providerConfigMap,
-  isLatest,
+function FamilyParentRow({
+  family,
   isExpanded,
   onToggleExpand,
+}: {
+  family: AggregatedFamily;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+}) {
+  const variantCount = family.variants.length;
+  return (
+    <TableRow
+      className="group cursor-pointer hover:bg-muted/50 transition-colors [&>td]:py-2"
+      onClick={onToggleExpand}
+      data-testid={`family-row-${family.key}`}
+    >
+      <TableCell className="px-2 max-[699px]:w-8 max-[699px]:px-1.5">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleExpand();
+          }}
+          className="p-1 text-gray-400 hover:text-gray-600 transition-colors rounded"
+          aria-label={
+            isExpanded
+              ? `Collapse ${family.label} variants`
+              : `Expand ${family.label} variants`
+          }
+          aria-expanded={isExpanded}
+        >
+          {isExpanded ? (
+            <ChevronDown className="w-4 h-4" />
+          ) : (
+            <ChevronRight className="w-4 h-4" />
+          )}
+        </button>
+      </TableCell>
+      <TableCell className="overflow-hidden max-[699px]:w-full">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="font-medium truncate">{family.label}</span>
+          <span className="inline-flex items-center shrink-0 rounded-full bg-gray-100 text-gray-600 px-2 py-0.5 text-[10px] font-medium">
+            {variantCount} {variantCount === 1 ? "variant" : "variants"}
+          </span>
+          {family.hasNewVariant && <NewBadge />}
+        </div>
+      </TableCell>
+      <TableCell className="overflow-hidden max-[699px]:hidden">
+        <div className="flex items-center gap-2 min-w-0">
+          <CatalogIcon
+            icon={family.providerIcon || undefined}
+            label={family.providerLabel}
+            size="sm"
+            fallback="none"
+          />
+          <span className="text-sm text-muted-foreground truncate">
+            {family.providerLabel}
+          </span>
+        </div>
+      </TableCell>
+      <TableCell className="hidden md:table-cell">
+        <CapabilityIcons capabilities={family.capabilities} />
+      </TableCell>
+      <TableCell className="hidden md:table-cell tabular-nums text-xs text-muted-foreground">
+        {family.intelligenceMin != null && family.intelligenceMax != null ? (
+          family.intelligenceMin === family.intelligenceMax ? (
+            <span>{Math.round(family.intelligenceMin)}</span>
+          ) : (
+            <span>
+              {Math.round(family.intelligenceMin)}
+              <span className="text-gray-400 mx-0.5">&ndash;</span>
+              {Math.round(family.intelligenceMax)}
+            </span>
+          )
+        ) : (
+          <span className="text-muted-foreground">{"\u2014"}</span>
+        )}
+      </TableCell>
+      <TableCell className="hidden md:table-cell tabular-nums text-muted-foreground text-xs">
+        {family.priceFrom != null ? (
+          <span>
+            <span className="text-xs text-gray-400">from </span>
+            {formatPricePerMillion(family.priceFrom)}
+            <span className="text-gray-400">/M</span>
+          </span>
+        ) : (
+          "\u2014"
+        )}
+      </TableCell>
+      <TableCell className="hidden md:table-cell tabular-nums text-muted-foreground text-xs">
+        {family.contextMax != null ? (
+          <span>
+            <span className="text-xs text-gray-400">up to </span>
+            {formatContextLength(family.contextMax)}
+          </span>
+        ) : (
+          "\u2014"
+        )}
+      </TableCell>
+      <TableCell className="hidden md:table-cell text-muted-foreground text-xs">
+        {family.releasedAt ? formatReleaseDate(family.releasedAt) : "\u2014"}
+      </TableCell>
+      <TableCell className="w-px whitespace-nowrap text-right pr-3 lg:pr-6 max-[699px]:sticky max-[699px]:right-0 max-[699px]:z-10 max-[699px]:px-1.5 max-[699px]:bg-background" />
+    </TableRow>
+  );
+}
+
+function VariantRow({
+  model,
+  isLatest,
+  context,
   onClick,
   onApiClick,
 }: {
   model: Model;
-  providerLabel: string;
-  providerIcon?: string | null;
-  providerConfigMap: Map<string, { display_name: string; icon?: string | null }>;
   isLatest: boolean;
-  isExpanded: boolean;
-  onToggleExpand: () => void;
-  onClick: () => void;
-  onApiClick: () => void;
+  context: PricingContext;
+  onClick: (model: Model) => void;
+  onApiClick: (model: Model) => void;
 }) {
-  const navigate = useNavigate();
-  const [copied, setCopied] = useState(false);
   const visibleTariffs = model.tariffs ? getUserFacingTariffs(model.tariffs) : [];
-  const cheapestPrice =
-    visibleTariffs.length > 0 ? getCheapestInputPrice(model.tariffs) : null;
-
-  const playgroundAvailable = !isPlaygroundDenied(model);
+  const chosenTariff = pickTariffForContext(model.tariffs, context);
   const isChat = getCatalogTabForModel(model) !== "embedding";
-  const colCount = 9;
+
+  const variantShortLabel =
+    model.display_name || model.alias.split("/").pop() || model.alias;
 
   return (
-    <Fragment>
-      <TableRow
-        className="group cursor-pointer hover:bg-muted/50 transition-colors [&>td]:py-1.5 max-[699px]:[&>td]:py-1"
-        onClick={onClick}
-      >
-        <TableCell className="px-2 max-[699px]:w-8 max-[699px]:px-1.5">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleExpand();
-            }}
-            className="p-1 text-gray-400 hover:text-gray-600 transition-colors rounded"
-            aria-label={isExpanded ? "Collapse row" : "Expand row"}
-          >
-            {isExpanded ? (
-              <ChevronUp className="w-4 h-4" />
-            ) : (
-              <ChevronDown className="w-4 h-4" />
-            )}
-          </button>
-        </TableCell>
-        <TableCell className="overflow-hidden max-[699px]:w-full max-[699px]:whitespace-normal max-[699px]:px-1">
-          <div className="flex min-w-0 items-center gap-2 max-[699px]:items-start max-[699px]:gap-1.5">
-            <div className="min-w-0 flex-1">
-              <div className="flex min-w-0 items-center gap-2 max-[699px]:flex-wrap max-[699px]:gap-1.5">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="font-medium truncate">{model.display_name || model.alias}</span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <span className="font-mono text-xs">{model.alias}</span>
-                  </TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className="shrink-0 p-0.5 text-gray-400 hover:text-gray-600 transition-colors"
-                      aria-label="Copy model alias"
-                      onClick={async (e) => {
-                        e.stopPropagation();
-                        if (await copyToClipboard(model.alias)) {
-                          setCopied(true);
-                          setTimeout(() => setCopied(false), 1500);
-                        }
-                      }}
-                    >
-                      {copied ? (
-                        <Check className="h-3.5 w-3.5 text-green-600" />
-                      ) : (
-                        <Copy className="h-3.5 w-3.5" />
-                      )}
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <span className="font-mono text-xs">{model.alias}</span>
-                  </TooltipContent>
-                </Tooltip>
-                {isLatest && (
-                  <span className="inline-flex items-center shrink-0 rounded-full bg-blue-100 text-blue-800 px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
-                    New
-                  </span>
-                )}
-                {model.metadata?.quantization && (
-                  <span className="inline-flex items-center shrink-0 rounded-full bg-gray-100 text-gray-600 px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
-                    {model.metadata.quantization}
-                  </span>
-                )}
-                {model.metadata?.extra?.deployment_providers?.map((dp) => {
-                  const config = providerConfigMap.get(dp);
-                  if (!config) return null;
-                  return (
-                    <Tooltip key={dp}>
-                      <TooltipTrigger asChild>
-                        <span className="hidden shrink-0 min-[700px]:inline-flex">
-                          <CatalogIcon
-                            icon={config.icon || undefined}
-                            label={config.display_name}
-                            size="sm"
-                            fallback="none"
-                          />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>{config.display_name}</TooltipContent>
-                    </Tooltip>
-                  );
-                })}
-              </div>
-
-              <div className="mt-1 hidden min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground max-[699px]:flex">
-                <CatalogIcon
-                  icon={providerIcon || undefined}
-                  label={providerLabel}
-                  size="sm"
-                  fallback="none"
-                />
-                <span className="truncate">{providerLabel}</span>
-                {model.metadata?.extra?.deployment_providers?.map((dp) => {
-                  const config = providerConfigMap.get(dp);
-                  if (!config) return null;
-
-                  return (
-                    <CatalogIcon
-                      key={dp}
-                      icon={config.icon || undefined}
-                      label={config.display_name}
-                      size="sm"
-                      fallback="none"
-                    />
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-        </TableCell>
-        <TableCell className="overflow-hidden max-[699px]:hidden">
-          <div className="flex items-center gap-2 min-w-0">
-            <CatalogIcon
-              icon={providerIcon || undefined}
-              label={providerLabel}
-              size="sm"
-              fallback="none"
+    <TableRow
+      className="group cursor-pointer bg-muted/20 hover:bg-muted/40 transition-colors [&>td]:py-1.5"
+      onClick={() => onClick(model)}
+    >
+      <TableCell className="px-2 max-[699px]:w-8 max-[699px]:px-1.5" />
+      <TableCell className="overflow-hidden max-[699px]:w-full max-[699px]:whitespace-normal">
+        <div className="flex items-center gap-2 min-w-0 pl-4">
+          <span className="text-sm text-gray-700 truncate">
+            {variantShortLabel}
+          </span>
+          <FormatBadges model={model} />
+          {isLatest && <NewBadge />}
+          <CopyAliasButton alias={model.alias} />
+        </div>
+      </TableCell>
+      <TableCell className="overflow-hidden max-[699px]:hidden text-xs text-muted-foreground" />
+      <TableCell className="hidden md:table-cell">
+        <CapabilityIcons capabilities={getDisplayCapabilities(model)} />
+      </TableCell>
+      <TableCell className="hidden md:table-cell">
+        {isChat ? (
+          model.metadata?.intelligence_index != null ? (
+            <IntelligenceBars
+              value={model.metadata.intelligence_index}
+              metadata={model.metadata}
             />
-            <span className="text-sm text-muted-foreground truncate">{providerLabel}</span>
-          </div>
-        </TableCell>
-        <TableCell className="hidden md:table-cell">
-          <CapabilityIcons capabilities={getDisplayCapabilities(model)} />
-        </TableCell>
-        <TableCell className="hidden md:table-cell">
-          {isChat ? (
-            model.metadata?.intelligence_index != null ? (
-              <IntelligenceBars value={model.metadata.intelligence_index} metadata={model.metadata} />
-            ) : (
-              <span className="text-muted-foreground">{"\u2014"}</span>
-            )
           ) : (
-            <EmbeddingScore metadata={model.metadata} />
-          )}
-        </TableCell>
-        <TableCell className="hidden md:table-cell tabular-nums text-muted-foreground text-xs">
-          {cheapestPrice && visibleTariffs.length > 0 ? (
-            <HoverCard openDelay={150} closeDelay={100}>
-              <HoverCardTrigger asChild>
-                <span className="cursor-default border-b border-dotted border-gray-300">
-                  <span className="text-xs text-gray-400">from </span>
-                  {cheapestPrice}/M
-                </span>
-              </HoverCardTrigger>
-              <HoverCardContent side="bottom" align="start" className="w-auto p-3">
-                <div className="space-y-1.5">
-                  {visibleTariffs.map((t) => (
-                    <div key={t.id} className="flex items-baseline justify-between gap-4 text-xs tabular-nums">
-                      <span className="text-muted-foreground">
-                        {getTariffDisplayName(t.api_key_purpose, t.completion_window)}
-                      </span>
-                      <span>
-                        {formatTariffPrice(t.input_price_per_token)}
-                        <span className="text-muted-foreground mx-0.5">/</span>
-                        {formatTariffPrice(t.output_price_per_token)}
-                      </span>
-                    </div>
-                  ))}
-                  <p className="text-[10px] text-muted-foreground pt-0.5">per 1M tokens · input / output</p>
-                </div>
-              </HoverCardContent>
-            </HoverCard>
-          ) : (
-            "\u2014"
-          )}
-        </TableCell>
-        <TableCell className="hidden md:table-cell tabular-nums text-muted-foreground text-xs">
-          {model.metadata?.context_window
-            ? formatContextLength(model.metadata.context_window)
-            : "\u2014"}
-        </TableCell>
-        <TableCell className="hidden md:table-cell text-muted-foreground text-xs">
-          {model.metadata?.released_at
-            ? formatReleaseDate(model.metadata.released_at)
-            : "\u2014"}
-        </TableCell>
-        <TableCell className="w-px whitespace-nowrap text-right pr-3 lg:pr-6 max-[699px]:sticky max-[699px]:right-0 max-[699px]:z-10 max-[699px]:px-1.5 max-[699px]:bg-background">
-          <div className="flex items-center justify-end gap-1.5 max-[699px]:gap-1">
-            {playgroundAvailable && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  navigate(
-                    `/playground?model=${encodeURIComponent(model.id)}`,
-                  );
-                }}
-                className="text-xs h-7 px-2.5 border-blue-200 text-blue-700 hover:bg-blue-50 hover:text-blue-800 max-[699px]:px-2"
-              >
-                <span className="max-[699px]:hidden">Try it &rarr;</span>
-                <span className="hidden max-[699px]:inline">Try</span>
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={(e) => {
-                e.stopPropagation();
-                onApiClick();
-              }}
-              className="text-xs h-7 px-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 max-[699px]:px-1.5"
-            >
-              <Code className="h-3.5 w-3.5" />
-              <span className="hidden ml-1 max-[699px]:inline lg:inline">API</span>
-            </Button>
-          </div>
-        </TableCell>
-      </TableRow>
-      {isExpanded && (
-        <TableRow className="hover:bg-transparent">
-          <TableCell colSpan={colCount} className="pt-0 pb-4 pl-10">
-            <ExpandedContent model={model} />
-          </TableCell>
-        </TableRow>
-      )}
-    </Fragment>
+            <span className="text-muted-foreground text-xs">{"\u2014"}</span>
+          )
+        ) : (
+          <EmbeddingScore metadata={model.metadata} />
+        )}
+      </TableCell>
+      <TableCell className="hidden md:table-cell tabular-nums text-xs text-muted-foreground">
+        {chosenTariff && visibleTariffs.length > 0 ? (
+          <CostHoverCard tariffs={visibleTariffs}>
+            <span className="cursor-default border-b border-dotted border-gray-300">
+              {formatTariffPrice(chosenTariff.input_price_per_token)}
+              <span className="text-gray-400">/M</span>
+            </span>
+          </CostHoverCard>
+        ) : (
+          "\u2014"
+        )}
+      </TableCell>
+      <TableCell className="hidden md:table-cell tabular-nums text-muted-foreground text-xs">
+        {model.metadata?.context_window
+          ? formatContextLength(model.metadata.context_window)
+          : "\u2014"}
+      </TableCell>
+      <TableCell className="hidden md:table-cell text-muted-foreground text-xs">
+        {model.metadata?.released_at
+          ? formatReleaseDate(model.metadata.released_at)
+          : "\u2014"}
+      </TableCell>
+      <TableCell className="w-px whitespace-nowrap text-right pr-3 lg:pr-6 max-[699px]:sticky max-[699px]:right-0 max-[699px]:z-10 max-[699px]:px-1.5 max-[699px]:bg-background">
+        <RowActions model={model} onApiClick={() => onApiClick(model)} />
+      </TableCell>
+    </TableRow>
   );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                   Table                                    */
+/* -------------------------------------------------------------------------- */
+
+interface SectionTableProps {
+  tableKey: string;
+  families: AggregatedFamily[];
+  newCutoff: string;
+  context: PricingContext;
+  expandedFamilies: Set<string>;
+  onToggleExpand: (key: string) => void;
+  sortField: ModelSortField | null;
+  sortDirection: SortDirection | null;
+  onSort: (tableKey: string, field: ModelSortField) => void;
+  onRowClick: (model: Model) => void;
+  onApiClick: (model: Model) => void;
 }
 
 function SectionTable({
   tableKey,
-  models,
-  providerConfigMap,
-  expandedRows,
+  families,
+  newCutoff,
+  context,
+  expandedFamilies,
   onToggleExpand,
-  onRowClick,
-  onApiClick,
   sortField,
   sortDirection,
   onSort,
-}: {
-  tableKey: string;
-  models: Model[];
-  providerConfigMap: Map<string, { display_name: string; icon?: string | null }>;
-  expandedRows: Set<string>;
-  onToggleExpand: (id: string) => void;
-  onRowClick: (id: string) => void;
-  onApiClick: (model: Model) => void;
-  sortField: ModelSortField | null;
-  sortDirection: SortDirection | null;
-  onSort: (tableKey: string, field: ModelSortField) => void;
-}) {
-  const newModelIds = useMemo(() => {
-    const cutoff = new Date();
-    cutoff.setMonth(cutoff.getMonth() - 3);
-    const cutoffStr = cutoff.toISOString().slice(0, 10);
-    const ids = new Set<string>();
-    for (const m of models) {
-      if (m.metadata?.released_at && m.metadata.released_at >= cutoffStr) {
-        ids.add(m.id);
-      }
-    }
-    return ids;
-  }, [models]);
+  onRowClick,
+  onApiClick,
+}: SectionTableProps) {
+  const sortedFamilies = useMemo(() => {
+    if (!sortField) return families;
+    const dir = sortDirection === "asc" ? 1 : -1;
 
-  const sortedModels = useMemo(() => {
-    const compareNumbers = (a?: number | null, b?: number | null) => {
+    const cmpNum = (a?: number | null, b?: number | null) => {
       if (a == null && b == null) return 0;
       if (a == null) return 1;
       if (b == null) return -1;
       return a - b;
     };
 
-    // Default: preserve server-side order (released_at desc, nulls last)
-    if (!sortField) {
-      return models;
-    }
-
-    const directionMultiplier = sortDirection === "asc" ? 1 : -1;
-
-    const compareReleasedAt = (a: Model, b: Model) => {
-      const aDate = a.metadata?.released_at;
-      const bDate = b.metadata?.released_at;
-      if (!aDate && !bDate) return 0;
-      if (!aDate) return 1;
-      if (!bDate) return -1;
-      return aDate.localeCompare(bDate);
-    };
-
-    return [...models].sort((a, b) => {
-      let comparison = 0;
-
+    return [...families].sort((a, b) => {
+      let c = 0;
       switch (sortField) {
         case "alias":
-          comparison = a.alias.localeCompare(b.alias);
+          c = a.label.localeCompare(b.label);
           break;
         case "intelligence_index":
-          comparison = compareNumbers(
-            a.metadata?.intelligence_index,
-            b.metadata?.intelligence_index,
-          );
+          c = cmpNum(a.intelligenceMax, b.intelligenceMax);
           break;
-        case "price_from": {
-          comparison = compareNumbers(
-            getCheapestInputPriceValue(a.tariffs),
-            getCheapestInputPriceValue(b.tariffs),
-          );
+        case "price_from":
+          c = cmpNum(a.priceFrom, b.priceFrom);
           break;
-        }
         case "context_window":
-          comparison = compareNumbers(
-            a.metadata?.context_window,
-            b.metadata?.context_window,
-          );
+          c = cmpNum(a.contextMax, b.contextMax);
           break;
         case "released_at":
-          comparison = compareReleasedAt(a, b);
+          if (a.releasedAt && b.releasedAt)
+            c = a.releasedAt.localeCompare(b.releasedAt);
+          else if (a.releasedAt) c = -1;
+          else if (b.releasedAt) c = 1;
           break;
       }
-
-      if (comparison !== 0) {
-        return comparison * directionMultiplier;
-      }
-
-      return a.alias.localeCompare(b.alias);
+      if (c !== 0) return c * dir;
+      return a.label.localeCompare(b.label);
     });
-  }, [models, sortDirection, sortField]);
-
-  const getProviderData = (model: Model) => {
-    const providerKey = (model.metadata?.provider?.trim() || "Other").toLowerCase();
-    const providerConfig = providerConfigMap.get(providerKey);
-
-    return {
-      providerLabel:
-        providerConfig?.display_name ||
-        model.metadata?.provider?.trim() ||
-        "Other",
-      providerIcon: providerConfig?.icon,
-    };
-  };
+  }, [families, sortField, sortDirection]);
 
   return (
     <div className="border rounded-lg overflow-hidden">
       <div className="overflow-x-auto">
         <Table className="w-full max-[699px]:table-fixed">
-          <TableHeader>
+          <TableHeader className="sticky top-0 z-20 bg-background">
             <TableRow>
               <TableHead className="px-2 max-[699px]:w-8 max-[699px]:px-1.5" />
               <TableHead className="max-[699px]:w-full">
@@ -639,31 +807,27 @@ function SectionTable({
                   label="Name"
                   sortField={sortField}
                   sortDirection={sortDirection}
-                  onSort={(field) => onSort(tableKey, field)}
+                  onSort={(f) => onSort(tableKey, f)}
                 />
               </TableHead>
-              <TableHead className="max-[699px]:hidden">
-                Provider
-              </TableHead>
-              <TableHead className="hidden md:table-cell">
-                Capabilities
-              </TableHead>
+              <TableHead className="max-[699px]:hidden">Provider</TableHead>
+              <TableHead className="hidden md:table-cell">Capabilities</TableHead>
               <TableHead className="hidden md:table-cell">
                 <SortButton
                   field="intelligence_index"
                   label="Intelligence"
                   sortField={sortField}
                   sortDirection={sortDirection}
-                  onSort={(field) => onSort(tableKey, field)}
+                  onSort={(f) => onSort(tableKey, f)}
                 />
               </TableHead>
               <TableHead className="hidden md:table-cell">
                 <SortButton
                   field="price_from"
-                  label="Cost"
+                  label="Cost ($/M)"
                   sortField={sortField}
                   sortDirection={sortDirection}
-                  onSort={(field) => onSort(tableKey, field)}
+                  onSort={(f) => onSort(tableKey, f)}
                 />
               </TableHead>
               <TableHead className="hidden md:table-cell">
@@ -672,7 +836,7 @@ function SectionTable({
                   label="Context"
                   sortField={sortField}
                   sortDirection={sortDirection}
-                  onSort={(field) => onSort(tableKey, field)}
+                  onSort={(f) => onSort(tableKey, f)}
                 />
               </TableHead>
               <TableHead className="hidden md:table-cell">
@@ -681,28 +845,37 @@ function SectionTable({
                   label="Released"
                   sortField={sortField}
                   sortDirection={sortDirection}
-                  onSort={(field) => onSort(tableKey, field)}
+                  onSort={(f) => onSort(tableKey, f)}
                 />
               </TableHead>
               <TableHead className="max-[699px]:sticky max-[699px]:right-0 max-[699px]:z-10 max-[699px]:w-px max-[699px]:px-1.5 max-[699px]:bg-background" />
             </TableRow>
           </TableHeader>
           <TableBody>
-            {sortedModels.map((model) => {
-              const { providerLabel, providerIcon } = getProviderData(model);
+            {sortedFamilies.map((family) => {
+              const isExpanded = expandedFamilies.has(family.key);
               return (
-                <ModelRow
-                  key={model.id}
-                  model={model}
-                  providerLabel={providerLabel}
-                  providerIcon={providerIcon}
-                  providerConfigMap={providerConfigMap}
-                  isLatest={newModelIds.has(model.id)}
-                  isExpanded={expandedRows.has(model.id)}
-                  onToggleExpand={() => onToggleExpand(model.id)}
-                  onClick={() => onRowClick(model.id)}
-                  onApiClick={() => onApiClick(model)}
-                />
+                <Fragment key={family.key}>
+                  <FamilyParentRow
+                    family={family}
+                    isExpanded={isExpanded}
+                    onToggleExpand={() => onToggleExpand(family.key)}
+                  />
+                  {isExpanded &&
+                    family.variants.map((variant) => (
+                      <VariantRow
+                        key={variant.id}
+                        model={variant}
+                        isLatest={
+                          !!variant.metadata?.released_at &&
+                          variant.metadata.released_at >= newCutoff
+                        }
+                        context={context}
+                        onClick={onRowClick}
+                        onApiClick={onApiClick}
+                      />
+                    ))}
+                </Fragment>
               );
             })}
           </TableBody>
@@ -711,6 +884,10 @@ function SectionTable({
     </div>
   );
 }
+
+/* -------------------------------------------------------------------------- */
+/*                                   Loading                                  */
+/* -------------------------------------------------------------------------- */
 
 function LoadingSkeleton() {
   return (
@@ -778,19 +955,152 @@ function LoadingSkeleton() {
   );
 }
 
+/* -------------------------------------------------------------------------- */
+/*                                Filter widgets                              */
+/* -------------------------------------------------------------------------- */
+
+function FilterDropdown({
+  label,
+  value,
+  options,
+  onChange,
+  ariaLabel,
+}: {
+  label: string;
+  value: string | null;
+  options: Array<{ value: string; label: string }>;
+  onChange: (next: string | null) => void;
+  ariaLabel: string;
+}) {
+  const selected = options.find((o) => o.value === value);
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          className="inline-flex items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 min-w-[140px]"
+        >
+          <span className="truncate">
+            {selected ? (
+              selected.label
+            ) : (
+              <span className="text-muted-foreground">{label}</span>
+            )}
+          </span>
+          <ChevronDown className="h-4 w-4 opacity-50 shrink-0" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-56 p-0">
+        <div className="max-h-64 overflow-y-auto">
+          <button
+            type="button"
+            onClick={() => onChange(null)}
+            className={`w-full flex items-center gap-2 rounded-sm py-1.5 pl-2 pr-2 text-sm hover:bg-accent hover:text-accent-foreground transition-colors text-left cursor-default ${
+              value == null ? "bg-accent/60" : ""
+            }`}
+          >
+            <div className="w-4 h-4 shrink-0 flex items-center justify-center">
+              {value == null && <Check className="h-4 w-4 text-primary" />}
+            </div>
+            <span>{label}</span>
+          </button>
+          {options.map((opt) => {
+            const active = value === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => onChange(opt.value)}
+                className={`w-full flex items-center gap-2 rounded-sm py-1.5 pl-2 pr-2 text-sm hover:bg-accent hover:text-accent-foreground transition-colors text-left cursor-default ${
+                  active ? "bg-accent/60" : ""
+                }`}
+              >
+                <div className="w-4 h-4 shrink-0 flex items-center justify-center">
+                  {active && <Check className="h-4 w-4 text-primary" />}
+                </div>
+                <span className="truncate">{opt.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function PricingToggle({
+  value,
+  onChange,
+}: {
+  value: PricingContext;
+  onChange: (next: PricingContext) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Pricing context"
+      className="inline-flex items-center rounded-md border bg-muted/40 p-0.5 text-xs"
+    >
+      {([
+        { key: "async", label: "Async Pricing" },
+        { key: "batch", label: "Batch Pricing" },
+      ] as const).map((opt) => {
+        const active = value === opt.key;
+        return (
+          <button
+            key={opt.key}
+            role="tab"
+            type="button"
+            aria-selected={active}
+            onClick={() => onChange(opt.key)}
+            className={`px-3 py-1.5 rounded-[5px] transition-colors ${
+              active
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                    Root                                    */
+/* -------------------------------------------------------------------------- */
+
 export const ModelCatalog: React.FC = () => {
   const navigate = useNavigate();
   const { hasPermission } = useAuthorization();
   const canManageGroups = hasPermission("manage-groups");
 
+  const newCutoff = useMemo(() => {
+    const cutoff = new Date();
+    cutoff.setMonth(cutoff.getMonth() - NEW_CUTOFF_MONTHS);
+    return cutoff.toISOString().slice(0, 10);
+  }, []);
+
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [providerFilter, setProviderFilter] = useState<string | null>(null);
+  const [capabilityFilter, setCapabilityFilter] = useState<string | null>(null);
+  const [pricingContext, setPricingContext] = useState<PricingContext>(() => {
+    try {
+      const stored = localStorage.getItem("catalog-pricing-context");
+      return stored === "batch" ? "batch" : "async";
+    } catch {
+      return "async";
+    }
+  });
   const [selectedGroups, setSelectedGroups] = useState<string[]>([
     EVERYONE_GROUP_ID,
   ]);
-  const [expandedRows, setExpandedRows] = useState<Set<string>>(() => {
+  const [expandedFamilies, setExpandedFamilies] = useState<Set<string>>(() => {
     try {
-      const stored = sessionStorage.getItem("catalog-expanded");
+      const stored = sessionStorage.getItem("catalog-expanded-families");
       return stored ? new Set(JSON.parse(stored) as string[]) : new Set();
     } catch {
       return new Set();
@@ -801,11 +1111,18 @@ export const ModelCatalog: React.FC = () => {
   >({});
   const [apiExamplesModel, setApiExamplesModel] = useState<Model | null>(null);
 
-  // Debounce search for server-side filtering
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchQuery), 250);
     return () => clearTimeout(timer);
   }, [searchQuery]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("catalog-pricing-context", pricingContext);
+    } catch {
+      // ignore quota errors
+    }
+  }, [pricingContext]);
 
   const { data: groupsData } = useGroups({
     limit: 100,
@@ -829,6 +1146,74 @@ export const ModelCatalog: React.FC = () => {
   });
   const { data: providerDisplayConfigs = [] } = useProviderDisplayConfigs();
 
+  const providerConfigMap = useMemo(
+    () => new Map(providerDisplayConfigs.map((c) => [c.provider_key, c])),
+    [providerDisplayConfigs],
+  );
+
+  const providerLabelOf = useMemo(
+    () => (providerKey: string) => {
+      const cfg = providerConfigMap.get(providerKey);
+      return cfg?.display_name ?? providerKey;
+    },
+    [providerConfigMap],
+  );
+  const providerIconOf = useMemo(
+    () => (providerKey: string) =>
+      providerConfigMap.get(providerKey)?.icon ?? null,
+    [providerConfigMap],
+  );
+
+  const allModels = useMemo(() => data?.data ?? [], [data?.data]);
+
+  // Derive provider filter options from the model list so we only show
+  // providers that actually have at least one model in the current result.
+  const providerOptions = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const m of allModels) {
+      const key = (m.metadata?.provider?.trim() || "other").toLowerCase();
+      if (!seen.has(key)) {
+        seen.set(key, providerLabelOf(key));
+      }
+    }
+    return Array.from(seen.entries())
+      .map(([value, label]) => ({ value, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [allModels, providerLabelOf]);
+
+  // Apply provider + capability filters client-side so the existing server
+  // hook doesn't need to change. The catalog is in-memory per PRD.
+  const filteredModels = useMemo(() => {
+    return allModels.filter((m) => {
+      if (providerFilter) {
+        const providerKey =
+          (m.metadata?.provider?.trim() || "other").toLowerCase();
+        if (providerKey !== providerFilter) return false;
+      }
+      if (capabilityFilter) {
+        const caps = getDisplayCapabilities(m);
+        if (!caps.includes(capabilityFilter)) return false;
+      }
+      return true;
+    });
+  }, [allModels, providerFilter, capabilityFilter]);
+
+  const sections = useMemo(() => {
+    return MODEL_PURPOSE_SECTIONS.map((section) => ({
+      ...section,
+      families: aggregateFamilies(
+        filteredModels.filter((m) => getCatalogTabForModel(m) === section.type),
+        {
+          newCutoff,
+          context: pricingContext,
+          providerLabelOf,
+          providerIconOf,
+          displayCapabilitiesOf: getDisplayCapabilities,
+        },
+      ),
+    })).filter((s) => s.families.length > 0);
+  }, [filteredModels, newCutoff, pricingContext, providerLabelOf, providerIconOf]);
+
   const handleSort = (tableKey: string, field: ModelSortField) => {
     const defaultDir = DEFAULT_SORT_DIRECTIONS[field] ?? "asc";
     setTableSorts((current) => {
@@ -839,174 +1224,187 @@ export const ModelCatalog: React.FC = () => {
           [tableKey]: { field, direction: defaultDir },
         };
       }
-
       return {
         ...current,
         [tableKey]: {
           field,
-          direction: existing.direction === defaultDir
-            ? (defaultDir === "asc" ? "desc" : "asc")
-            : defaultDir,
+          direction:
+            existing.direction === defaultDir
+              ? defaultDir === "asc"
+                ? "desc"
+                : "asc"
+              : defaultDir,
         },
       };
     });
   };
 
-  const providerConfigMap = useMemo(
-    () => new Map(providerDisplayConfigs.map((config) => [config.provider_key, config])),
-    [providerDisplayConfigs],
-  );
-
-  const sections = useMemo(() => {
-    const all = data?.data || [];
-    return MODEL_PURPOSE_SECTIONS
-      .map((section) => ({
-        ...section,
-        models: all.filter((m) => getCatalogTabForModel(m) === section.type),
-      }))
-      .filter((section) => section.models.length > 0);
-  }, [data?.data]);
-
-  const toggleExpand = (id: string) => {
-    setExpandedRows((prev) => {
+  const toggleExpandFamily = (key: string) => {
+    setExpandedFamilies((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      sessionStorage.setItem("catalog-expanded", JSON.stringify([...next]));
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      try {
+        sessionStorage.setItem(
+          "catalog-expanded-families",
+          JSON.stringify([...next]),
+        );
+      } catch {
+        // ignore quota errors
+      }
       return next;
     });
   };
 
-  const hasAnyFilters = !!debouncedSearch;
+  const hasAnyFilters =
+    !!debouncedSearch || !!providerFilter || !!capabilityFilter;
 
   return (
     <div className="p-3 md:p-4">
-      {/* Header */}
-      <div className="mb-3">
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+      <div className="mb-4">
+        <div className="flex flex-col gap-1">
           <h1 className="text-2xl md:text-3xl font-bold text-doubleword-neutral-900">
             Models
           </h1>
-          <div className="flex items-center gap-3">
-            {canManageGroups && (
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">Group:</span>
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <button
-                      className="inline-flex items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 min-w-[160px]"
-                      aria-label="Filter by group"
-                    >
-                      <span className="flex-1 text-left truncate">
-                        {selectedGroups.length === 0 ? (
-                          <span className="text-muted-foreground">
-                            All groups
-                          </span>
-                        ) : selectedGroups.length === 1 ? (
-                          <span>
-                            {groups.find((g) => g.id === selectedGroups[0])
-                              ?.name || "Everyone"}
-                          </span>
-                        ) : (
-                          <span className="flex gap-1 flex-wrap">
-                            {selectedGroups.map((groupId) => {
-                              const group = groups.find(
-                                (g) => g.id === groupId,
-                              );
-                              return group ? (
-                                <span
-                                  key={groupId}
-                                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-secondary text-secondary-foreground text-xs"
-                                >
-                                  {group.name}
-                                  <X
-                                    className="h-3 w-3 cursor-pointer hover:opacity-70"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      setSelectedGroups(
-                                        selectedGroups.filter(
-                                          (id) => id !== groupId,
-                                        ),
-                                      );
-                                    }}
-                                  />
-                                </span>
-                              ) : null;
-                            })}
-                          </span>
-                        )}
-                      </span>
-                      <ChevronDown className="h-4 w-4 opacity-50 shrink-0 ml-2" />
-                    </button>
-                  </PopoverTrigger>
-                  <PopoverContent align="end" className="w-56 p-0">
-                    <div className="max-h-64 overflow-y-auto">
-                      {groups.length === 0 ? (
-                        <div className="p-3 text-sm text-muted-foreground">
-                          No groups available
-                        </div>
-                      ) : (
-                        groups.map((group) => {
-                          const isSelected = selectedGroups.includes(group.id);
-                          return (
-                            <button
-                              key={group.id}
-                              onClick={() => {
-                                if (isSelected) {
-                                  setSelectedGroups(
-                                    selectedGroups.filter(
-                                      (id) => id !== group.id,
-                                    ),
-                                  );
-                                } else {
-                                  setSelectedGroups([
-                                    ...selectedGroups,
-                                    group.id,
-                                  ]);
-                                }
-                              }}
-                              className="w-full flex items-center gap-2 rounded-sm py-1.5 pl-2 pr-2 text-sm hover:bg-accent hover:text-accent-foreground transition-colors text-left cursor-default"
-                            >
-                              <div className="w-4 h-4 shrink-0 flex items-center justify-center">
-                                {isSelected && (
-                                  <Check className="h-4 w-4 text-primary" />
-                                )}
-                              </div>
-                              <span>{group.name}</span>
-                            </button>
-                          );
-                        })
-                      )}
-                    </div>
-                  </PopoverContent>
-                </Popover>
-              </div>
-            )}
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4 z-10 pointer-events-none" />
-              <Input
-                type="text"
-                placeholder="Search models..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-10 w-full md:w-64"
-                aria-label="Search models"
-              />
-            </div>
-          </div>
+          <p className="text-sm text-muted-foreground">
+            Discover and integrate the latest generation of foundation models.
+          </p>
         </div>
       </div>
-      {/* Content */}
+
+      {!isLoading && allModels.length > 0 && (
+        <FeaturedReleases models={allModels} newCutoff={newCutoff} />
+      )}
+
+      <div className="mb-3 flex flex-wrap items-center gap-2 rounded-lg border bg-background p-2">
+        <div className="relative flex-1 min-w-[180px] max-w-md">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4 z-10 pointer-events-none" />
+          <Input
+            type="text"
+            placeholder="Search models, tags, or IDs..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-10 w-full"
+            aria-label="Search models"
+          />
+        </div>
+
+        <FilterDropdown
+          label="All providers"
+          value={providerFilter}
+          options={providerOptions}
+          onChange={setProviderFilter}
+          ariaLabel="Filter by provider"
+        />
+
+        <FilterDropdown
+          label="All capabilities"
+          value={capabilityFilter}
+          options={FILTERABLE_CAPABILITIES.map((c) => ({
+            value: c.key,
+            label: c.label,
+          }))}
+          onChange={setCapabilityFilter}
+          ariaLabel="Filter by capability"
+        />
+
+        <div className="ml-auto flex items-center gap-2">
+          {canManageGroups && (
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  className="inline-flex items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 min-w-[140px]"
+                  aria-label="Filter by group"
+                >
+                  <span className="flex-1 text-left truncate">
+                    {selectedGroups.length === 0 ? (
+                      <span className="text-muted-foreground">All groups</span>
+                    ) : selectedGroups.length === 1 ? (
+                      <span>
+                        {groups.find((g) => g.id === selectedGroups[0])?.name ||
+                          "Everyone"}
+                      </span>
+                    ) : (
+                      <span className="flex gap-1 flex-wrap">
+                        {selectedGroups.map((groupId) => {
+                          const group = groups.find((g) => g.id === groupId);
+                          return group ? (
+                            <span
+                              key={groupId}
+                              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-secondary text-secondary-foreground text-xs"
+                            >
+                              {group.name}
+                              <X
+                                className="h-3 w-3 cursor-pointer hover:opacity-70"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setSelectedGroups(
+                                    selectedGroups.filter(
+                                      (id) => id !== groupId,
+                                    ),
+                                  );
+                                }}
+                              />
+                            </span>
+                          ) : null;
+                        })}
+                      </span>
+                    )}
+                  </span>
+                  <ChevronDown className="h-4 w-4 opacity-50 shrink-0 ml-2" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-56 p-0">
+                <div className="max-h-64 overflow-y-auto">
+                  {groups.length === 0 ? (
+                    <div className="p-3 text-sm text-muted-foreground">
+                      No groups available
+                    </div>
+                  ) : (
+                    groups.map((group) => {
+                      const isSelected = selectedGroups.includes(group.id);
+                      return (
+                        <button
+                          key={group.id}
+                          onClick={() => {
+                            if (isSelected) {
+                              setSelectedGroups(
+                                selectedGroups.filter((id) => id !== group.id),
+                              );
+                            } else {
+                              setSelectedGroups([...selectedGroups, group.id]);
+                            }
+                          }}
+                          className="w-full flex items-center gap-2 rounded-sm py-1.5 pl-2 pr-2 text-sm hover:bg-accent hover:text-accent-foreground transition-colors text-left cursor-default"
+                        >
+                          <div className="w-4 h-4 shrink-0 flex items-center justify-center">
+                            {isSelected && (
+                              <Check className="h-4 w-4 text-primary" />
+                            )}
+                          </div>
+                          <span>{group.name}</span>
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+          )}
+          <PricingToggle value={pricingContext} onChange={setPricingContext} />
+        </div>
+      </div>
+
       {isLoading ? (
         <LoadingSkeleton />
       ) : sections.length === 0 ? (
         <div className="border rounded-lg py-16 text-center text-muted-foreground">
-          {searchQuery || hasAnyFilters
+          {hasAnyFilters
             ? "No models matching your filters"
             : "No models available"}
         </div>
       ) : (
-        <div className="space-y-4">
+        <div className="space-y-6">
           {sections.map((section) => (
             <div key={section.type}>
               <h2 className="text-sm font-medium text-muted-foreground mb-1.5">
@@ -1014,15 +1412,16 @@ export const ModelCatalog: React.FC = () => {
               </h2>
               <SectionTable
                 tableKey={section.type}
-                models={section.models}
-                providerConfigMap={providerConfigMap}
-                expandedRows={expandedRows}
-                onToggleExpand={toggleExpand}
-                onRowClick={(id) => navigate(`/models/${id}`)}
-                onApiClick={(model) => setApiExamplesModel(model)}
+                families={section.families}
+                newCutoff={newCutoff}
+                context={pricingContext}
+                expandedFamilies={expandedFamilies}
+                onToggleExpand={toggleExpandFamily}
                 sortField={tableSorts[section.type]?.field ?? null}
                 sortDirection={tableSorts[section.type]?.direction ?? null}
                 onSort={handleSort}
+                onRowClick={(m) => navigate(`/models/${m.id}`)}
+                onApiClick={(m) => setApiExamplesModel(m)}
               />
             </div>
           ))}

--- a/dashboard/src/components/features/models/catalog/modelFamily.test.ts
+++ b/dashboard/src/components/features/models/catalog/modelFamily.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+import type { Model, ModelTariff } from "../../../../api/control-layer/types";
+import {
+  aggregateFamilies,
+  getFamilyInfo,
+  getFormatBadges,
+  pickTariffForContext,
+} from "./modelFamily";
+
+function buildModel(overrides: Partial<Model> = {}): Model {
+  return {
+    id: "model-1",
+    alias: "Qwen/Qwen3.5-397B-A17B-FP8",
+    model_name: "Qwen/Qwen3.5-397B-A17B-FP8",
+    model_type: "CHAT",
+    metadata: {
+      provider: "Alibaba",
+    },
+    ...overrides,
+  };
+}
+
+function buildTariff(overrides: Partial<ModelTariff> = {}): ModelTariff {
+  return {
+    id: "t1",
+    deployed_model_id: "m1",
+    name: "default",
+    input_price_per_token: "0.000001",
+    output_price_per_token: "0.000002",
+    valid_from: "2026-01-01T00:00:00Z",
+    valid_until: null,
+    is_active: true,
+    api_key_purpose: "realtime",
+    completion_window: null,
+    ...overrides,
+  };
+}
+
+describe("getFamilyInfo", () => {
+  it("splits Qwen3.5 variants into family + variant", () => {
+    const info = getFamilyInfo(
+      buildModel({ alias: "Qwen/Qwen3.5-397B-A17B-FP8" }),
+    );
+    expect(info.label).toBe("Qwen 3.5");
+    expect(info.variantLabel).toBe("397 B A 17 B FP 8");
+    expect(info.key).toBe("alibaba::qwen3.5");
+  });
+
+  it("groups Qwen3.5 sizes together regardless of quantization", () => {
+    const a = getFamilyInfo(
+      buildModel({ alias: "Qwen/Qwen3.5-397B-A17B-FP8" }),
+    );
+    const b = getFamilyInfo(
+      buildModel({ alias: "Qwen/Qwen3.5-35B-A3B-FP8" }),
+    );
+    expect(a.key).toBe(b.key);
+  });
+
+  it("keeps Qwen3 and Qwen3.5 families distinct", () => {
+    const a = getFamilyInfo(buildModel({ alias: "Qwen/Qwen3-14B-FP8" }));
+    const b = getFamilyInfo(buildModel({ alias: "Qwen/Qwen3.5-35B-A3B-FP8" }));
+    expect(a.key).not.toBe(b.key);
+  });
+
+  it("keeps Qwen3-VL separate from Qwen3 since VL is not a size token", () => {
+    const a = getFamilyInfo(buildModel({ alias: "Qwen/Qwen3-14B-FP8" }));
+    const b = getFamilyInfo(
+      buildModel({ alias: "Qwen/Qwen3-VL-235B-A22B-Instruct-FP8" }),
+    );
+    expect(a.key).not.toBe(b.key);
+  });
+
+  it("handles aliases without a slash", () => {
+    const info = getFamilyInfo(
+      buildModel({
+        alias: "gpt-oss-20b",
+        metadata: { provider: "OpenAI" },
+      }),
+    );
+    expect(info.label).toBe("gpt oss");
+    expect(info.variantLabel).toBe("20 b");
+  });
+
+  it("uses provider from metadata to disambiguate identical stems", () => {
+    const a = getFamilyInfo(
+      buildModel({
+        alias: "X/Foo-7B",
+        metadata: { provider: "Alice" },
+      }),
+    );
+    const b = getFamilyInfo(
+      buildModel({
+        alias: "X/Foo-7B",
+        metadata: { provider: "Bob" },
+      }),
+    );
+    expect(a.key).not.toBe(b.key);
+  });
+});
+
+describe("getFormatBadges", () => {
+  it("returns the explicit quantization when present", () => {
+    const badges = getFormatBadges(
+      buildModel({
+        alias: "Qwen/Qwen3.5-9B",
+        metadata: { provider: "Alibaba", quantization: "FP8" },
+      }),
+    );
+    expect(badges).toEqual(["FP8"]);
+  });
+
+  it("infers quantization from alias tokens as a fallback", () => {
+    const badges = getFormatBadges(
+      buildModel({
+        alias: "Qwen/Qwen3.5-35B-A3B-INT4",
+        metadata: { provider: "Alibaba" },
+      }),
+    );
+    expect(badges).toEqual(["INT4"]);
+  });
+
+  it("returns an empty list when no format is present", () => {
+    const badges = getFormatBadges(
+      buildModel({ alias: "Qwen/Qwen3.5-9B", metadata: null }),
+    );
+    expect(badges).toEqual([]);
+  });
+});
+
+describe("pickTariffForContext", () => {
+  const realtime = buildTariff({
+    id: "rt",
+    api_key_purpose: "realtime",
+    input_price_per_token: "0.000001",
+    output_price_per_token: "0.000002",
+  });
+  const async1h = buildTariff({
+    id: "a1",
+    api_key_purpose: "batch",
+    completion_window: "1h",
+    input_price_per_token: "0.0000008",
+    output_price_per_token: "0.0000016",
+  });
+  const batch24h = buildTariff({
+    id: "b24",
+    api_key_purpose: "batch",
+    completion_window: "24h",
+    input_price_per_token: "0.0000004",
+    output_price_per_token: "0.0000008",
+  });
+  const playground = buildTariff({
+    id: "pg",
+    api_key_purpose: "playground",
+  });
+
+  it("picks the realtime tariff for async context", () => {
+    expect(
+      pickTariffForContext([realtime, async1h, batch24h, playground], "async")
+        ?.id,
+    ).toBe("rt");
+  });
+
+  it("picks the 1h batch tariff when no realtime tariff exists", () => {
+    expect(pickTariffForContext([async1h, batch24h], "async")?.id).toBe("a1");
+  });
+
+  it("picks the 24h batch tariff for batch context", () => {
+    expect(
+      pickTariffForContext([realtime, async1h, batch24h], "batch")?.id,
+    ).toBe("b24");
+  });
+
+  it("ignores playground tariffs", () => {
+    expect(pickTariffForContext([playground], "async")).toBeNull();
+  });
+
+  it("returns null for models without tariffs", () => {
+    expect(pickTariffForContext(null, "async")).toBeNull();
+    expect(pickTariffForContext([], "async")).toBeNull();
+  });
+});
+
+describe("aggregateFamilies", () => {
+  const providerLabelOf = (p: string) =>
+    p === "alibaba" ? "Alibaba" : p === "openai" ? "OpenAI" : p;
+  const providerIconOf = () => null;
+  const displayCapabilitiesOf = (m: Model) =>
+    m.metadata?.display_category === "embedding" ? ["embeddings"] : ["text"];
+
+  it("groups Qwen 3.5 variants into a single family and aggregates stats", () => {
+    const models: Model[] = [
+      buildModel({
+        id: "big",
+        alias: "Qwen/Qwen3.5-397B-A17B-FP8",
+        metadata: {
+          provider: "Alibaba",
+          intelligence_index: 45,
+          context_window: 262144,
+          released_at: "2026-02-16",
+        },
+        tariffs: [
+          buildTariff({
+            id: "big-rt",
+            input_price_per_token: "0.0000015",
+            output_price_per_token: "0.0000030",
+          }),
+        ],
+      }),
+      buildModel({
+        id: "mid",
+        alias: "Qwen/Qwen3.5-35B-A3B-FP8",
+        metadata: {
+          provider: "Alibaba",
+          intelligence_index: 37,
+          context_window: 262144,
+          released_at: "2026-02-24",
+        },
+        tariffs: [
+          buildTariff({
+            id: "mid-rt",
+            input_price_per_token: "0.0000003",
+            output_price_per_token: "0.0000009",
+          }),
+        ],
+      }),
+    ];
+
+    const families = aggregateFamilies(models, {
+      newCutoff: "2026-02-01",
+      context: "async",
+      providerLabelOf,
+      providerIconOf,
+      displayCapabilitiesOf,
+    });
+
+    expect(families).toHaveLength(1);
+    const fam = families[0];
+    expect(fam.label).toBe("Qwen 3.5");
+    expect(fam.variants).toHaveLength(2);
+    expect(fam.intelligenceMin).toBe(37);
+    expect(fam.intelligenceMax).toBe(45);
+    expect(fam.contextMax).toBe(262144);
+    expect(fam.priceFrom).toBeCloseTo(0.0000003);
+    expect(fam.releasedAt).toBe("2026-02-24");
+    expect(fam.hasNewVariant).toBe(true);
+  });
+
+  it("sorts variants by intelligence descending within a family", () => {
+    const models: Model[] = [
+      buildModel({
+        id: "small",
+        alias: "Qwen/Qwen3.5-9B",
+        metadata: { provider: "Alibaba", intelligence_index: 20 },
+      }),
+      buildModel({
+        id: "big",
+        alias: "Qwen/Qwen3.5-397B-A17B-FP8",
+        metadata: { provider: "Alibaba", intelligence_index: 45 },
+      }),
+    ];
+
+    const families = aggregateFamilies(models, {
+      newCutoff: "2099-01-01",
+      context: "async",
+      providerLabelOf,
+      providerIconOf,
+      displayCapabilitiesOf,
+    });
+
+    expect(families[0].variants.map((v) => v.id)).toEqual(["big", "small"]);
+  });
+
+  it("orders families by most recent release first", () => {
+    const models: Model[] = [
+      buildModel({
+        id: "older",
+        alias: "Old/Old-9B",
+        metadata: { provider: "Old", released_at: "2024-01-01" },
+      }),
+      buildModel({
+        id: "newer",
+        alias: "New/New-9B",
+        metadata: { provider: "New", released_at: "2026-04-01" },
+      }),
+    ];
+
+    const families = aggregateFamilies(models, {
+      newCutoff: "2026-01-01",
+      context: "async",
+      providerLabelOf: (p) => p,
+      providerIconOf,
+      displayCapabilitiesOf,
+    });
+
+    expect(families.map((f) => f.label)).toEqual(["New", "Old"]);
+  });
+});

--- a/dashboard/src/components/features/models/catalog/modelFamily.test.ts
+++ b/dashboard/src/components/features/models/catalog/modelFamily.test.ts
@@ -153,25 +153,83 @@ describe("pickTariffForContext", () => {
     api_key_purpose: "playground",
   });
 
-  it("picks the realtime tariff for async context", () => {
+  it("picks the realtime tariff for async context regardless of input order", () => {
     expect(
       pickTariffForContext([realtime, async1h, batch24h, playground], "async")
+        ?.id,
+    ).toBe("rt");
+    // The bug was that find() returned whichever matching tariff came first
+    // in the array, so the realtime preference was order-dependent.
+    expect(
+      pickTariffForContext([async1h, realtime, batch24h, playground], "async")
+        ?.id,
+    ).toBe("rt");
+    expect(
+      pickTariffForContext([batch24h, async1h, realtime, playground], "async")
         ?.id,
     ).toBe("rt");
   });
 
   it("picks the 1h batch tariff when no realtime tariff exists", () => {
     expect(pickTariffForContext([async1h, batch24h], "async")?.id).toBe("a1");
+    expect(pickTariffForContext([batch24h, async1h], "async")?.id).toBe("a1");
   });
 
-  it("picks the 24h batch tariff for batch context", () => {
+  it("falls back to a 24h batch tariff for async when no realtime/1h exists", () => {
+    expect(pickTariffForContext([batch24h], "async")?.id).toBe("b24");
+  });
+
+  it("picks the 24h batch tariff for batch context regardless of input order", () => {
     expect(
       pickTariffForContext([realtime, async1h, batch24h], "batch")?.id,
     ).toBe("b24");
+    expect(
+      pickTariffForContext([batch24h, async1h, realtime], "batch")?.id,
+    ).toBe("b24");
+    expect(
+      pickTariffForContext([async1h, batch24h, realtime], "batch")?.id,
+    ).toBe("b24");
+  });
+
+  it("falls back to the 1h batch tariff for batch context when no 24h exists", () => {
+    expect(pickTariffForContext([realtime, async1h], "batch")?.id).toBe("a1");
+  });
+
+  it("falls back to a realtime tariff for batch context when no batch tariff exists", () => {
+    expect(pickTariffForContext([realtime], "batch")?.id).toBe("rt");
+  });
+
+  it("breaks ties between equally-ranked tariffs by cheaper input price", () => {
+    const cheapRealtime = buildTariff({
+      id: "rt-cheap",
+      api_key_purpose: "realtime",
+      input_price_per_token: "0.0000005",
+      output_price_per_token: "0.0000010",
+    });
+    const expensiveRealtime = buildTariff({
+      id: "rt-expensive",
+      api_key_purpose: "realtime",
+      input_price_per_token: "0.0000020",
+      output_price_per_token: "0.0000040",
+    });
+    expect(
+      pickTariffForContext([expensiveRealtime, cheapRealtime], "async")?.id,
+    ).toBe("rt-cheap");
+    expect(
+      pickTariffForContext([cheapRealtime, expensiveRealtime], "async")?.id,
+    ).toBe("rt-cheap");
   });
 
   it("ignores playground tariffs", () => {
     expect(pickTariffForContext([playground], "async")).toBeNull();
+  });
+
+  it("ignores inactive tariffs", () => {
+    const inactive = buildTariff({
+      id: "rt-old",
+      is_active: false,
+    });
+    expect(pickTariffForContext([inactive], "async")).toBeNull();
   });
 
   it("returns null for models without tariffs", () => {

--- a/dashboard/src/components/features/models/catalog/modelFamily.ts
+++ b/dashboard/src/components/features/models/catalog/modelFamily.ts
@@ -122,26 +122,64 @@ export function getFormatBadges(model: Model): string[] {
  */
 export type PricingContext = "async" | "batch";
 
-function tariffMatchesContext(
+/**
+ * Rank a tariff for the given pricing context. Lower score = better match.
+ *
+ * The ranking is intentionally total so that the result of
+ * `pickTariffForContext` is independent of the order in which the backend
+ * returns tariffs. When multiple tariffs match the ideal shape (e.g. two
+ * realtime tariffs) we break ties by input price (cheaper wins) so behaviour
+ * is still deterministic.
+ *
+ * Preference order:
+ *
+ *   Async context
+ *     1. realtime
+ *     2. batch + 1h
+ *     3. any other batch (24h / 48h / null) — fallback so the cell isn't blank
+ *     4. anything else visible
+ *
+ *   Batch context
+ *     1. batch + 24h
+ *     2. batch + 48h
+ *     3. batch + null  (legacy rows that predate completion_window)
+ *     4. batch + 1h    (fallback only)
+ *     5. realtime      (fallback only)
+ *     6. anything else visible
+ */
+function tariffPriority(
   tariff: Pick<ModelTariff, "api_key_purpose" | "completion_window">,
   context: PricingContext,
-): boolean {
+): number {
   const purpose = tariff.api_key_purpose ?? "realtime";
+  const window = tariff.completion_window;
+
   if (context === "async") {
-    return purpose === "realtime" || (purpose === "batch" && tariff.completion_window === "1h");
+    if (purpose === "realtime") return 0;
+    if (purpose === "batch" && window === "1h") return 1;
+    if (purpose === "batch") return 2;
+    return 10;
   }
+
   // context === "batch"
-  return (
-    purpose === "batch" &&
-    (tariff.completion_window == null || tariff.completion_window === "24h" ||
-      tariff.completion_window === "48h")
-  );
+  if (purpose === "batch" && window === "24h") return 0;
+  if (purpose === "batch" && window === "48h") return 1;
+  if (purpose === "batch" && window == null) return 2;
+  if (purpose === "batch" && window === "1h") return 3;
+  if (purpose === "realtime") return 4;
+  return 10;
 }
 
 /**
  * Pick the tariff that best represents the given pricing context for a model.
- * Falls back across tariffs if the preferred combination isn't available so
- * that the cost column always has something to show when any pricing exists.
+ *
+ * Visible tariffs (non-playground, active) are scored with `tariffPriority`
+ * and the lowest-scoring one is returned. If multiple tariffs tie on score
+ * (e.g. a model with two realtime rows) the cheaper input price wins so the
+ * catalog's "from $X/M" aggregation stays stable.
+ *
+ * Returns `null` when the model has no user-facing tariffs at all — callers
+ * render a dash in that case.
  */
 export function pickTariffForContext(
   tariffs: ModelTariff[] | undefined | null,
@@ -153,19 +191,21 @@ export function pickTariffForContext(
   );
   if (visible.length === 0) return null;
 
-  const preferred = visible.find((t) => tariffMatchesContext(t, context));
-  if (preferred) return preferred;
-
-  // Fallbacks: if the user asked for batch but we only have realtime, still
-  // show something rather than a dash.
-  if (context === "batch") {
-    const anyBatch = visible.find((t) => t.api_key_purpose === "batch");
-    if (anyBatch) return anyBatch;
-  } else {
-    const anyRealtime = visible.find((t) => t.api_key_purpose === "realtime");
-    if (anyRealtime) return anyRealtime;
+  let best: ModelTariff | null = null;
+  let bestScore = Infinity;
+  let bestPrice = Infinity;
+  for (const t of visible) {
+    const score = tariffPriority(t, context);
+    if (score > bestScore) continue;
+    const price = parseFloat(t.input_price_per_token);
+    const priceKey = Number.isFinite(price) ? price : Infinity;
+    if (score < bestScore || priceKey < bestPrice) {
+      best = t;
+      bestScore = score;
+      bestPrice = priceKey;
+    }
   }
-  return visible[0];
+  return best;
 }
 
 export interface AggregatedFamily {

--- a/dashboard/src/components/features/models/catalog/modelFamily.ts
+++ b/dashboard/src/components/features/models/catalog/modelFamily.ts
@@ -1,0 +1,306 @@
+import type { Model, ModelTariff } from "../../../../api/control-layer/types";
+
+/**
+ * Utilities for grouping model variants into families on the catalog page.
+ *
+ * A "family" is a group of variants that share a common base (e.g. all the
+ * "Qwen 3.5" sizes / quantizations). The user sees a single collapsed row
+ * per family and can expand to see the specific variants.
+ *
+ * The approach is heuristic: we split the model alias on `-` and treat the
+ * tokens up to (but not including) the first size token (e.g. `397B`, `20b`,
+ * `A17B`) as the family name, and everything from the size token onwards as
+ * the variant label.
+ */
+
+export interface FamilyInfo {
+  /** Stable case-insensitive key used for grouping. */
+  key: string;
+  /** Human-friendly family label (e.g. "Qwen 3.5"). */
+  label: string;
+  /** Human-friendly variant label (e.g. "397B A17B FP8"). */
+  variantLabel: string;
+}
+
+const SIZE_TOKEN_RE = /^\d+(\.\d+)?[bm]$|^a\d+b$/i;
+
+function isSizeToken(token: string): boolean {
+  return SIZE_TOKEN_RE.test(token);
+}
+
+/**
+ * Insert spaces between letters and adjacent digits so that e.g. "Qwen3.5"
+ * becomes "Qwen 3.5". Hyphens are preserved (they are converted to spaces by
+ * callers that want a fully-humanized label).
+ */
+function humanizeToken(token: string): string {
+  return token.replace(/([A-Za-z])(\d)/g, "$1 $2").replace(/(\d)([A-Za-z])/g, "$1 $2");
+}
+
+/**
+ * Derive family / variant info from a model.
+ *
+ * Groups by provider + family stem so that "Alibaba/Qwen3.5-*" models get
+ * lumped together but "Alibaba/Qwen3-*" and "Alibaba/Qwen3-VL-*" stay
+ * separate (since VL is not a size token and so is part of the family stem).
+ */
+export function getFamilyInfo(model: Model): FamilyInfo {
+  const alias = model.alias || model.model_name || "";
+  const slashIdx = alias.lastIndexOf("/");
+  const aliasProvider = slashIdx >= 0 ? alias.slice(0, slashIdx) : "";
+  const stem = slashIdx >= 0 ? alias.slice(slashIdx + 1) : alias;
+  const provider =
+    (model.metadata?.provider || aliasProvider || "").trim() || "Unknown";
+
+  const tokens = stem.split("-").filter(Boolean);
+  if (tokens.length === 0) {
+    return {
+      key: `${provider}::${alias}`.toLowerCase(),
+      label: alias || "Unknown",
+      variantLabel: "",
+    };
+  }
+
+  let firstSizeIdx = tokens.findIndex(isSizeToken);
+  // Must have at least one family token before the size token; if the alias
+  // starts with a size token we treat the full stem as the family.
+  if (firstSizeIdx <= 0) firstSizeIdx = -1;
+
+  const familyTokens =
+    firstSizeIdx === -1 ? tokens : tokens.slice(0, firstSizeIdx);
+  const variantTokens =
+    firstSizeIdx === -1 ? [] : tokens.slice(firstSizeIdx);
+
+  const familyStem = familyTokens.join("-");
+
+  const key = `${provider}::${familyStem}`.toLowerCase();
+
+  // Family label: humanize each token and join with spaces. e.g. "Qwen3.5" ->
+  // "Qwen 3.5", "gpt-oss" -> "gpt oss".
+  const label = familyTokens.map(humanizeToken).join(" ") || stem;
+
+  const variantLabel = variantTokens.map(humanizeToken).join(" ");
+
+  return { key, label, variantLabel };
+}
+
+/**
+ * Return true if the alias contains a recognisable quantization / format
+ * marker (e.g. FP8, INT4).
+ */
+const QUANT_TOKENS = new Set([
+  "fp8",
+  "fp16",
+  "bf16",
+  "int4",
+  "int8",
+  "awq",
+  "gptq",
+]);
+
+export function getFormatBadges(model: Model): string[] {
+  const badges: string[] = [];
+  if (model.metadata?.quantization) {
+    badges.push(model.metadata.quantization);
+    return badges;
+  }
+  const stem =
+    model.alias.split("/").pop() || model.model_name.split("/").pop() || "";
+  const tokens = stem.split("-");
+  for (const token of tokens) {
+    if (QUANT_TOKENS.has(token.toLowerCase())) {
+      badges.push(token.toUpperCase());
+    }
+  }
+  return badges;
+}
+
+/**
+ * Pricing contexts surfaced on the catalog. The Doubleword platform exposes
+ * both "Async" (realtime / 1h batch) and "Batch" (24h+) tariffs and users
+ * want to flip between them at the top of the table.
+ */
+export type PricingContext = "async" | "batch";
+
+function tariffMatchesContext(
+  tariff: Pick<ModelTariff, "api_key_purpose" | "completion_window">,
+  context: PricingContext,
+): boolean {
+  const purpose = tariff.api_key_purpose ?? "realtime";
+  if (context === "async") {
+    return purpose === "realtime" || (purpose === "batch" && tariff.completion_window === "1h");
+  }
+  // context === "batch"
+  return (
+    purpose === "batch" &&
+    (tariff.completion_window == null || tariff.completion_window === "24h" ||
+      tariff.completion_window === "48h")
+  );
+}
+
+/**
+ * Pick the tariff that best represents the given pricing context for a model.
+ * Falls back across tariffs if the preferred combination isn't available so
+ * that the cost column always has something to show when any pricing exists.
+ */
+export function pickTariffForContext(
+  tariffs: ModelTariff[] | undefined | null,
+  context: PricingContext,
+): ModelTariff | null {
+  if (!tariffs || tariffs.length === 0) return null;
+  const visible = tariffs.filter(
+    (t) => t.api_key_purpose !== "playground" && t.is_active !== false,
+  );
+  if (visible.length === 0) return null;
+
+  const preferred = visible.find((t) => tariffMatchesContext(t, context));
+  if (preferred) return preferred;
+
+  // Fallbacks: if the user asked for batch but we only have realtime, still
+  // show something rather than a dash.
+  if (context === "batch") {
+    const anyBatch = visible.find((t) => t.api_key_purpose === "batch");
+    if (anyBatch) return anyBatch;
+  } else {
+    const anyRealtime = visible.find((t) => t.api_key_purpose === "realtime");
+    if (anyRealtime) return anyRealtime;
+  }
+  return visible[0];
+}
+
+export interface AggregatedFamily {
+  key: string;
+  label: string;
+  /** Provider key shared by all children (or the first child's provider if mixed). */
+  provider: string;
+  providerLabel: string;
+  providerIcon?: string | null;
+  variants: Model[];
+  /** Min / max intelligence index across variants. */
+  intelligenceMin: number | null;
+  intelligenceMax: number | null;
+  /** Max context window across variants. */
+  contextMax: number | null;
+  /** Cheapest input price (per token) across variants for the current pricing context. */
+  priceFrom: number | null;
+  /** Latest release date across variants (YYYY-MM-DD). */
+  releasedAt: string | null;
+  /** Union of display capabilities across variants. */
+  capabilities: string[];
+  /** True if any child was released within the "new" window. */
+  hasNewVariant: boolean;
+}
+
+export interface AggregateOptions {
+  newCutoff: string; // YYYY-MM-DD
+  context: PricingContext;
+  providerLabelOf: (provider: string) => string;
+  providerIconOf: (provider: string) => string | null | undefined;
+  displayCapabilitiesOf: (model: Model) => string[];
+}
+
+/**
+ * Reduce a flat list of models into family groups ordered by a sensible
+ * default (latest release first, then label ascending).
+ */
+export function aggregateFamilies(
+  models: Model[],
+  options: AggregateOptions,
+): AggregatedFamily[] {
+  const map = new Map<string, AggregatedFamily>();
+
+  for (const model of models) {
+    const info = getFamilyInfo(model);
+    const providerKey = (model.metadata?.provider?.trim() || "Other").toLowerCase();
+    const providerLabel = options.providerLabelOf(providerKey);
+    const providerIcon = options.providerIconOf(providerKey);
+
+    let family = map.get(info.key);
+    if (!family) {
+      family = {
+        key: info.key,
+        label: info.label,
+        provider: providerKey,
+        providerLabel,
+        providerIcon,
+        variants: [],
+        intelligenceMin: null,
+        intelligenceMax: null,
+        contextMax: null,
+        priceFrom: null,
+        releasedAt: null,
+        capabilities: [],
+        hasNewVariant: false,
+      };
+      map.set(info.key, family);
+    }
+
+    family.variants.push(model);
+
+    const intel = model.metadata?.intelligence_index ?? null;
+    if (intel != null) {
+      family.intelligenceMin =
+        family.intelligenceMin == null
+          ? intel
+          : Math.min(family.intelligenceMin, intel);
+      family.intelligenceMax =
+        family.intelligenceMax == null
+          ? intel
+          : Math.max(family.intelligenceMax, intel);
+    }
+
+    const ctx = model.metadata?.context_window ?? null;
+    if (ctx != null) {
+      family.contextMax =
+        family.contextMax == null ? ctx : Math.max(family.contextMax, ctx);
+    }
+
+    const tariff = pickTariffForContext(model.tariffs, options.context);
+    if (tariff) {
+      const price = parseFloat(tariff.input_price_per_token);
+      if (Number.isFinite(price)) {
+        family.priceFrom =
+          family.priceFrom == null ? price : Math.min(family.priceFrom, price);
+      }
+    }
+
+    const released = model.metadata?.released_at ?? null;
+    if (released) {
+      family.releasedAt =
+        !family.releasedAt || released > family.releasedAt
+          ? released
+          : family.releasedAt;
+      if (released >= options.newCutoff) {
+        family.hasNewVariant = true;
+      }
+    }
+
+    for (const cap of options.displayCapabilitiesOf(model)) {
+      if (!family.capabilities.includes(cap)) {
+        family.capabilities.push(cap);
+      }
+    }
+  }
+
+  const result = Array.from(map.values());
+  result.sort((a, b) => {
+    if (a.releasedAt && b.releasedAt && a.releasedAt !== b.releasedAt) {
+      return b.releasedAt.localeCompare(a.releasedAt);
+    }
+    if (a.releasedAt && !b.releasedAt) return -1;
+    if (!a.releasedAt && b.releasedAt) return 1;
+    return a.label.localeCompare(b.label);
+  });
+
+  // Sort variants within each family: by intelligence desc, then size desc
+  for (const family of result) {
+    family.variants.sort((a, b) => {
+      const ai = a.metadata?.intelligence_index ?? -Infinity;
+      const bi = b.metadata?.intelligence_index ?? -Infinity;
+      if (ai !== bi) return bi - ai;
+      return a.alias.localeCompare(b.alias);
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
Revamps the dashboard Models catalog to group model variants into expandable “families”, add a featured section, and introduce an async/batch pricing context toggle.

Changes:

Added catalog utilities to derive model families, infer format badges, and deterministically select the best tariff for a pricing context.
Reworked ModelCatalog UI to render family parent rows + variant rows, add featured releases, and add provider/capability filters plus a pricing context toggle with persistence.
Updated dashboard README with project-specific setup, structure, and testing conventions.

Replaces PR 1020 which was merged from main not feature branch. 