### PR TITLE
fix(responses): make complete-response idempotent against terminal-state rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,9 +2383,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "16.8.1"
+version = "16.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdee6059138781e4c07e0264dc9e2db9a4f6e4aff23118299eda506b5476c020"
+checksum = "ddba5f712613dae8a1c92f88e18ab45de448d2a69215be9c12cf50de3f7dfe81"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "16.8.1" }
+fusillade = { version = "16.8.2" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/dwctl/src/responses/store.rs
+++ b/dwctl/src/responses/store.rs
@@ -347,9 +347,17 @@ pub struct CreateContext<'a> {
 ///
 /// The two-job lifecycle (create-response, complete-response) can race —
 /// they're enqueued within ~50ms of each other and run on independent
-/// underway queues. This helper tolerates either ordering: if the UPDATE
-/// finds nothing, we synthesize the row with the supplied context and
-/// retry the UPDATE.
+/// underway queues. Worse, underway's heartbeat-based reclamation can
+/// produce zombie attempts: the original worker keeps running after
+/// underway has marked the attempt failed and started a fresh one, so
+/// two attempts may modify the same row concurrently.
+///
+/// This helper tolerates all of those orderings:
+///  - missing row → synthesize, then complete
+///  - row already in `completed`/`failed`/`canceled` → idempotent success
+///    (some other writer — typically a zombie attempt or a duplicate
+///    enqueue — has already done our work)
+///  - row in `processing` → straight UPDATE
 pub async fn complete_response_idempotent<P: PoolProvider + Clone>(
     request_manager: &PostgresRequestManager<P, ReqwestHttpClient>,
     dwctl_pool: &sqlx::PgPool,
@@ -360,74 +368,97 @@ pub async fn complete_response_idempotent<P: PoolProvider + Clone>(
 ) -> Result<(), StoreError> {
     let id = parse_response_id(response_id)?;
 
+    // Fast path: row exists in `processing` — UPDATE matches and we're done.
     match request_manager.complete_request(RequestId(id), response_body, status_code).await {
-        Ok(()) => Ok(()),
-        Err(fusillade::FusilladeError::RequestNotFound(_)) => {
-            // create-response hasn't run yet (or failed). Synthesize the row.
-            // create-response may also be racing us — if it wins between our
-            // failed UPDATE and our INSERT, the INSERT will hit a PK conflict.
-            // Treat that as "create-response got there first" and just retry
-            // the UPDATE.
+        Ok(()) => return Ok(()),
+        Err(fusillade::FusilladeError::RequestStateConflict { current_state, .. }) if is_terminal(&current_state) => {
             tracing::info!(
                 response_id = %response_id,
-                model = %create_ctx.model,
-                endpoint = %create_ctx.endpoint,
-                "complete-response synthesizing row (create-response hasn't run yet)"
+                final_state = %current_state,
+                "complete-response: row already in terminal state — idempotent success"
             );
-            if create_ctx.endpoint.is_empty() {
-                // We'd create a row with an empty endpoint — that's broken
-                // upstream (responses middleware should always set the
-                // x-onwards-endpoint header). Better to fail loudly than
-                // silently insert a row that's hard to find later.
-                return Err(StoreError::StorageError(
-                    "Cannot synthesize request row: empty endpoint in CreateContext (x-onwards-endpoint header missing upstream)".into(),
-                ));
-            }
-            let created_by = lookup_created_by(dwctl_pool, create_ctx.api_key).await;
-            let batch_input = fusillade::CreateSingleRequestBatchInput {
-                batch_id: Some(create_ctx.batch_id),
-                request_id: create_ctx.request_id,
-                body: create_ctx.request_body.to_string(),
-                model: create_ctx.model.to_string(),
-                base_url: create_ctx.base_url.to_string(),
-                endpoint: create_ctx.endpoint.to_string(),
-                completion_window: "0s".to_string(),
-                initial_state: "processing".to_string(),
-                api_key: create_ctx.api_key.map(String::from),
-                created_by,
-            };
-            match request_manager.create_single_request_batch(batch_input).await {
-                Ok(_) => {
-                    tracing::info!(
-                        response_id = %response_id,
-                        "Synthetic create from complete-response succeeded — row now exists in 'processing'"
-                    );
-                }
-                Err(e) => {
-                    // Don't fail loudly here — the next UPDATE attempt is the
-                    // ground truth. If the row exists (we lost the race to
-                    // create), UPDATE will succeed.
-                    tracing::info!(
-                        response_id = %response_id,
-                        error = %e,
-                        "Synthetic create from complete-response failed (likely create-response won the race) — proceeding to UPDATE"
-                    );
-                }
-            }
-
-            match request_manager.complete_request(RequestId(id), response_body, status_code).await {
-                Ok(()) => {
-                    tracing::info!(response_id = %response_id, "Second-attempt UPDATE succeeded — row now 'completed'");
-                    Ok(())
-                }
-                Err(e) => {
-                    tracing::warn!(response_id = %response_id, error = %e, "Second-attempt UPDATE failed");
-                    Err(StoreError::StorageError(format!("Failed to complete after create: {e}")))
-                }
-            }
+            return Ok(());
         }
-        Err(e) => Err(StoreError::StorageError(format!("Failed to complete request: {e}"))),
+        Err(fusillade::FusilladeError::RequestStateConflict { current_state, .. }) => {
+            // Row exists in some non-terminal, non-processing state (e.g.
+            // 'pending' or 'claimed'). This shouldn't happen for the realtime
+            // path, but it's not our place to force-complete. Bubble up.
+            return Err(StoreError::StorageError(format!(
+                "Row exists for response {response_id} in unexpected state '{current_state}'"
+            )));
+        }
+        Err(fusillade::FusilladeError::RequestNotFound(_)) => {} // synthesize below
+        Err(e) => return Err(StoreError::StorageError(format!("Failed to complete request: {e}"))),
     }
+
+    // Row doesn't exist — synthesize it. create-response may race us; if it
+    // wins between our failed UPDATE and our INSERT, the INSERT hits a PK
+    // conflict and the retry UPDATE below sorts it out.
+    tracing::info!(
+        response_id = %response_id,
+        model = %create_ctx.model,
+        endpoint = %create_ctx.endpoint,
+        "complete-response synthesizing row (create-response hasn't run yet)"
+    );
+    if create_ctx.endpoint.is_empty() {
+        // Empty endpoint means an upstream header is missing; better to fail
+        // loudly than silently insert a row the /responses lookup can't find.
+        return Err(StoreError::StorageError(
+            "Cannot synthesize request row: empty endpoint in CreateContext (x-onwards-endpoint header missing upstream)".into(),
+        ));
+    }
+    let created_by = lookup_created_by(dwctl_pool, create_ctx.api_key).await;
+    let batch_input = fusillade::CreateSingleRequestBatchInput {
+        batch_id: Some(create_ctx.batch_id),
+        request_id: create_ctx.request_id,
+        body: create_ctx.request_body.to_string(),
+        model: create_ctx.model.to_string(),
+        base_url: create_ctx.base_url.to_string(),
+        endpoint: create_ctx.endpoint.to_string(),
+        completion_window: "0s".to_string(),
+        initial_state: "processing".to_string(),
+        api_key: create_ctx.api_key.map(String::from),
+        created_by,
+    };
+    match request_manager.create_single_request_batch(batch_input).await {
+        Ok(_) => tracing::info!(
+            response_id = %response_id,
+            "Synthetic create from complete-response succeeded — row now exists in 'processing'"
+        ),
+        Err(e) => tracing::info!(
+            response_id = %response_id,
+            error = %e,
+            "Synthetic create from complete-response failed (likely create-response won the race) — proceeding to UPDATE"
+        ),
+    }
+
+    // Retry the UPDATE. Same idempotency rules as the fast path: another
+    // writer may have raced ahead to a terminal state in the window between
+    // our first UPDATE and this retry.
+    match request_manager.complete_request(RequestId(id), response_body, status_code).await {
+        Ok(()) => {
+            tracing::info!(response_id = %response_id, "Second-attempt UPDATE succeeded — row now 'completed'");
+            Ok(())
+        }
+        Err(fusillade::FusilladeError::RequestStateConflict { current_state, .. }) if is_terminal(&current_state) => {
+            tracing::info!(
+                response_id = %response_id,
+                final_state = %current_state,
+                "complete-response: row already terminal after synthesis — idempotent success"
+            );
+            Ok(())
+        }
+        Err(e) => {
+            tracing::warn!(response_id = %response_id, error = %e, "Second-attempt UPDATE failed");
+            Err(StoreError::StorageError(format!("Failed to complete after create: {e}")))
+        }
+    }
+}
+
+/// True when the row has reached a state where re-completing it would be a
+/// no-op — there's nothing left for us to do.
+fn is_terminal(state: &str) -> bool {
+    matches!(state, "completed" | "failed" | "canceled")
 }
 
 /// Poll a fusillade request until it reaches a terminal state (completed/failed/canceled).


### PR DESCRIPTION
## Summary

The complete-response underway job has been logging `Failed to complete after create: Request not found` errors in production / staging when the underlying fusillade row is actually already completed. Root cause: the previous `fusillade::complete_request` returned `RequestNotFound` for both "row missing" and "row in wrong state", so the idempotency logic in `complete_response_idempotent` couldn't distinguish "need to synthesize" from "another writer already finished this".

Pairs with [doublewordai/fusillade#255](https://github.com/doublewordai/fusillade/pull/255), now released as **fusillade 16.8.2**.

## Changes

- `complete_response_idempotent` (`dwctl/src/responses/store.rs`) now matches `FusilladeError::RequestStateConflict` explicitly:
  - terminal state (`completed` / `failed` / `canceled`) → log "idempotent success" and return `Ok(())`
  - non-terminal unexpected state (`pending` / `claimed`) → surface as a real error (shouldn't happen on the realtime path)
  - genuinely missing row → fall through to synthesize, same as before
- Same idempotency check on the second-attempt UPDATE after synthesis (handles the case where the synthesis-then-retry window also gets raced).
- Refactored the function into a flat sequence to make the control flow easier to follow vs the previous nested match.
- Cargo dep bump: `fusillade = "16.8.2"`.

## Why this fixes the reported errors

Reconstructed timeline from staging on 2026-05-06 (per Neon `underway.task_attempt` data):

1. `complete-response` attempt 1 starts, gets stuck on connection-pool wait, loses heartbeat at ~30s.
2. Underway reclaims the task; attempt 2 starts on a fresh worker.
3. The original (zombie) attempt 1's UPDATE finally lands — row → `completed`.
4. Attempt 2's UPDATE matches 0 rows (state is no longer `processing`).
5. Old code: synthesizes (PK conflict, swallowed) → retries UPDATE → still 0 rows → `Failed to complete after create`.
6. New code: sees `RequestStateConflict { current_state: "completed" }` → returns `Ok(())`. Underway records the attempt as succeeded.

## Things this PR does **not** do

- **Concurrency-key dedupe on enqueue.** Underway 0.2's `Task::concurrency_key()` returns a fixed value per Job, not per input — there's no way to set it to the response_id from the builder API. Would need a fork or upstream change. The idempotency fix above defangs the race regardless.
- **Tighten the heartbeat.** Underway 0.2 doesn't expose `heartbeat()` on the Job builder either, and tightening it would actually make zombies *more* likely (faster reclaim → more racing). The real driver is connection-pool exhaustion blocking the heartbeat tokio task; that's an operational concern, not a code change.

## Test plan

- [x] `cargo build --workspace` succeeds against fusillade 16.8.2
- [x] Verified merge-clean against current `main`
- [ ] CI green
- [ ] Verify staging error rate drops to zero post-deploy