### PR TITLE
fix: filter priority from queue metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2082,7 +2082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2292,9 +2292,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "16.6.0"
+version = "16.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f7881d158dbfdf017cb39d446a472b12a6d0d650b91fd8fb9f1b0170605973"
+checksum = "8d6cd5b1e00dbf1716e6fe8fa2b0f44342a31e030e4536ac41378f4cbf2a8dda"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3699,7 +3699,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5130,7 +5130,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5201,7 +5201,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5664,7 +5664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6047,7 +6047,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6973,7 +6973,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "16.6.0" }
+fusillade = { version = "16.6.1" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/dwctl/src/api/handlers/queue.rs
+++ b/dwctl/src/api/handlers/queue.rs
@@ -4,6 +4,7 @@
 
 use axum::{extract::State, response::Json};
 use fusillade::Storage;
+use fusillade::request::ServiceTierFilter;
 use sqlx_pool_router::PoolProvider;
 use std::collections::HashMap;
 
@@ -25,6 +26,9 @@ type PendingCountsByModelAndWindow = HashMap<String, HashMap<String, i64>>;
 /// - Escalated requests (racing duplicate requests)
 /// - Requests without a template_id
 /// - Requests in batches being cancelled
+/// - Realtime requests (`service_tier = 'priority'`), which are managed
+///   externally rather than by the fusillade daemon and so should not drive
+///   GPU scheduling decisions.
 ///
 /// Useful for monitoring queue depth and load distribution across models.
 #[utoipa::path(
@@ -52,10 +56,17 @@ pub async fn get_pending_request_counts<P: PoolProvider>(
         .collect::<Vec<_>>();
     let states = vec!["pending".to_string(), "claimed".to_string(), "processing".to_string()]; // Include claimed and processing to get a more complete picture of queue depth
     let model_filter: Vec<String> = Vec::new();
+    let service_tier_filter = ServiceTierFilter::Exclude(vec![Some("priority".to_string())]);
 
     let counts = state
         .request_manager
-        .get_pending_request_counts_by_model_and_window(&windows, &states, &model_filter, false)
+        .get_pending_request_counts_by_model_and_window(
+            &windows,
+            &states,
+            &model_filter,
+            &service_tier_filter,
+            false,
+        )
         .await
         .map_err(|e| Error::Internal {
             operation: format!("get pending request counts: {}", e),

--- a/dwctl/src/api/handlers/queue.rs
+++ b/dwctl/src/api/handlers/queue.rs
@@ -60,13 +60,7 @@ pub async fn get_pending_request_counts<P: PoolProvider>(
 
     let counts = state
         .request_manager
-        .get_pending_request_counts_by_model_and_window(
-            &windows,
-            &states,
-            &model_filter,
-            &service_tier_filter,
-            false,
-        )
+        .get_pending_request_counts_by_model_and_window(&windows, &states, &model_filter, &service_tier_filter, false)
         .await
         .map_err(|e| Error::Internal {
             operation: format!("get pending request counts: {}", e),

--- a/dwctl/src/api/handlers/queue.rs
+++ b/dwctl/src/api/handlers/queue.rs
@@ -118,4 +118,86 @@ mod tests {
         // Should be empty when no requests exist
         assert_eq!(counts.len(), 0, "Should have no pending requests");
     }
+
+    #[sqlx::test]
+    async fn test_pending_request_counts_excludes_priority_service_tier(pool: PgPool) {
+        use fusillade::{CreateSingleRequestBatchInput, Storage};
+        use sqlx::postgres::PgConnectOptions;
+        use sqlx_pool_router::TestDbPools;
+
+        let (server, _bg): (TestServer, _) = create_test_app(pool.clone(), false).await;
+        let admin = create_test_admin_user(&pool, Role::PlatformManager).await;
+
+        // Connect a request_manager to the same `fusillade` schema the app
+        // uses. Migrations are already run by the app's setup_database.
+        let base_opts: PgConnectOptions = pool.connect_options().as_ref().clone();
+        let fusillade_pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(2)
+            .min_connections(0)
+            .connect_with(base_opts.options([("search_path", "fusillade")]))
+            .await
+            .expect("Failed to create fusillade pool");
+        let fusillade_pools = TestDbPools::new(fusillade_pool.clone()).await.expect("TestDbPools");
+        let request_manager = fusillade::PostgresRequestManager::new(fusillade_pools, Default::default());
+
+        // Create three single-request batches for the same model with
+        // different completion windows. fusillade derives service_tier from
+        // completion_window:
+        //   "24h" → service_tier IS NULL (batch tier — counted)
+        //   "1h"  → service_tier = 'flex'   (counted)
+        //   "0s"  → service_tier = 'priority' (EXCLUDED — managed externally)
+        let model = "test-model";
+        let mut batch_ids = Vec::new();
+        for completion_window in ["24h", "1h", "0s"] {
+            let batch_id = uuid::Uuid::new_v4();
+            request_manager
+                .create_single_request_batch(CreateSingleRequestBatchInput {
+                    batch_id: Some(batch_id),
+                    request_id: uuid::Uuid::new_v4(),
+                    body: r#"{"input":"x"}"#.to_string(),
+                    model: model.to_string(),
+                    base_url: "http://localhost".to_string(),
+                    endpoint: "/v1/chat/completions".to_string(),
+                    completion_window: completion_window.to_string(),
+                    initial_state: "pending".to_string(),
+                    api_key: None,
+                    created_by: None,
+                })
+                .await
+                .expect("create single-request batch");
+            batch_ids.push(batch_id);
+        }
+
+        // Pin all expires_at into the configured 24h window so the deadline
+        // predicate matches deterministically regardless of the original
+        // completion_window.
+        for batch_id in &batch_ids {
+            sqlx::query("UPDATE batches SET expires_at = NOW() + interval '30 minutes' WHERE id = $1")
+                .bind(batch_id)
+                .execute(&fusillade_pool)
+                .await
+                .expect("pin expires_at");
+        }
+
+        let response = server
+            .get("/admin/api/v1/monitoring/pending-request-counts")
+            .add_header(&add_auth_headers(&admin)[0].0, &add_auth_headers(&admin)[0].1)
+            .add_header(&add_auth_headers(&admin)[1].0, &add_auth_headers(&admin)[1].1)
+            .await;
+
+        response.assert_status_ok();
+        let counts: HashMap<String, HashMap<String, i64>> = response.json();
+
+        // The default test config queries the "24h" window only. All three
+        // batches expire in 30 min so they all fall inside it. Priority must
+        // be excluded; batch + flex remain.
+        let model_counts = counts
+            .get(model)
+            .unwrap_or_else(|| panic!("expected '{model}' in response, got {counts:?}"));
+        let count_24h = *model_counts.get("24h").unwrap_or(&0);
+        assert_eq!(
+            count_24h, 2,
+            "expected 2 (batch + flex) within 24h window — priority must be excluded; got {count_24h} ({model_counts:?})"
+        );
+    }
 }

--- a/dwctl/src/api/handlers/sla_capacity.rs
+++ b/dwctl/src/api/handlers/sla_capacity.rs
@@ -190,6 +190,7 @@ pub(crate) async fn reserve_capacity<P: sqlx_pool_router::PoolProvider>(
 ) -> Result<Vec<Uuid>, CapacityError> {
     use crate::db::handlers::BatchCapacityReservations;
     use fusillade::Storage;
+    use fusillade::request::ServiceTierFilter;
 
     let mut tx = dwctl_pool
         .begin()
@@ -230,8 +231,17 @@ pub(crate) async fn reserve_capacity<P: sqlx_pool_router::PoolProvider>(
     let states = vec!["pending".to_string(), "claimed".to_string(), "processing".to_string()];
     let model_filter: Vec<String> = input.file_model_counts.keys().cloned().collect();
 
+    // Exclude realtime (`priority`) requests: they're processed externally
+    // (not via the fusillade daemon) and should not consume batch capacity
+    // when admitting new batches.
     let pending_counts: HashMap<String, HashMap<String, i64>> = request_manager
-        .get_pending_request_counts_by_model_and_window(&windows, &states, &model_filter, true)
+        .get_pending_request_counts_by_model_and_window(
+            &windows,
+            &states,
+            &model_filter,
+            &ServiceTierFilter::Exclude(vec![Some("priority".to_string())]),
+            true,
+        )
         .await
         .map_err(|e| CapacityError::Internal(format!("get pending counts: {e}")))?;
 


### PR DESCRIPTION
**Changes**:
  - dwctl/Cargo.toml:22 — fusillade = { version = "16.6.1" }.
  - queue.rs — ServiceTierFilter::Exclude(vec![Some("priority".to_string())]) for the monitoring endpoint.
  - sla_capacity.rs — corrected to ServiceTierFilter::Exclude(vec![Some("priority".to_string())]) per your callout. Realtime requests are processed externally, so they shouldn't consume
  batch admission capacity. Comment updated to reflect the new reasoning.