### PR TITLE
feat(monitoring): add fairness query param to pending-request-counts

### DIFF
--- a/docs/SCOUTER.md
+++ b/docs/SCOUTER.md
@@ -16,3 +16,44 @@
   - Claimed requests are excluded
   - Escalated requests are excluded
   - Counts are correct across multiple models and completion windows
+
+## Fairness-aware Mode (`?fairness=true`)
+
+The endpoint accepts an optional `fairness` query parameter:
+
+- `GET /admin/api/v1/monitoring/pending-request-counts` — raw pending counts (default).
+- `GET /admin/api/v1/monitoring/pending-request-counts?fairness=true` — counts with each user's contribution capped at the bucket's average.
+
+### Policy
+
+For each `(model, completion_window)` bucket:
+
+- `p_u` = pending count for user `u` (only users with `p_u > 0`).
+- `U` = number of such users.
+- `T` = `sum(p_u)`.
+- `fair_share` = `max(1, ceil(T / U))`.
+- `effective(u)` = `min(p_u, fair_share)`.
+- `effective_count` = `sum(effective(u))`.
+
+Properties:
+
+- Reduces to `T` when demand is balanced across users.
+- Caps a single dominant user's contribution at the bucket average so the
+  reported depth does not over-state demand a per-user fair scheduler will
+  throttle.
+- Stateless wrt in-flight counts — pure function of pending rows.
+
+### Contract with `claim_requests`
+
+The fairness-aware count is intended to stay directionally aligned with the
+per-user fairness ordering applied by `fusillade::Storage::claim_requests`.
+Both call sites carry a comment block referencing each other; the integration
+test `test_effective_counts_track_claim_order` in `fusillade` will fail if
+the policies drift in opposite directions.
+
+If you change either policy:
+
+1. Update the SQL in both `claim_requests` and
+   `get_effective_pending_request_counts_by_model_and_window`.
+2. Update the policy block in this doc.
+3. Re-run the drift-detector test.

--- a/dwctl/src/api/handlers/queue.rs
+++ b/dwctl/src/api/handlers/queue.rs
@@ -2,9 +2,13 @@
 //!
 //! Endpoints for querying queue depth and pending request metrics from fusillade.
 
-use axum::{extract::State, response::Json};
+use axum::{
+    extract::{Query, State},
+    response::Json,
+};
 use fusillade::Storage;
 use fusillade::request::ServiceTierFilter;
+use serde::Deserialize;
 use sqlx_pool_router::PoolProvider;
 use std::collections::HashMap;
 
@@ -19,6 +23,16 @@ use crate::{
 /// Nested map of pending request counts: model -> completion_window -> count
 type PendingCountsByModelAndWindow = HashMap<String, HashMap<String, i64>>;
 
+/// Query parameters accepted by `get_pending_request_counts`.
+#[derive(Debug, Deserialize, Default)]
+pub struct PendingCountsQuery {
+    /// When true, apply the per-user fair-share policy described in
+    /// `fusillade::Storage::get_effective_pending_request_counts_by_model_and_window`.
+    /// When false or omitted, return raw pending counts.
+    #[serde(default)]
+    pub fairness: bool,
+}
+
 /// Get pending, claimed, and processing request counts grouped by model and completion window
 ///
 /// Returns a nested map showing how many pending requests are queued for each
@@ -27,22 +41,31 @@ type PendingCountsByModelAndWindow = HashMap<String, HashMap<String, i64>>;
 /// - Requests without a template_id
 /// - Requests in batches being cancelled
 /// - Realtime requests (`service_tier = 'priority'`), which are managed
-///   externally rather than by the fusillade daemon and so should not drive
-///   GPU scheduling decisions.
+///   externally and so should not appear in queue depth.
 ///
-/// Useful for monitoring queue depth and load distribution across models.
+/// **Query parameters:**
+/// - `fairness` (bool, default `false`): when `true`, returns *effective*
+///   counts where each user's contribution to a (model, window) bucket is
+///   capped at that bucket's average pending count. See the trait method
+///   `get_effective_pending_request_counts_by_model_and_window` for the
+///   exact policy. Use this mode when the consumer needs a depth signal
+///   that reflects per-user fair scheduling rather than raw queue length.
 #[utoipa::path(
     get,
     path = "/admin/api/v1/monitoring/pending-request-counts",
+    params(
+        ("fairness" = Option<bool>, Query, description = "Apply per-user fair-share cap")
+    ),
     responses(
         (status = 200, description = "Pending request counts by model and completion window", body = HashMap<String, HashMap<String, i64>>),
         (status = 500, description = "Internal server error"),
     ),
     tag = "monitoring",
 )]
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, fields(fairness = q.fairness))]
 pub async fn get_pending_request_counts<P: PoolProvider>(
     State(state): State<AppState<P>>,
+    Query(q): Query<PendingCountsQuery>,
     _: RequiresPermission<resource::System, operation::ReadAll>,
 ) -> Result<Json<PendingCountsByModelAndWindow>, Error> {
     let config = state.current_config();
@@ -58,13 +81,20 @@ pub async fn get_pending_request_counts<P: PoolProvider>(
     let model_filter: Vec<String> = Vec::new();
     let service_tier_filter = ServiceTierFilter::Exclude(vec![Some("priority".to_string())]);
 
-    let counts = state
-        .request_manager
-        .get_pending_request_counts_by_model_and_window(&windows, &states, &model_filter, &service_tier_filter, false)
-        .await
-        .map_err(|e| Error::Internal {
-            operation: format!("get pending request counts: {}", e),
-        })?;
+    let counts = if q.fairness {
+        state
+            .request_manager
+            .get_effective_pending_request_counts_by_model_and_window(&windows, &states, &model_filter, &service_tier_filter, false)
+            .await
+    } else {
+        state
+            .request_manager
+            .get_pending_request_counts_by_model_and_window(&windows, &states, &model_filter, &service_tier_filter, false)
+            .await
+    }
+    .map_err(|e| Error::Internal {
+        operation: format!("get pending request counts: {}", e),
+    })?;
 
     Ok(Json(counts))
 }
@@ -199,5 +229,84 @@ mod tests {
             count_24h, 2,
             "expected 2 (batch + flex) within 24h window — priority must be excluded; got {count_24h} ({model_counts:?})"
         );
+    }
+
+    #[sqlx::test]
+    async fn test_pending_request_counts_fairness_caps_dominant_user(pool: PgPool) {
+        use fusillade::{CreateSingleRequestBatchInput, Storage};
+        use sqlx::postgres::PgConnectOptions;
+        use sqlx_pool_router::TestDbPools;
+
+        let (server, _bg): (TestServer, _) = create_test_app(pool.clone(), false).await;
+        let admin = create_test_admin_user(&pool, Role::PlatformManager).await;
+
+        let base_opts: PgConnectOptions = pool.connect_options().as_ref().clone();
+        let fusillade_pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(2)
+            .min_connections(0)
+            .connect_with(base_opts.options([("search_path", "fusillade")]))
+            .await
+            .expect("Failed to create fusillade pool");
+        let fusillade_pools = TestDbPools::new(fusillade_pool.clone()).await.expect("TestDbPools");
+        let request_manager = fusillade::PostgresRequestManager::new(fusillade_pools, Default::default());
+
+        // user-a: 6 pending; user-b: 2 pending; one model.
+        async fn seed(
+            mgr: &fusillade::PostgresRequestManager<sqlx_pool_router::TestDbPools, fusillade::http::ReqwestHttpClient>,
+            user: &str,
+            n: usize,
+        ) -> Vec<uuid::Uuid> {
+            let mut ids = Vec::new();
+            for _ in 0..n {
+                let batch_id = uuid::Uuid::new_v4();
+                mgr.create_single_request_batch(CreateSingleRequestBatchInput {
+                    batch_id: Some(batch_id),
+                    request_id: uuid::Uuid::new_v4(),
+                    body: r#"{"input":"x"}"#.to_string(),
+                    model: "model-x".to_string(),
+                    base_url: "http://localhost".to_string(),
+                    endpoint: "/v1/chat/completions".to_string(),
+                    completion_window: "24h".to_string(),
+                    initial_state: "pending".to_string(),
+                    api_key: None,
+                    created_by: Some(user.to_string()),
+                })
+                .await
+                .expect("create batch");
+                ids.push(batch_id);
+            }
+            ids
+        }
+
+        let mut all = seed(&request_manager, "user-a", 6).await;
+        all.extend(seed(&request_manager, "user-b", 2).await);
+        // Pin expires_at into the 24h window
+        for batch_id in &all {
+            sqlx::query("UPDATE batches SET expires_at = NOW() + interval '30 minutes' WHERE id = $1")
+                .bind(batch_id)
+                .execute(&fusillade_pool)
+                .await
+                .expect("pin expires_at");
+        }
+
+        // Raw: total = 8
+        let resp = server
+            .get("/admin/api/v1/monitoring/pending-request-counts")
+            .add_header(&add_auth_headers(&admin)[0].0, &add_auth_headers(&admin)[0].1)
+            .add_header(&add_auth_headers(&admin)[1].0, &add_auth_headers(&admin)[1].1)
+            .await;
+        resp.assert_status_ok();
+        let raw: HashMap<String, HashMap<String, i64>> = resp.json();
+        assert_eq!(*raw.get("model-x").unwrap().get("24h").unwrap(), 8);
+
+        // Fairness: fair_share=ceil(8/2)=4 → effective = 4 + 2 = 6
+        let resp = server
+            .get("/admin/api/v1/monitoring/pending-request-counts?fairness=true")
+            .add_header(&add_auth_headers(&admin)[0].0, &add_auth_headers(&admin)[0].1)
+            .add_header(&add_auth_headers(&admin)[1].0, &add_auth_headers(&admin)[1].1)
+            .await;
+        resp.assert_status_ok();
+        let eff: HashMap<String, HashMap<String, i64>> = resp.json();
+        assert_eq!(*eff.get("model-x").unwrap().get("24h").unwrap(), 6);
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `?fairness=true` query parameter to `GET /admin/api/v1/monitoring/pending-request-counts`.

When set, each user's contribution to a `(model, completion_window)` bucket is capped at the bucket's average pending count, so a single dominant user cannot inflate the reported depth beyond what a per-user fair scheduler will actually drain. Default behaviour (flag absent) is unchanged.

### Policy

For each `(model, window)` bucket:
- `p_u` = pending count for user `u` (only users with `p_u > 0`)
- `U` = number of such users
- `T` = `sum(p_u)`
- `fair_share` = `max(1, ceil(T / U))`
- `effective(u)` = `min(p_u, fair_share)`
- `effective_count` = `sum(effective(u))`

Reduces to `T` when demand is balanced; caps a dominant user's contribution at the bucket average otherwise.

## Dependencies

Depends on the upstream fusillade trait method `get_effective_pending_request_counts_by_model_and_window`:
👉 https://github.com/doublewordai/fusillade/pull/251

CI will fail until that PR ships and `dwctl/Cargo.toml` is bumped to the new fusillade release. The new dependency was verified locally against the fusillade branch via `[patch.crates-io]`.

## Test plan

- [x] New handler test `test_pending_request_counts_fairness_caps_dominant_user` passes locally
- [x] Existing `queue::tests` (4 tests including the new one) all pass
- [x] `just lint rust` passes (with local fusillade patch)
- [ ] Re-run CI once fusillade is released and bumped here