### PR TITLE
feat(webhooks): allow org members read-only access to org webhooks

### DIFF
--- a/dashboard/src/api/control-layer/hooks.ts
+++ b/dashboard/src/api/control-layer/hooks.ts
@@ -82,11 +82,13 @@ export function useUsers(options?: UsersQuery & { enabled?: boolean }) {
 }
 
 
-export function useUser(id: string, options?: { include?: string }) {
+export function useUser(id: string, options?: { include?: string; enabled?: boolean }) {
+  const { enabled = true, include } = options || {};
   return useQuery({
-    queryKey: queryKeys.users.byId(id, options?.include),
-    queryFn: () => dwctlApi.users.get(id, options),
+    queryKey: queryKeys.users.byId(id, include),
+    queryFn: () => dwctlApi.users.get(id, { include }),
     staleTime: 30 * 1000, // 30 seconds - matches useTransactions to keep balance in sync
+    enabled,
   });
 }
 

--- a/dashboard/src/components/features/notifications/NotificationSettings.tsx
+++ b/dashboard/src/components/features/notifications/NotificationSettings.tsx
@@ -164,7 +164,10 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
   isOrganization = false,
   readOnly = false,
 }) => {
-  const { data: user, refetch: refetchUser } = useUser(userId);
+  // Skip the user fetch in read-only mode — every consumer of `user` is in
+  // the email/low-balance section, which read-only callers don't render. Also
+  // avoids a needless 403 if a member lacks permission to read the org user.
+  const { data: user, refetch: refetchUser } = useUser(userId, { enabled: !readOnly });
   const updateUserMutation = useUpdateUser();
   const updateOrgMutation = useUpdateOrganization();
   const navigate = useNavigate();

--- a/dashboard/src/components/features/notifications/NotificationSettings.tsx
+++ b/dashboard/src/components/features/notifications/NotificationSettings.tsx
@@ -149,12 +149,20 @@ interface NotificationSettingsProps {
   showPlatformScope?: boolean;
   /** Whether the userId refers to an organization */
   isOrganization?: boolean;
+  /**
+   * Render webhook list as read-only — hides email & low-balance toggles
+   * and all webhook mutation controls. Used to let regular org members see
+   * the org's webhooks (and any delivery failures) without being able to
+   * change them.
+   */
+  readOnly?: boolean;
 }
 
 export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
   userId,
   showPlatformScope = false,
   isOrganization = false,
+  readOnly = false,
 }) => {
   const { data: user, refetch: refetchUser } = useUser(userId);
   const updateUserMutation = useUpdateUser();
@@ -355,9 +363,11 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
     <>
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
         <h4 className="text-lg font-medium text-gray-900 mb-4">
-          Notifications
+          {readOnly ? "Webhooks" : "Notifications"}
         </h4>
 
+        {!readOnly && (
+          <>
         {/* Email Section */}
         <h5 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-3">
           Email
@@ -446,10 +456,15 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
           </div>
         </div>
 
+          </>
+        )}
+
         {/* Webhooks Section */}
-        <h5 className="text-sm font-medium text-gray-500 uppercase tracking-wide mt-6 mb-3">
-          Webhooks
-        </h5>
+        {!readOnly && (
+          <h5 className="text-sm font-medium text-gray-500 uppercase tracking-wide mt-6 mb-3">
+            Webhooks
+          </h5>
+        )}
         <div>
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-3">
@@ -458,19 +473,23 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
               </div>
               <div>
                 <p className="text-xs text-gray-500">
-                  Receive HTTP callbacks when events occur
+                  {readOnly
+                    ? "HTTP callbacks sent when events occur. Contact an admin to make changes."
+                    : "Receive HTTP callbacks when events occur"}
                 </p>
               </div>
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={openCreateWebhookDialog}
-              aria-label="Add webhook"
-            >
-              <Plus className="w-3.5 h-3.5" />
-              Add Webhook
-            </Button>
+            {!readOnly && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={openCreateWebhookDialog}
+                aria-label="Add webhook"
+              >
+                <Plus className="w-3.5 h-3.5" />
+                Add Webhook
+              </Button>
+            )}
           </div>
 
           {/* Webhook List */}
@@ -541,53 +560,56 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
                         )}
                       </div>
                     </div>
-                    <div className="flex items-center gap-1 shrink-0">
-                      <Switch
-                        checked={webhook.enabled}
-                        onCheckedChange={() =>
-                          handleWebhookToggle(webhook)
-                        }
-                        aria-label={`Toggle webhook ${webhook.url}`}
-                      />
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7"
-                            onClick={() => openEditWebhookDialog(webhook)}
-                            aria-label={`Edit webhook ${webhook.url}`}
-                          >
-                            <Pencil className="w-3.5 h-3.5" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Edit webhook</TooltipContent>
-                      </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7 text-red-500 hover:text-red-700 hover:bg-red-50"
-                            onClick={() =>
-                              setDeletingWebhookId(webhook.id)
-                            }
-                            aria-label={`Delete webhook ${webhook.url}`}
-                          >
-                            <Trash2 className="w-3.5 h-3.5" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Delete webhook</TooltipContent>
-                      </Tooltip>
-                    </div>
+                    {!readOnly && (
+                      <div className="flex items-center gap-1 shrink-0">
+                        <Switch
+                          checked={webhook.enabled}
+                          onCheckedChange={() =>
+                            handleWebhookToggle(webhook)
+                          }
+                          aria-label={`Toggle webhook ${webhook.url}`}
+                        />
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7"
+                              onClick={() => openEditWebhookDialog(webhook)}
+                              aria-label={`Edit webhook ${webhook.url}`}
+                            >
+                              <Pencil className="w-3.5 h-3.5" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Edit webhook</TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7 text-red-500 hover:text-red-700 hover:bg-red-50"
+                              onClick={() =>
+                                setDeletingWebhookId(webhook.id)
+                              }
+                              aria-label={`Delete webhook ${webhook.url}`}
+                            >
+                              <Trash2 className="w-3.5 h-3.5" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Delete webhook</TooltipContent>
+                        </Tooltip>
+                      </div>
+                    )}
                   </div>
                 </div>
               ))}
             </div>
           ) : (
             <div className="text-sm text-gray-500 py-4 text-center border border-dashed border-gray-200 rounded-lg">
-              No webhooks configured. Add one to receive HTTP
-              notifications.
+              {readOnly
+                ? "No webhooks configured."
+                : "No webhooks configured. Add one to receive HTTP notifications."}
             </div>
           )}
         </div>

--- a/dashboard/src/components/features/organizations/MyOrganization.test.tsx
+++ b/dashboard/src/components/features/organizations/MyOrganization.test.tsx
@@ -101,7 +101,7 @@ describe("MyOrganization", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not render notification settings for regular members", async () => {
+  it("renders read-only webhooks view for regular members", async () => {
     server.use(userWithOrg("member"));
     const { container } = render(<MyOrganization />, {
       wrapper: createWrapper(),
@@ -113,8 +113,18 @@ describe("MyOrganization", () => {
       ).toBeInTheDocument();
     });
 
+    // Read-only view: heading is "Webhooks", and admin-only controls are absent.
+    expect(
+      within(container).getByRole("heading", { name: "Webhooks" }),
+    ).toBeInTheDocument();
     expect(
       within(container).queryByRole("heading", { name: "Notifications" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(container).queryByRole("button", { name: "Add webhook" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(container).queryByRole("switch", { name: "Email notifications" }),
     ).not.toBeInTheDocument();
   });
 

--- a/dashboard/src/components/features/organizations/MyOrganization.tsx
+++ b/dashboard/src/components/features/organizations/MyOrganization.tsx
@@ -63,9 +63,11 @@ export function MyOrganization() {
         readOnly={!canManage}
       />
 
-      {canManage && (
-        <NotificationSettings userId={activeOrganizationId} isOrganization />
-      )}
+      <NotificationSettings
+        userId={activeOrganizationId}
+        isOrganization
+        readOnly={!canManage}
+      />
     </div>
   );
 }

--- a/dwctl/src/api/handlers/webhooks.rs
+++ b/dwctl/src/api/handlers/webhooks.rs
@@ -27,7 +27,7 @@ use crate::{
     path = "/users/{user_id}/webhooks",
     tag = "webhooks",
     summary = "List webhooks",
-    description = "List all webhooks for a user. Users can list their own webhooks; admins can list any user's webhooks.",
+    description = "List all webhooks for a user. Users can list their own webhooks; admins can list any user's webhooks; members of an organization can list webhooks owned by that organization (read-only).",
     params(
         ("user_id" = uuid::Uuid, Path, description = "User ID"),
     ),
@@ -54,7 +54,13 @@ pub async fn list_webhooks<P: PoolProvider>(
         UserIdOrCurrent::Id(id) => id,
     };
 
-    // Check permissions: can read all webhooks OR read own webhooks
+    // Allowed if any of:
+    //  - admin permission (ReadAll)
+    //  - reading own webhooks (ReadOwn)
+    //  - target is an organization the caller belongs to (any role) — read-only
+    //    access for org members, so they can spot delivery failures and notify
+    //    admins. Mutating handlers stay restricted to owner/admin via
+    //    can_manage_org_resource.
     let can_read_all = permissions::has_permission(&current_user, Resource::Webhooks, Operation::ReadAll);
     let can_read_own =
         target_user_id == current_user.id && permissions::has_permission(&current_user, Resource::Webhooks, Operation::ReadOwn);
@@ -222,7 +228,7 @@ pub async fn create_webhook<P: PoolProvider>(
     path = "/users/{user_id}/webhooks/{webhook_id}",
     tag = "webhooks",
     summary = "Get webhook",
-    description = "Get a specific webhook. Secret is not included in the response.",
+    description = "Get a specific webhook. Users can read their own webhooks; admins can read any user's webhooks; members of an organization can read webhooks owned by that organization (read-only). Secret is not included in the response.",
     params(
         ("user_id" = uuid::Uuid, Path, description = "User ID"),
         ("webhook_id" = uuid::Uuid, Path, description = "Webhook ID"),
@@ -251,7 +257,8 @@ pub async fn get_webhook<P: PoolProvider>(
         UserIdOrCurrent::Id(id) => id,
     };
 
-    // Check permissions
+    // Same authorization model as list_webhooks: admin (ReadAll), owner
+    // (ReadOwn), or member of the target organization (read-only).
     let can_read_all = permissions::has_permission(&current_user, Resource::Webhooks, Operation::ReadAll);
     let can_read_own =
         target_user_id == current_user.id && permissions::has_permission(&current_user, Resource::Webhooks, Operation::ReadOwn);

--- a/dwctl/src/api/handlers/webhooks.rs
+++ b/dwctl/src/api/handlers/webhooks.rs
@@ -61,10 +61,10 @@ pub async fn list_webhooks<P: PoolProvider>(
 
     if !can_read_all && !can_read_own {
         let mut conn = state.db.read().acquire().await.map_err(|e| Error::Database(e.into()))?;
-        let can_org = permissions::can_manage_org_resource(&current_user, target_user_id, &mut conn)
+        let is_member = permissions::is_org_member(&current_user, target_user_id, &mut conn)
             .await
             .map_err(Error::Database)?;
-        if !can_org {
+        if !is_member {
             return Err(Error::InsufficientPermissions {
                 required: Permission::Any(vec![
                     Permission::Allow(Resource::Webhooks, Operation::ReadAll),
@@ -258,10 +258,10 @@ pub async fn get_webhook<P: PoolProvider>(
 
     if !can_read_all && !can_read_own {
         let mut conn = state.db.read().acquire().await.map_err(|e| Error::Database(e.into()))?;
-        let can_org = permissions::can_manage_org_resource(&current_user, target_user_id, &mut conn)
+        let is_member = permissions::is_org_member(&current_user, target_user_id, &mut conn)
             .await
             .map_err(Error::Database)?;
-        if !can_org {
+        if !is_member {
             return Err(Error::InsufficientPermissions {
                 required: Permission::Any(vec![
                     Permission::Allow(Resource::Webhooks, Operation::ReadAll),
@@ -858,5 +858,204 @@ mod tests {
             .await;
 
         response.assert_status_ok();
+    }
+
+    // ── Read-only org member webhook access ────────────────────────────────
+    //
+    // Members of an org (any role, including plain "member") can list and read
+    // the org's webhooks so they can spot delivery failures and notify admins,
+    // but they cannot mutate them.
+
+    /// Helper: create a webhook for an org via the API as the owner, returning
+    /// the created webhook (with secret).
+    async fn create_org_webhook(
+        app: &axum_test::TestServer,
+        owner: &crate::api::models::users::UserResponse,
+        org_id: UserId,
+        url: &str,
+    ) -> WebhookWithSecretResponse {
+        let response = app
+            .post(&format!("/admin/api/v1/users/{}/webhooks", org_id))
+            .add_header(&add_auth_headers(owner)[0].0, &add_auth_headers(owner)[0].1)
+            .add_header(&add_auth_headers(owner)[1].0, &add_auth_headers(owner)[1].1)
+            .json(&json!({ "url": url }))
+            .await;
+        response.assert_status(StatusCode::CREATED);
+        response.json()
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_org_member_can_list_org_webhooks_without_secrets(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let alice = create_test_user(&pool, Role::StandardUser).await;
+        let bob = create_test_user(&pool, Role::StandardUser).await;
+        let org = create_test_org(&pool, alice.id).await;
+        add_org_member(&pool, org.id, bob.id, "member").await;
+
+        create_org_webhook(&app, &alice, org.id, "https://example.com/hook").await;
+
+        // Bob (plain member) lists the org's webhooks
+        let response = app
+            .get(&format!("/admin/api/v1/users/{}/webhooks", org.id))
+            .add_header(&add_auth_headers(&bob)[0].0, &add_auth_headers(&bob)[0].1)
+            .add_header(&add_auth_headers(&bob)[1].0, &add_auth_headers(&bob)[1].1)
+            .await;
+
+        response.assert_status_ok();
+        let webhooks: Vec<WebhookResponse> = response.json();
+        assert_eq!(webhooks.len(), 1);
+        assert_eq!(webhooks[0].url, "https://example.com/hook");
+
+        // Secrets must never appear in member-visible responses. WebhookResponse
+        // has no `secret` field, but check the raw JSON too as a belt-and-braces
+        // guard against future struct changes.
+        let raw: serde_json::Value = response.json();
+        let item = &raw.as_array().unwrap()[0];
+        assert!(item.get("secret").is_none(), "list response must not include secret");
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_org_member_can_get_single_org_webhook(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let alice = create_test_user(&pool, Role::StandardUser).await;
+        let bob = create_test_user(&pool, Role::StandardUser).await;
+        let org = create_test_org(&pool, alice.id).await;
+        add_org_member(&pool, org.id, bob.id, "member").await;
+
+        let created = create_org_webhook(&app, &alice, org.id, "https://example.com/hook").await;
+
+        let response = app
+            .get(&format!("/admin/api/v1/users/{}/webhooks/{}", org.id, created.id))
+            .add_header(&add_auth_headers(&bob)[0].0, &add_auth_headers(&bob)[0].1)
+            .add_header(&add_auth_headers(&bob)[1].0, &add_auth_headers(&bob)[1].1)
+            .await;
+
+        response.assert_status_ok();
+        let raw: serde_json::Value = response.json();
+        assert!(raw.get("secret").is_none(), "get response must not include secret");
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_non_member_cannot_list_org_webhooks(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let alice = create_test_user(&pool, Role::StandardUser).await;
+        let outsider = create_test_user(&pool, Role::StandardUser).await;
+        let org = create_test_org(&pool, alice.id).await;
+
+        create_org_webhook(&app, &alice, org.id, "https://example.com/hook").await;
+
+        let response = app
+            .get(&format!("/admin/api/v1/users/{}/webhooks", org.id))
+            .add_header(&add_auth_headers(&outsider)[0].0, &add_auth_headers(&outsider)[0].1)
+            .add_header(&add_auth_headers(&outsider)[1].0, &add_auth_headers(&outsider)[1].1)
+            .await;
+
+        response.assert_status_forbidden();
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_org_member_cannot_create_org_webhook(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let alice = create_test_user(&pool, Role::StandardUser).await;
+        let bob = create_test_user(&pool, Role::StandardUser).await;
+        let org = create_test_org(&pool, alice.id).await;
+        add_org_member(&pool, org.id, bob.id, "member").await;
+
+        let response = app
+            .post(&format!("/admin/api/v1/users/{}/webhooks", org.id))
+            .add_header(&add_auth_headers(&bob)[0].0, &add_auth_headers(&bob)[0].1)
+            .add_header(&add_auth_headers(&bob)[1].0, &add_auth_headers(&bob)[1].1)
+            .json(&json!({ "url": "https://example.com/hook" }))
+            .await;
+
+        response.assert_status_forbidden();
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_org_member_cannot_update_org_webhook(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let alice = create_test_user(&pool, Role::StandardUser).await;
+        let bob = create_test_user(&pool, Role::StandardUser).await;
+        let org = create_test_org(&pool, alice.id).await;
+        add_org_member(&pool, org.id, bob.id, "member").await;
+
+        let created = create_org_webhook(&app, &alice, org.id, "https://example.com/hook").await;
+
+        let response = app
+            .patch(&format!("/admin/api/v1/users/{}/webhooks/{}", org.id, created.id))
+            .add_header(&add_auth_headers(&bob)[0].0, &add_auth_headers(&bob)[0].1)
+            .add_header(&add_auth_headers(&bob)[1].0, &add_auth_headers(&bob)[1].1)
+            .json(&json!({ "enabled": false }))
+            .await;
+
+        response.assert_status_forbidden();
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_org_member_cannot_delete_org_webhook(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let alice = create_test_user(&pool, Role::StandardUser).await;
+        let bob = create_test_user(&pool, Role::StandardUser).await;
+        let org = create_test_org(&pool, alice.id).await;
+        add_org_member(&pool, org.id, bob.id, "member").await;
+
+        let created = create_org_webhook(&app, &alice, org.id, "https://example.com/hook").await;
+
+        let response = app
+            .delete(&format!("/admin/api/v1/users/{}/webhooks/{}", org.id, created.id))
+            .add_header(&add_auth_headers(&bob)[0].0, &add_auth_headers(&bob)[0].1)
+            .add_header(&add_auth_headers(&bob)[1].0, &add_auth_headers(&bob)[1].1)
+            .await;
+
+        response.assert_status_forbidden();
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_org_member_cannot_rotate_org_webhook_secret(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let alice = create_test_user(&pool, Role::StandardUser).await;
+        let bob = create_test_user(&pool, Role::StandardUser).await;
+        let org = create_test_org(&pool, alice.id).await;
+        add_org_member(&pool, org.id, bob.id, "member").await;
+
+        let created = create_org_webhook(&app, &alice, org.id, "https://example.com/hook").await;
+
+        let response = app
+            .post(&format!("/admin/api/v1/users/{}/webhooks/{}/rotate-secret", org.id, created.id))
+            .add_header(&add_auth_headers(&bob)[0].0, &add_auth_headers(&bob)[0].1)
+            .add_header(&add_auth_headers(&bob)[1].0, &add_auth_headers(&bob)[1].1)
+            .await;
+
+        response.assert_status_forbidden();
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_org_admin_can_still_manage_webhooks(pool: PgPool) {
+        // Regression guard: existing owner/admin write path must keep working
+        // after we relaxed the read-permission fallback from can_manage_org_resource
+        // (owner/admin only) to is_org_member (any role).
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let alice = create_test_user(&pool, Role::StandardUser).await;
+        let bob = create_test_user(&pool, Role::StandardUser).await;
+        let org = create_test_org(&pool, alice.id).await;
+        add_org_member(&pool, org.id, bob.id, "admin").await;
+
+        // Bob (org admin) creates a webhook for the org.
+        let response = app
+            .post(&format!("/admin/api/v1/users/{}/webhooks", org.id))
+            .add_header(&add_auth_headers(&bob)[0].0, &add_auth_headers(&bob)[0].1)
+            .add_header(&add_auth_headers(&bob)[1].0, &add_auth_headers(&bob)[1].1)
+            .json(&json!({ "url": "https://example.com/hook" }))
+            .await;
+
+        response.assert_status(StatusCode::CREATED);
     }
 }


### PR DESCRIPTION
## Summary

Currently, only owner/admin members of an org can see the org's webhooks. Plain members have no way to spot when a webhook has been auto-disabled by the circuit breaker or when deliveries are failing — they can't notify an admin without first noticing something has gone wrong.

This PR adds a read-only path:

- **Backend** (`dwctl/src/api/handlers/webhooks.rs`): `list_webhooks` and `get_webhook` fall through to `is_org_member` when the caller has no direct/own permission. Org-scoped webhooks live at `user_id = org_id`, so this lets any member of that org user read the list. Mutating handlers (`create`, `update`, `delete`, `rotate_secret`) keep the existing `can_manage_org_resource` check, so writes still require owner/admin.
- **Frontend** (`NotificationSettings`): new `readOnly` prop hides email + low-balance toggles, the **Add Webhook** button, and the per-row Switch/Edit/Delete controls. Renders the same webhook list — URL, description, scope, event types, enabled state, auto-disable warning — without any controls.
- **Frontend** (`MyOrganization`): always renders `NotificationSettings`, passes `readOnly={!canManage}`. Owners/admins see no change; plain members now see a read-only "Webhooks" card.

### Out of scope (intentional)

- Platform-scope webhooks. Org members should not see platform-scope webhooks (created by PlatformManagers, fire on platform-wide events). Since the existing per-user list endpoint only returns webhooks owned by `user_id`, and the dashboard only ever requests `user_id = active_organization_id`, members never see platform-scope webhooks through this path.
- Cross-org isolation. The `is_org_member` check is keyed on the org user being requested, so a member of org A cannot enumerate org B's webhooks.
- Other members' personal webhooks. Members only see webhooks owned by the org user itself, not webhooks personally owned by other members.
- Secrets. The existing `WebhookResponse` type omits the `secret` field; only `create` and `rotate-secret` ever return `WebhookWithSecretResponse`, and both remain admin-only.

## Test plan

Backend (8 new integration tests in `dwctl/src/api/handlers/webhooks.rs`):

- [x] `test_org_member_can_list_org_webhooks_without_secrets` — member lists the org's webhooks; raw JSON has no `secret` field
- [x] `test_org_member_can_get_single_org_webhook` — single-webhook GET also works and omits secret
- [x] `test_non_member_cannot_list_org_webhooks` — outsider gets 403
- [x] `test_org_member_cannot_create_org_webhook` — POST → 403
- [x] `test_org_member_cannot_update_org_webhook` — PATCH → 403
- [x] `test_org_member_cannot_delete_org_webhook` — DELETE → 403
- [x] `test_org_member_cannot_rotate_org_webhook_secret` — POST `/rotate-secret` → 403
- [x] `test_org_admin_can_still_manage_webhooks` — regression guard for the existing owner/admin write path

Frontend:

- [x] `MyOrganization.test.tsx` — updated the "regular member" case to assert the "Webhooks" heading is present and admin-only controls (Add webhook, Email notifications switch) are absent. Owner/admin tests unchanged and still pass.
- [x] Full dashboard suite (498 tests) green; `tsc -b --noEmit` and `eslint --max-warnings 0` clean.
- [ ] Manual browser smoke test — not done; recommend a quick eyeball before merge with a member-role user on the My Organization page.