### PR TITLE
fix(responses): terminate fusillade row on client cancel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,9 +2383,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "16.8.2"
+version = "16.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddba5f712613dae8a1c92f88e18ab45de448d2a69215be9c12cf50de3f7dfe81"
+checksum = "de712031542971f0b94e8fcadcb288975566577b32f63a50c0e9c62461bfe909"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4099,9 +4099,9 @@ dependencies = [
 
 [[package]]
 name = "outlet"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2267a2dcdc06dc06dc701bd768ee9b6ca9f12567094477898c1d8108e9b407"
+checksum = "058ce12aaf808056347c45d87d8943514895b6ca9ec01bf597ec56078e54f3d5"
 dependencies = [
  "anyhow",
  "axum",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "16.8.2" }
+fusillade = { version = "16.8.3" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
@@ -85,7 +85,7 @@ axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
-outlet = "0.8.0"
+outlet = "0.8.1"
 outlet-postgres = "0.5.1"
 async-openai = { version = "0.34.0", default-features = false, features = [
   "chat-completion-types",

--- a/dwctl/src/responses/outlet_handler.rs
+++ b/dwctl/src/responses/outlet_handler.rs
@@ -150,6 +150,84 @@ impl RequestHandler for FusilladeOutletHandler {
             }
         }
     }
+
+    fn handle_abandoned(&self, request_data: RequestData) -> impl std::future::Future<Output = ()> + Send {
+        let job = self.job.clone();
+
+        async move {
+            // Same header-presence gating as handle_response — without
+            // `x-onwards-response-id` this wasn't a responses-middleware
+            // request, so nothing for us to do.
+            let response_id = match Self::extract_response_id(&request_data) {
+                Some(id) => id,
+                None => return,
+            };
+            let request_id = match Self::extract_request_id(&request_data) {
+                Some(id) => id,
+                None => {
+                    tracing::warn!(response_id = %response_id, "Missing x-fusillade-request-id header on abandoned request — skipping enqueue");
+                    return;
+                }
+            };
+            let batch_id = match Self::extract_batch_id(&request_data) {
+                Some(id) => id,
+                None => {
+                    tracing::warn!(response_id = %response_id, "Missing x-fusillade-batch-id header on abandoned request — skipping enqueue");
+                    return;
+                }
+            };
+
+            // We don't have a body captured here — RequestData::body is None
+            // because outlet's AbandonGuard builds a minimal record before
+            // body capture completes. That's fine for create-if-missing:
+            // the row's body column ends up empty, which is correct since
+            // no upstream call ever happened. The endpoint/model headers
+            // still need to be present so the synthesized row is queryable.
+            let model = Self::header_str(&request_data, "x-onwards-model").unwrap_or("unknown").to_string();
+            let endpoint = Self::header_str(&request_data, "x-onwards-endpoint").unwrap_or("").to_string();
+            let api_key = Self::extract_api_key(&request_data);
+
+            if endpoint.is_empty() {
+                tracing::warn!(
+                    response_id = %response_id,
+                    uri = %request_data.uri,
+                    "Missing x-onwards-endpoint header on abandoned request — complete-response synthesize will fail"
+                );
+            }
+
+            // 499 Client Closed Request — nginx-popularized status for
+            // exactly this scenario. The structured body marks the row
+            // distinguishable from a real upstream 5xx in the responses
+            // listing without inventing a new schema.
+            const STATUS_CLIENT_CLOSED: u16 = 499;
+            let abandoned_body = serde_json::json!({
+                "error": {
+                    "type": "client_disconnected",
+                    "message": "client cancelled request before upstream response",
+                    "code": STATUS_CLIENT_CLOSED,
+                }
+            })
+            .to_string();
+
+            if let Err(e) = job
+                .enqueue(&CompleteResponseInput {
+                    response_id: response_id.clone(),
+                    status_code: STATUS_CLIENT_CLOSED,
+                    response_body: abandoned_body,
+                    batch_id,
+                    request_id,
+                    request_body: String::new(),
+                    model,
+                    endpoint,
+                    base_url: String::new(),
+                    api_key,
+                })
+                .await
+            {
+                tracing::warn!(error = %e, response_id = %response_id, "Failed to enqueue complete-response job for abandoned request");
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/dwctl/src/responses/outlet_handler.rs
+++ b/dwctl/src/responses/outlet_handler.rs
@@ -56,6 +56,73 @@ impl FusilladeOutletHandler {
             .and_then(|values| values.first())
             .and_then(|bytes| std::str::from_utf8(bytes).ok())
     }
+
+    /// Extract the identifiers + attribution context every `CompleteResponseJob`
+    /// needs. Returns `None` (after logging) when a required header is absent
+    /// or unparseable, so both [`Self::handle_response`] and
+    /// [`Self::handle_abandoned`] short-circuit consistently. Centralising
+    /// this here keeps the two handler paths from drifting on which headers
+    /// are gating vs. just warned-about.
+    fn extract_complete_response_ctx(request: &RequestData) -> Option<CompleteResponseCtx> {
+        // Only the responses middleware sets `x-onwards-response-id`, so its
+        // absence means this is either a daemon-driven fusillade batch request
+        // (daemon handles its own completion) or unrelated traffic. Silent
+        // no-op — no warning, no work to do.
+        let response_id = Self::extract_response_id(request)?;
+
+        let request_id = match Self::extract_request_id(request) {
+            Some(id) => id,
+            None => {
+                tracing::warn!(response_id = %response_id, "Missing x-fusillade-request-id header — skipping enqueue");
+                return None;
+            }
+        };
+        let batch_id = match Self::extract_batch_id(request) {
+            Some(id) => id,
+            None => {
+                tracing::warn!(response_id = %response_id, "Missing x-fusillade-batch-id header — skipping enqueue");
+                return None;
+            }
+        };
+
+        let model = Self::header_str(request, "x-onwards-model").unwrap_or("unknown").to_string();
+        let endpoint = Self::header_str(request, "x-onwards-endpoint").unwrap_or("").to_string();
+        let api_key = Self::extract_api_key(request);
+
+        if endpoint.is_empty() {
+            // Empty endpoint isn't fatal here — `complete_response_idempotent`
+            // will refuse to synthesize a row without it. We continue (rather
+            // than returning None) so the UPDATE path still succeeds if the
+            // row already exists.
+            tracing::warn!(
+                response_id = %response_id,
+                uri = %request.uri,
+                "Missing x-onwards-endpoint header — complete-response synthesize will fail if create-response hasn't run"
+            );
+        }
+
+        Some(CompleteResponseCtx {
+            response_id,
+            request_id,
+            batch_id,
+            model,
+            endpoint,
+            api_key,
+        })
+    }
+}
+
+/// Per-request identifiers + attribution extracted from the captured headers,
+/// shared by [`FusilladeOutletHandler::handle_response`] and
+/// [`FusilladeOutletHandler::handle_abandoned`].
+#[derive(Debug, PartialEq, Eq)]
+struct CompleteResponseCtx {
+    response_id: String,
+    request_id: Uuid,
+    batch_id: Uuid,
+    model: String,
+    endpoint: String,
+    api_key: Option<String>,
 }
 
 impl RequestHandler for FusilladeOutletHandler {
@@ -65,36 +132,8 @@ impl RequestHandler for FusilladeOutletHandler {
         let job = self.job.clone();
 
         async move {
-            // Only the responses middleware sets `x-onwards-response-id`, so
-            // its absence means this is either a daemon-driven fusillade batch
-            // request (the daemon handles its own completion) or some other
-            // non-responses traffic — nothing for us to do.
-            let response_id = match Self::extract_response_id(&request_data) {
-                Some(id) => id,
-                None => return,
-            };
-
-            // We also need the raw request UUID for the create-if-missing path.
-            // The responses middleware always sets both headers together; if it's
-            // missing here something upstream is broken — bail out.
-            let request_id = match Self::extract_request_id(&request_data) {
-                Some(id) => id,
-                None => {
-                    tracing::warn!(response_id = %response_id, "Missing x-fusillade-request-id header on response — skipping enqueue");
-                    return;
-                }
-            };
-
-            // Same story for the batch_id — middleware always sets it alongside
-            // request_id. If it's missing, complete-response would synthesize a
-            // row with a fresh batch_id that doesn't match what create-response
-            // used, breaking the analytics join.
-            let batch_id = match Self::extract_batch_id(&request_data) {
-                Some(id) => id,
-                None => {
-                    tracing::warn!(response_id = %response_id, "Missing x-fusillade-batch-id header on response — skipping enqueue");
-                    return;
-                }
+            let Some(ctx) = Self::extract_complete_response_ctx(&request_data) else {
+                return;
             };
 
             let status_code = response_data.status.as_u16();
@@ -104,49 +143,29 @@ impl RequestHandler for FusilladeOutletHandler {
                 .and_then(|b| std::str::from_utf8(b).ok())
                 .unwrap_or("")
                 .to_string();
-
-            // Context used by complete-response if it has to synthesize the row
-            // (i.e., raced ahead of create-response). The middleware sets these
-            // headers explicitly so we don't have to parse the body or guess
-            // path nesting.
             let request_body = request_data
                 .body
                 .as_ref()
                 .and_then(|b| std::str::from_utf8(b).ok())
                 .unwrap_or("")
                 .to_string();
-            let model = Self::header_str(&request_data, "x-onwards-model").unwrap_or("unknown").to_string();
-            let endpoint = Self::header_str(&request_data, "x-onwards-endpoint").unwrap_or("").to_string();
-            let api_key = Self::extract_api_key(&request_data);
-
-            if endpoint.is_empty() {
-                // The responses middleware always sets x-onwards-endpoint when
-                // it intercepts. If we get here without it, complete-response
-                // would synthesize a row with an empty endpoint that the
-                // /responses lookup queries can't find. Log loudly.
-                tracing::warn!(
-                    response_id = %response_id,
-                    uri = %request_data.uri,
-                    "Missing x-onwards-endpoint header on captured request — complete-response will fail"
-                );
-            }
 
             if let Err(e) = job
                 .enqueue(&CompleteResponseInput {
-                    response_id: response_id.clone(),
+                    response_id: ctx.response_id.clone(),
                     status_code,
                     response_body,
-                    batch_id,
-                    request_id,
+                    batch_id: ctx.batch_id,
+                    request_id: ctx.request_id,
                     request_body,
-                    model,
-                    endpoint,
+                    model: ctx.model,
+                    endpoint: ctx.endpoint,
                     base_url: String::new(),
-                    api_key,
+                    api_key: ctx.api_key,
                 })
                 .await
             {
-                tracing::warn!(error = %e, response_id = %response_id, "Failed to enqueue complete-response job");
+                tracing::warn!(error = %e, response_id = %ctx.response_id, "Failed to enqueue complete-response job");
             }
         }
     }
@@ -155,50 +174,21 @@ impl RequestHandler for FusilladeOutletHandler {
         let job = self.job.clone();
 
         async move {
-            // Same header-presence gating as handle_response — without
-            // `x-onwards-response-id` this wasn't a responses-middleware
-            // request, so nothing for us to do.
-            let response_id = match Self::extract_response_id(&request_data) {
-                Some(id) => id,
-                None => return,
-            };
-            let request_id = match Self::extract_request_id(&request_data) {
-                Some(id) => id,
-                None => {
-                    tracing::warn!(response_id = %response_id, "Missing x-fusillade-request-id header on abandoned request — skipping enqueue");
-                    return;
-                }
-            };
-            let batch_id = match Self::extract_batch_id(&request_data) {
-                Some(id) => id,
-                None => {
-                    tracing::warn!(response_id = %response_id, "Missing x-fusillade-batch-id header on abandoned request — skipping enqueue");
-                    return;
-                }
+            let Some(ctx) = Self::extract_complete_response_ctx(&request_data) else {
+                return;
             };
 
-            // We don't have a body captured here — RequestData::body is None
-            // because outlet's AbandonGuard builds a minimal record before
-            // body capture completes. That's fine for create-if-missing:
-            // the row's body column ends up empty, which is correct since
-            // no upstream call ever happened. The endpoint/model headers
-            // still need to be present so the synthesized row is queryable.
-            let model = Self::header_str(&request_data, "x-onwards-model").unwrap_or("unknown").to_string();
-            let endpoint = Self::header_str(&request_data, "x-onwards-endpoint").unwrap_or("").to_string();
-            let api_key = Self::extract_api_key(&request_data);
-
-            if endpoint.is_empty() {
-                tracing::warn!(
-                    response_id = %response_id,
-                    uri = %request_data.uri,
-                    "Missing x-onwards-endpoint header on abandoned request — complete-response synthesize will fail"
-                );
-            }
-
-            // 499 Client Closed Request — nginx-popularized status for
-            // exactly this scenario. The structured body marks the row
-            // distinguishable from a real upstream 5xx in the responses
-            // listing without inventing a new schema.
+            // 499 Client Closed Request — nginx-popularized status for this
+            // scenario. The structured body distinguishes the row from a
+            // real upstream 5xx in the responses listing; status 499 also
+            // maps to `client_disconnected` in `status_to_error_type` so
+            // the body and the derived UI error type agree.
+            //
+            // We omit `request_body` (set to "") because outlet's
+            // AbandonGuard builds the abandon-time RequestData before body
+            // capture completes — `request_data.body` is always None on
+            // this path. That's fine for create-if-missing: an empty body
+            // is correct since no upstream call ever happened.
             const STATUS_CLIENT_CLOSED: u16 = 499;
             let abandoned_body = serde_json::json!({
                 "error": {
@@ -211,20 +201,20 @@ impl RequestHandler for FusilladeOutletHandler {
 
             if let Err(e) = job
                 .enqueue(&CompleteResponseInput {
-                    response_id: response_id.clone(),
+                    response_id: ctx.response_id.clone(),
                     status_code: STATUS_CLIENT_CLOSED,
                     response_body: abandoned_body,
-                    batch_id,
-                    request_id,
+                    batch_id: ctx.batch_id,
+                    request_id: ctx.request_id,
                     request_body: String::new(),
-                    model,
-                    endpoint,
+                    model: ctx.model,
+                    endpoint: ctx.endpoint,
                     base_url: String::new(),
-                    api_key,
+                    api_key: ctx.api_key,
                 })
                 .await
             {
-                tracing::warn!(error = %e, response_id = %response_id, "Failed to enqueue complete-response job for abandoned request");
+                tracing::warn!(error = %e, response_id = %ctx.response_id, "Failed to enqueue complete-response job for abandoned request");
             }
         }
     }
@@ -328,5 +318,103 @@ mod tests {
     fn test_extract_api_key_absent() {
         let request = make_request_data(HashMap::new());
         assert!(FusilladeOutletHandler::extract_api_key(&request).is_none());
+    }
+
+    fn full_headers() -> HashMap<String, Vec<Bytes>> {
+        let mut headers = HashMap::new();
+        headers.insert(
+            ONWARDS_RESPONSE_ID_HEADER.to_string(),
+            vec![Bytes::from("resp_12345678-1234-1234-1234-123456789abc")],
+        );
+        headers.insert(
+            "x-fusillade-request-id".to_string(),
+            vec![Bytes::from("12345678-1234-1234-1234-123456789abc")],
+        );
+        headers.insert(
+            "x-fusillade-batch-id".to_string(),
+            vec![Bytes::from("abcdef00-0000-0000-0000-000000000001")],
+        );
+        headers.insert("x-onwards-model".to_string(), vec![Bytes::from("Qwen/Qwen3.5-9B")]);
+        headers.insert("x-onwards-endpoint".to_string(), vec![Bytes::from("http://127.0.0.1:3001/ai")]);
+        headers.insert("authorization".to_string(), vec![Bytes::from("Bearer sk-test")]);
+        headers
+    }
+
+    #[test]
+    fn test_extract_complete_response_ctx_all_headers_present() {
+        let request = make_request_data(full_headers());
+        let ctx = FusilladeOutletHandler::extract_complete_response_ctx(&request).expect("should extract");
+        assert_eq!(ctx.response_id, "resp_12345678-1234-1234-1234-123456789abc");
+        assert_eq!(ctx.request_id, Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap());
+        assert_eq!(ctx.batch_id, Uuid::parse_str("abcdef00-0000-0000-0000-000000000001").unwrap());
+        assert_eq!(ctx.model, "Qwen/Qwen3.5-9B");
+        assert_eq!(ctx.endpoint, "http://127.0.0.1:3001/ai");
+        assert_eq!(ctx.api_key, Some("sk-test".to_string()));
+    }
+
+    #[test]
+    fn test_extract_complete_response_ctx_missing_response_id_returns_none() {
+        // x-onwards-response-id absence is the silent-no-op gate: this is
+        // either daemon traffic or unrelated, and the handler must return
+        // without enqueueing anything.
+        let mut headers = full_headers();
+        headers.remove(ONWARDS_RESPONSE_ID_HEADER);
+        let request = make_request_data(headers);
+        assert!(FusilladeOutletHandler::extract_complete_response_ctx(&request).is_none());
+    }
+
+    #[test]
+    fn test_extract_complete_response_ctx_missing_request_id_returns_none() {
+        let mut headers = full_headers();
+        headers.remove("x-fusillade-request-id");
+        let request = make_request_data(headers);
+        assert!(FusilladeOutletHandler::extract_complete_response_ctx(&request).is_none());
+    }
+
+    #[test]
+    fn test_extract_complete_response_ctx_missing_batch_id_returns_none() {
+        let mut headers = full_headers();
+        headers.remove("x-fusillade-batch-id");
+        let request = make_request_data(headers);
+        assert!(FusilladeOutletHandler::extract_complete_response_ctx(&request).is_none());
+    }
+
+    #[test]
+    fn test_extract_complete_response_ctx_invalid_request_id_returns_none() {
+        let mut headers = full_headers();
+        headers.insert("x-fusillade-request-id".to_string(), vec![Bytes::from("not-a-uuid")]);
+        let request = make_request_data(headers);
+        assert!(FusilladeOutletHandler::extract_complete_response_ctx(&request).is_none());
+    }
+
+    #[test]
+    fn test_extract_complete_response_ctx_missing_endpoint_warns_but_returns_some() {
+        // Empty endpoint is non-fatal — extraction returns Some so the
+        // UPDATE path can still succeed if the row already exists.
+        // complete_response_idempotent refuses to synthesize on empty
+        // endpoint; that's the failure mode, not silent skip here.
+        let mut headers = full_headers();
+        headers.remove("x-onwards-endpoint");
+        let request = make_request_data(headers);
+        let ctx = FusilladeOutletHandler::extract_complete_response_ctx(&request).expect("should still extract");
+        assert_eq!(ctx.endpoint, "");
+    }
+
+    #[test]
+    fn test_extract_complete_response_ctx_missing_model_defaults_to_unknown() {
+        let mut headers = full_headers();
+        headers.remove("x-onwards-model");
+        let request = make_request_data(headers);
+        let ctx = FusilladeOutletHandler::extract_complete_response_ctx(&request).expect("should extract");
+        assert_eq!(ctx.model, "unknown");
+    }
+
+    #[test]
+    fn test_extract_complete_response_ctx_missing_api_key_is_none() {
+        let mut headers = full_headers();
+        headers.remove("authorization");
+        let request = make_request_data(headers);
+        let ctx = FusilladeOutletHandler::extract_complete_response_ctx(&request).expect("should extract");
+        assert_eq!(ctx.api_key, None);
     }
 }

--- a/dwctl/src/responses/store.rs
+++ b/dwctl/src/responses/store.rs
@@ -683,6 +683,12 @@ fn status_to_error_type(status: u16) -> &'static str {
         403 => "permission_error",
         404 => "not_found_error",
         429 => "rate_limit_error",
+        // 499 is the nginx-popularized "Client Closed Request" status —
+        // emitted by `FusilladeOutletHandler::handle_abandoned` when the
+        // client cancels before the upstream responds. Without this case
+        // the listing UI would derive the type from the catch-all
+        // `server_error` arm while the stored body said `client_disconnected`.
+        499 => "client_disconnected",
         _ => "server_error",
     }
 }


### PR DESCRIPTION
## Summary

- Realtime requests cancelled by the client *before* the upstream responded left a row in \`fusillade.requests\` stuck in \`processing\` indefinitely. The outlet handler's \`handle_response\` only fires once the upstream yields headers and a detached response task takes over; before that, dropping the outer future is silent — no completion job, no row update. The row was only rescued by the \`processing_timeout_ms\` reclaim (4h prod), and even then via a phantom upstream re-fire the client never sees.
- Implement \`FusilladeOutletHandler::handle_abandoned\` (new outlet hook landing in [doublewordai/outlet#74](https://github.com/doublewordai/outlet/pull/74)) to enqueue a \`CompleteResponseJob\` with status \`499 Client Closed Request\` and a structured \`client_disconnected\` body. Reuses the existing idempotent synthesize-or-update path.

## Test plan

- [x] \`cargo check\`, \`just lint rust\` clean.
- [x] All responses-related unit tests pass (\`cargo test --lib responses\` — 103 passed).
- [x] **Manual end-to-end**: \`curl --max-time 0.4 -X POST .../v1/chat/completions\` (cancels mid-flight). Row appeared in DB, transitioned from \`processing\` → \`completed\` with \`response_status = 499\` within ~400ms of creation, body = \`{"error":{"type":"client_disconnected", ...}}\`. Pre-fix: row stuck in \`processing\` indefinitely.
- [ ] Once outlet PR merges + releases, bump the outlet version pin in \`dwctl/Cargo.toml\` from \`0.8.0\` → \`0.9.x\`. This PR depends on the new \`handle_abandoned\` trait method.

## Dependency note

This PR requires outlet >= 0.9 (the next release after [outlet#74](https://github.com/doublewordai/outlet/pull/74) lands). \`handle_abandoned\` has a default no-op impl on the trait, so existing outlet consumers compile unchanged — this PR is the active wire-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)