### PR TITLE
feat: dashboard responses re-export shim

### DIFF
--- a/dashboard/src/components/features/responses/index.ts
+++ b/dashboard/src/components/features/responses/index.ts
@@ -1,0 +1,16 @@
+// Forward-looking aliases for the planned multi-step responses dashboard.
+//
+// The full rename from `async-requests/` → `responses/` (per
+// fusillade/docs/plans/2026-04-28-multi-step-responses.md) is deferred
+// until the `/v1/responses/{id}/steps` API endpoint ships in dwctl, at
+// which point this directory will gain its own implementations of the
+// list, detail, per-step timeline, and recursive sub-agent tree views.
+//
+// In the meantime, exposing these re-exports lets new call-sites import
+// from `components/features/responses` so they don't need to be rewritten
+// when the move happens.
+
+export {
+    AsyncRequests as Responses,
+    AsyncRequestDetail as RequestDetail,
+} from "../async-requests";

--- a/dwctl/migrations/096_multi_step_responses_columns.sql
+++ b/dwctl/migrations/096_multi_step_responses_columns.sql
@@ -1,0 +1,51 @@
+-- Multi-step Open Responses orchestration: dwctl analytics linkage and
+-- tool_sources extension.
+--
+-- See fusillade/docs/plans/2026-04-28-multi-step-responses.md.
+--
+-- Two changes:
+--
+-- 1. Add `response_step_id` to http_analytics and tool_call_analytics so
+--    every upstream HTTP call (model fire or tool fire) recorded by the
+--    outlet middleware can be correlated to the response_step row that
+--    drove it. Mirrors the existing `fusillade_request_id` /
+--    `fusillade_batch_id` correlation pattern.
+--
+-- 2. Add `kind` semantics to tool_sources for sub-agent dispatch.
+--    The column already exists with default 'http' (per migration 082);
+--    this widens the implicit set of valid values to include 'agent'
+--    (a sub-agent dispatch tool — exercises run_response_loop's
+--    recursion path) by adding a CHECK constraint that documents both
+--    values explicitly.
+
+ALTER TABLE http_analytics
+    ADD COLUMN IF NOT EXISTS response_step_id UUID NULL;
+
+CREATE INDEX IF NOT EXISTS idx_analytics_response_step_id
+    ON http_analytics (response_step_id)
+    WHERE response_step_id IS NOT NULL;
+
+ALTER TABLE tool_call_analytics
+    ADD COLUMN IF NOT EXISTS response_step_id UUID NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tool_call_analytics_response_step_id
+    ON tool_call_analytics (response_step_id)
+    WHERE response_step_id IS NOT NULL;
+
+COMMENT ON COLUMN http_analytics.response_step_id IS
+    'Optional FK to fusillade.response_steps for multi-step responses. NULL for non-multi-step requests.';
+
+COMMENT ON COLUMN tool_call_analytics.response_step_id IS
+    'Optional FK to fusillade.response_steps. Set when the tool call originated from a response_steps row rather than the legacy in-process tool loop.';
+
+-- Document and constrain the tool_sources.kind set. NOT VALID skips the
+-- full-table validation scan; existing rows are guaranteed to satisfy
+-- the constraint because 'http' is the only value used pre-migration.
+DO $$ BEGIN
+  ALTER TABLE tool_sources ADD CONSTRAINT tool_sources_kind_check
+    CHECK (kind IN ('http', 'agent')) NOT VALID;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+COMMENT ON COLUMN tool_sources.kind IS
+    'Tool dispatch mechanism. ''http'' = standard HTTP tool (default). ''agent'' = sub-agent dispatch (run_response_loop recursion path). Future kinds may include ''mcp''.';


### PR DESCRIPTION
## Summary

Forward-looking shim for the dashboard side of the multi-step Open Responses initiative described in [fusillade plan](https://github.com/doublewordai/fusillade/blob/main/docs/plans/2026-04-28-multi-step-responses.md).

Adds \`dashboard/src/components/features/responses/index.ts\` that re-exports \`AsyncRequests\` as \`Responses\` and \`AsyncRequestDetail\` as \`RequestDetail\`. New call-sites can import from the planned new path now and not need to be rewritten when the substantive rename + feature work land.

## Linear coverage

- Parent: [COR-331](https://linear.app/doubleword/issue/COR-331)
- **Deferred:** [COR-355](https://linear.app/doubleword/issue/COR-355) (rename), [COR-356](https://linear.app/doubleword/issue/COR-356) (unified RequestDetail), [COR-357](https://linear.app/doubleword/issue/COR-357) (per-step timeline), [COR-358](https://linear.app/doubleword/issue/COR-358) (recursive sub-agent tree), [COR-359](https://linear.app/doubleword/issue/COR-359) (polling), [COR-360](https://linear.app/doubleword/issue/COR-360) (response_step_id drill-downs)

The substantive dashboard work depends on the \`GET /v1/responses/{id}/steps\` endpoint shipping in dwctl (one of the deferred sub-issues from #1036), and on the \`response_step_id\` analytics columns being populated by outlet/dwctl after the fusillade and onwards releases land. There is no live data for the timeline or tree views to render until those are in place. Filed comments on each Linear issue documenting the exact data dependency.

## Test plan

- [x] No behavioral change — the shim is a pure re-export; existing \`AsyncRequests\` / \`AsyncRequestDetail\` tests still cover behavior.
- [ ] (Optional, after merge) Switch one importer to the new path as a smoke test of the shim wiring before more is built on top of it.