### PR TITLE
fix: guard rendering of optional group description

### DIFF
--- a/dashboard/src/components/features/users-groups/UsersGroups/UsersGroups.tsx
+++ b/dashboard/src/components/features/users-groups/UsersGroups/UsersGroups.tsx
@@ -613,9 +613,11 @@ const UsersGroups: React.FC = () => {
                       />
                     </div>
                   </div>
-                  <p className="text-sm text-doubleword-neutral-600 mb-4 wrap-break-word">
-                    {group.description}
-                  </p>
+                  {group.description && (
+                    <p className="text-sm text-doubleword-neutral-600 mb-4 wrap-break-word">
+                      {group.description}
+                    </p>
+                  )}
                   <div className="flex items-center justify-start pt-4 border-t border-doubleword-neutral-100">
                     <div className="flex -space-x-2">
                       {group.memberIds.slice(0, 4).map((memberId) => {

--- a/dashboard/src/components/modals/UserGroupsModal/UserGroupsModal.tsx
+++ b/dashboard/src/components/modals/UserGroupsModal/UserGroupsModal.tsx
@@ -207,8 +207,8 @@ export const UserGroupsModal: React.FC<UserGroupsModalProps> = ({
                           {group.name}
                         </h4>
                         <p className="text-sm text-gray-500">
-                          {group.description} • {group.users?.length || 0}{" "}
-                          members
+                          {group.description && `${group.description} • `}
+                          {group.users?.length || 0} members
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Closes #137 — wraps the optional `group.description` field in a render guard so missing descriptions don't leave behind empty markup.
- `UsersGroups.tsx` (group card view): an undefined description was rendering an empty `<p>` with `mb-4`, producing inconsistent spacing between cards.
- `UserGroupsModal.tsx`: the description shared a line with the member count via " • ", so an absent description left a stranded ` • N members`. Bullet now only renders when description exists.

Other description renders called out in the issue (Models, Endpoints, Notifications, Combobox) were already correctly guarded — verified via grep — so no additional changes were needed.

## Test plan
- [ ] Visual check on Users & Groups page: cards with no description should not have a phantom margin row.
- [ ] Visual check on UserGroupsModal: groups without a description should display only `N members` (no leading bullet).
- [ ] `just lint ts` / `just test ts` pass in CI.