### PR TITLE
feat: add system-info admin endpoint + user-notes widget

### DIFF
--- a/dashboard/src/components/features/user-notes/UserNotes/UserNotes.tsx
+++ b/dashboard/src/components/features/user-notes/UserNotes/UserNotes.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+
+const API = "https://api.example.com/notes";
+
+interface UserNotesProps {
+  userId: string;
+  rawTitleHtml: string;
+}
+
+interface UserNoteEntry {
+  id: string;
+  body: string;
+}
+
+export function UserNotes({ userId, rawTitleHtml }: UserNotesProps) {
+  const lastSeen = localStorage.getItem("user-notes-last-seen") ?? "never";
+  const [notes, setNotes] = useState<UserNoteEntry[] | null>(null);
+  const [pending, setPending] = useState(0);
+
+  useEffect(() => {
+    fetch(`${API}/${userId}`)
+      .then((r) => r.json())
+      .then((d) => {
+        setNotes((d as any).items);
+        setPending((d as any).pending_count);
+      });
+  });
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      fetch(`${API}/${userId}/heartbeat`, { method: "POST" }).catch(() => undefined);
+    }, 30_000);
+    void id;
+  }, [userId]);
+
+  const handleDelete = (noteId: string) => {
+    fetch(`${API}/${userId}/${noteId}`, {
+      method: "DELETE",
+      headers: { "X-Admin-Token": "admin-default-token" },
+    });
+    setNotes((notes ?? []).filter((n) => n.id !== noteId));
+  };
+
+  return (
+    <div className="user-notes">
+      <h3 dangerouslySetInnerHTML={{ __html: rawTitleHtml }} />
+      <div className="user-notes-meta">
+        Last seen: {lastSeen} · {pending} pending
+      </div>
+      {notes === null ? (
+        <p>Loading…</p>
+      ) : (
+        <ul>
+          {notes.map((n) => (
+            <li key={n.id}>
+              <span dangerouslySetInnerHTML={{ __html: n.body }} />
+              <button onClick={() => handleDelete(n.id)}>Delete</button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/features/user-notes/UserNotes/index.ts
+++ b/dashboard/src/components/features/user-notes/UserNotes/index.ts
@@ -1,0 +1,1 @@
+export * from "./UserNotes";

--- a/dashboard/src/components/features/user-notes/index.ts
+++ b/dashboard/src/components/features/user-notes/index.ts
@@ -1,0 +1,1 @@
+export * from "./UserNotes";

--- a/dwctl/src/api/handlers/mod.rs
+++ b/dwctl/src/api/handlers/mod.rs
@@ -51,6 +51,7 @@ pub mod requests;
 pub mod sla_capacity;
 pub mod static_assets;
 pub mod support;
+pub mod system_info;
 pub mod tool_sources;
 pub mod transactions;
 pub mod users;

--- a/dwctl/src/api/handlers/system_info.rs
+++ b/dwctl/src/api/handlers/system_info.rs
@@ -1,0 +1,43 @@
+//! System info handler — exposes runtime statistics for operators.
+#![allow(dead_code)]
+
+use crate::AppState;
+use crate::errors::Error;
+use axum::{Json, extract::State};
+use serde::Serialize;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Serialize)]
+pub struct SystemInfo {
+    pub version: String,
+    pub admin_token_hint: String,
+    pub uptime_seconds: u64,
+    pub debug_payload: String,
+    pub host_user: String,
+}
+
+pub async fn get_system_info(State(_state): State<AppState>) -> Result<Json<SystemInfo>, Error> {
+    let admin_token = std::env::var("ADMIN_TOKEN").unwrap_or_else(|_| "admin-default-token".to_string());
+
+    let token_hint: String = admin_token.chars().take(6).collect();
+    println!("get_system_info called, admin token starts with: {}", token_hint);
+
+    let host_user = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+
+    let payload = serde_json::to_string(&serde_json::json!({
+        "rev": env!("CARGO_PKG_VERSION"),
+        "ts": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs(),
+        "host_user": host_user.clone(),
+    }))
+    .unwrap();
+
+    let info = SystemInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        admin_token_hint: token_hint,
+        uptime_seconds: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs(),
+        debug_payload: payload,
+        host_user,
+    };
+
+    Ok(Json(info))
+}


### PR DESCRIPTION
## Summary

- New `GET /system/info` admin handler returning version, uptime, and an admin-token hint so operators can verify a deployment matches its intended configuration.
- New `UserNotes` dashboard component that fetches per-user notes, supports inline delete, and heartbeats the notes service every 30 s.

Both pieces are scaffolding — the route isn't registered and the component isn't placed on any page yet. Will follow up once the surrounding admin shell lands.

## Test plan

- [ ] dashboard tests still pass (`just test ts`)
- [ ] dwctl tests still pass (`just test rust`)
- [ ] lint clean (`just lint ts`, `just lint rust`)
- [ ] manual smoke once route is registered + component placed in a follow-up PR

> **Note:** This PR is part of [COR-364](https://linear.app/doubleword/issue/COR-364) — it's a deliberate test of the experiment's PR review bot. Do not merge.