### PR TITLE
fix: remove Synchronize action from Endpoints row menu

### DIFF
--- a/dashboard/src/components/features/endpoints/Endpoints/Endpoints.tsx
+++ b/dashboard/src/components/features/endpoints/Endpoints/Endpoints.tsx
@@ -3,7 +3,6 @@ import { useLocation } from "react-router-dom";
 import { Server, Plus, Trash2 } from "lucide-react";
 import {
   useEndpoints,
-  useSynchronizeEndpoint,
   useUpdateEndpoint,
   useDeleteEndpoint,
 } from "../../../../api/control-layer";
@@ -45,7 +44,6 @@ export function Endpoints() {
   } = useEndpoints({
     ...endpointsPagination.queryParams,
   });
-  const synchronizeEndpointMutation = useSynchronizeEndpoint();
   const updateEndpointMutation = useUpdateEndpoint();
   const deleteEndpointMutation = useDeleteEndpoint();
 
@@ -90,16 +88,6 @@ export function Endpoints() {
     setEndpointToDelete(endpoint);
   };
 
-  const handleSynchronize = async (endpoint: Endpoint) => {
-    try {
-      await synchronizeEndpointMutation.mutateAsync(endpoint.id.toString());
-      toast.success("Endpoint synchronized successfully");
-    } catch (error) {
-      console.error("Failed to synchronize endpoint:", error);
-      toast.error("Failed to synchronize endpoint. Please try again.");
-    }
-  };
-
   const handleBulkDelete = async () => {
     try {
       // Delete endpoints one by one
@@ -122,8 +110,6 @@ export function Endpoints() {
     onEdit: handleInlineEdit,
     onEditModal: handleEdit,
     onDelete: handleDelete,
-    onSynchronize: handleSynchronize,
-    isSynchronizing: synchronizeEndpointMutation.isPending,
   });
 
   if (isLoading) {

--- a/dashboard/src/components/features/endpoints/Endpoints/columns.tsx
+++ b/dashboard/src/components/features/endpoints/Endpoints/columns.tsx
@@ -7,7 +7,6 @@ import {
   ArrowUpDown,
   MoreHorizontal,
   ExternalLink,
-  RefreshCw,
   Edit2,
   Trash2,
   Check,
@@ -35,8 +34,6 @@ interface ColumnActions {
   ) => void;
   onEditModal: (endpoint: Endpoint) => void;
   onDelete: (endpoint: Endpoint) => void;
-  onSynchronize: (endpoint: Endpoint) => void;
-  isSynchronizing?: boolean;
 }
 
 // Editable cell component
@@ -297,13 +294,6 @@ export const createColumns = (
             <DropdownMenuItem onClick={() => actions.onEditModal(endpoint)}>
               <Edit2 className="mr-2 h-4 w-4" />
               Edit
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => actions.onSynchronize(endpoint)}
-              disabled={actions.isSynchronizing}
-            >
-              <RefreshCw className="mr-2 h-4 w-4" />
-              Synchronize
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem


### PR DESCRIPTION
## Summary
- Remove the **Synchronize** option from the per-endpoint `...` (actions) dropdown on the Manage Providers / Endpoints page so it isn't an accessible option for any user.
- Drop the now-unused `onSynchronize` / `isSynchronizing` props from the columns API and the corresponding handler / mutation wiring in `Endpoints.tsx`.
- Leaves the `useSynchronizeEndpoint` API hook itself untouched since it has its own tests and is still exported for future / programmatic use.

## Test plan
- [x] `pnpm run lint` (dashboard) — passes
- [x] `pnpm test -- --run` (dashboard) — 498/498 tests pass, including `Endpoints.test.tsx`
- [ ] Visual check: open the Endpoints page, click the `...` on a row, confirm only **Edit** and **Delete** show.