### PR TITLE
feat: unified http client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -155,7 +155,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -1060,7 +1060,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1184,9 +1184,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1463,7 +1463,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools 0.13.0",
+ "itertools",
  "num-traits",
  "oorandom",
  "page_size",
@@ -1484,7 +1484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.13.0",
+ "itertools",
 ]
 
 [[package]]
@@ -1713,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2146,7 +2146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2384,6 +2384,8 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "fusillade"
 version = "17.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba270cfbceca4ece0a85b337a8d8599e16548a104077097631a1ce81bb6a636"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2715,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -3129,7 +3131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3195,15 +3197,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -3360,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags",
  "libc",
@@ -3556,9 +3549,9 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -3589,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e56997f084e57b045edf17c3ed8ba7f9f779c670df8206dfd1c736f4c02dc4a"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -3792,7 +3785,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3916,6 +3909,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "onwards"
 version = "0.27.0"
+source = "git+https://github.com/doublewordai/onwards?branch=feat%2Fmulti-step-feature-flag#12bc0f7fb06e066ea8f287cc92d85de3af2cebed"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3980,9 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4011,9 +4005,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -4287,18 +4281,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4588,7 +4582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4702,7 +4696,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5275,7 +5269,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5334,7 +5328,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5797,7 +5791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6180,7 +6174,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6332,9 +6326,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -7096,7 +7090,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7408,9 +7402,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -7614,9 +7608,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2146,7 +2146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3785,7 +3785,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3908,8 +3908,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onwards"
-version = "0.27.0"
-source = "git+https://github.com/doublewordai/onwards?branch=feat%2Fmulti-step-feature-flag#12bc0f7fb06e066ea8f287cc92d85de3af2cebed"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8498231f24361847fff445896e2f63e0adc2948394cb8776ac5d5bd32eaadec"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4696,7 +4697,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5269,7 +5270,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5328,7 +5329,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6174,7 +6175,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7090,7 +7091,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -1115,15 +1115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,9 +1184,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1885,7 +1876,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwctl"
-version = "8.50.0"
+version = "8.49.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2291,12 +2282,13 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.29"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -2391,9 +2383,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "17.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba270cfbceca4ece0a85b337a8d8599e16548a104077097631a1ce81bb6a636"
+version = "17.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2725,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -2894,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -3139,7 +3129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -3337,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -3356,7 +3346,6 @@ dependencies = [
  "sha2 0.10.9",
  "signature 2.2.0",
  "simple_asn1",
- "zeroize",
 ]
 
 [[package]]
@@ -3371,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
 dependencies = [
  "bitflags",
  "libc",
@@ -3407,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.11.22"
+version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
 dependencies = [
  "async-trait",
  "base64",
@@ -3567,9 +3556,9 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "metrics"
-version = "0.24.6"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -3600,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.20.4"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
+checksum = "9e56997f084e57b045edf17c3ed8ba7f9f779c670df8206dfd1c736f4c02dc4a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -3927,8 +3916,6 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "onwards"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81966038f80cfe8584717a8161241dc3d3615e9f08a202b2a36f5d36e536388c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3942,6 +3929,7 @@ dependencies = [
  "dashmap",
  "eventsource-stream",
  "flate2",
+ "fusillade",
  "futures-util",
  "governor",
  "http-body-util",
@@ -4299,18 +4287,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.13"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.13"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5105,11 +5093,11 @@ dependencies = [
 
 [[package]]
 name = "retry-policies"
-version = "0.5.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
+checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
 dependencies = [
- "rand 0.10.1",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -5567,9 +5555,9 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "1.1.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d525c8ff68aa99e5818302259bdd02d86d0303710616f39c0f44846ff6d332"
+checksum = "c2316d01592c3382277c5062105510e35e0a6bfb2851e30028485f7af8cf1240"
 dependencies = [
  "itoa",
  "percent-encoding",
@@ -5591,12 +5579,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
  "base64",
- "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5611,9 +5598,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -6345,9 +6332,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -7421,9 +7408,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -7627,9 +7614,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -7651,20 +7638,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -155,7 +155,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1876,7 +1876,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwctl"
-version = "8.49.1"
+version = "8.50.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2146,7 +2146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2383,7 +2383,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "17.0.1"
+version = "17.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3792,7 +3792,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5275,7 +5275,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5334,7 +5334,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5797,7 +5797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6180,7 +6180,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7096,7 +7096,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,23 @@
 [workspace]
 members = ["dwctl"]
 resolver = "2"
+
+# Local path overrides for the in-flight onwards multi-step rollout.
+# `fusillade` main has the streaming-event-callback work merged but
+# unreleased; `onwards` is still on `feat/multi-step-feature-flag`
+# (which pulls fusillade from the same git URL until both publish).
+# Once both publish, drop these and bump the version specifiers in
+# `dwctl/Cargo.toml` instead.
+[patch.crates-io]
+fusillade = { path = "../fusillade" }
+onwards = { path = "../onwards" }
+
+# Collapse onwards's git-based fusillade dep onto the same local
+# fusillade source. Without this, cargo treats the crates.io-versioned
+# fusillade (used by dwctl) and the git-versioned fusillade (used by
+# onwards' multi-step feature) as two separate crates, even though
+# both resolve to the same path — and the `fusillade::HttpClient`
+# trait from one then doesn't satisfy bounds expressed against the
+# other.
+[patch."https://github.com/doublewordai/fusillade"]
+fusillade = { path = "../fusillade" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,3 @@
 [workspace]
 members = ["dwctl"]
 resolver = "2"
-
-# Local path overrides for the in-flight onwards multi-step rollout.
-# `fusillade` main has the streaming-event-callback work merged but
-# unreleased; `onwards` is still on `feat/multi-step-feature-flag`
-# (which pulls fusillade from the same git URL until both publish).
-# Once both publish, drop these and bump the version specifiers in
-# `dwctl/Cargo.toml` instead.
-[patch.crates-io]
-fusillade = { path = "../fusillade" }
-onwards = { path = "../onwards" }
-
-# Collapse onwards's git-based fusillade dep onto the same local
-# fusillade source. Without this, cargo treats the crates.io-versioned
-# fusillade (used by dwctl) and the git-versioned fusillade (used by
-# onwards' multi-step feature) as two separate crates, even though
-# both resolve to the same path — and the `fusillade::HttpClient`
-# trait from one then doesn't satisfy bounds expressed against the
-# other.
-[patch."https://github.com/doublewordai/fusillade"]
-fusillade = { path = "../fusillade" }

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -79,10 +79,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 argon2 = "0.5"
 base64 = "0.22"
 bytes = "1.5"
-# Tracking the in-flight `feat/multi-step-feature-flag` branch until
-# onwards publishes a release with the `multi-step` feature. Once
-# published, switch to `{ version = "0.28", features = ["multi-step"] }`.
-onwards = { git = "https://github.com/doublewordai/onwards", branch = "feat/multi-step-feature-flag", features = ["multi-step"] }
+onwards = { version = "0.28", features = ["multi-step"] }
 thiserror = "2.0.14"
 axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -79,7 +79,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 argon2 = "0.5"
 base64 = "0.22"
 bytes = "1.5"
-onwards = "0.27.0"
+onwards = { version = "0.27", features = ["multi-step"] }
 thiserror = "2.0.14"
 axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -79,7 +79,10 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 argon2 = "0.5"
 base64 = "0.22"
 bytes = "1.5"
-onwards = { version = "0.27", features = ["multi-step"] }
+# Tracking the in-flight `feat/multi-step-feature-flag` branch until
+# onwards publishes a release with the `multi-step` feature. Once
+# published, switch to `{ version = "0.28", features = ["multi-step"] }`.
+onwards = { git = "https://github.com/doublewordai/onwards", branch = "feat/multi-step-feature-flag", features = ["multi-step"] }
 thiserror = "2.0.14"
 axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -2616,14 +2616,12 @@ impl Application {
         // path and daemon path use identical streaming semantics.
         let batch_daemon_cfg = &config.background_services.batch_daemon;
         let batch_daemon_fusillade_cfg = batch_daemon_cfg.to_fusillade_config();
-        let multi_step_http_client: Arc<fusillade::ReqwestHttpClient> = Arc::new(
-            fusillade::ReqwestHttpClient::new(
-                std::time::Duration::from_millis(batch_daemon_fusillade_cfg.first_chunk_timeout_ms),
-                std::time::Duration::from_millis(batch_daemon_fusillade_cfg.chunk_timeout_ms),
-                std::time::Duration::from_millis(batch_daemon_fusillade_cfg.body_timeout_ms),
-                batch_daemon_fusillade_cfg.streamable_endpoints.clone(),
-            ),
-        );
+        let multi_step_http_client: Arc<fusillade::ReqwestHttpClient> = Arc::new(fusillade::ReqwestHttpClient::new(
+            std::time::Duration::from_millis(batch_daemon_fusillade_cfg.first_chunk_timeout_ms),
+            std::time::Duration::from_millis(batch_daemon_fusillade_cfg.chunk_timeout_ms),
+            std::time::Duration::from_millis(batch_daemon_fusillade_cfg.body_timeout_ms),
+            batch_daemon_fusillade_cfg.streamable_endpoints.clone(),
+        ));
         let multi_step_loop_config = onwards::LoopConfig {
             max_response_step_depth: config.responses.max_response_step_depth,
             max_response_iterations: config.responses.max_response_iterations,

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -2615,12 +2615,15 @@ impl Application {
         // come from the same config knobs the daemon respects, so warm
         // path and daemon path use identical streaming semantics.
         let batch_daemon_cfg = &config.background_services.batch_daemon;
-        let multi_step_http_client: Arc<fusillade::ReqwestHttpClient> = Arc::new(fusillade::ReqwestHttpClient::new(
-            std::time::Duration::from_millis(batch_daemon_cfg.first_chunk_timeout_ms),
-            std::time::Duration::from_millis(batch_daemon_cfg.chunk_timeout_ms),
-            std::time::Duration::from_millis(batch_daemon_cfg.body_timeout_ms),
-            batch_daemon_cfg.streamable_endpoints.clone(),
-        ));
+        let batch_daemon_fusillade_cfg = batch_daemon_cfg.to_fusillade_config();
+        let multi_step_http_client: Arc<fusillade::ReqwestHttpClient> = Arc::new(
+            fusillade::ReqwestHttpClient::new(
+                batch_daemon_fusillade_cfg.first_chunk_timeout,
+                batch_daemon_fusillade_cfg.chunk_timeout,
+                batch_daemon_fusillade_cfg.body_timeout,
+                batch_daemon_fusillade_cfg.streamable_endpoints.clone(),
+            ),
+        );
         let multi_step_loop_config = onwards::LoopConfig {
             max_response_step_depth: config.responses.max_response_step_depth,
             max_response_iterations: config.responses.max_response_iterations,

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -2618,9 +2618,9 @@ impl Application {
         let batch_daemon_fusillade_cfg = batch_daemon_cfg.to_fusillade_config();
         let multi_step_http_client: Arc<fusillade::ReqwestHttpClient> = Arc::new(
             fusillade::ReqwestHttpClient::new(
-                batch_daemon_fusillade_cfg.first_chunk_timeout,
-                batch_daemon_fusillade_cfg.chunk_timeout,
-                batch_daemon_fusillade_cfg.body_timeout,
+                std::time::Duration::from_millis(batch_daemon_fusillade_cfg.first_chunk_timeout_ms),
+                std::time::Duration::from_millis(batch_daemon_fusillade_cfg.chunk_timeout_ms),
+                std::time::Duration::from_millis(batch_daemon_fusillade_cfg.body_timeout_ms),
                 batch_daemon_fusillade_cfg.streamable_endpoints.clone(),
             ),
         );

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -2608,8 +2608,19 @@ impl Application {
             multi_step_reqwest_client.clone(),
             Some(multi_step_tool_executor_pool.clone()),
         ));
-        let multi_step_http_client: Arc<dyn onwards::client::HttpClient + Send + Sync> =
-            Arc::new(onwards::client::create_hyper_client(10, 30));
+        // Same `ReqwestHttpClient` shape the batch daemon uses internally,
+        // so per-step model fires inherit fusillade's header stamping
+        // (`X-Fusillade-Request-Id` for analytics correlation) and
+        // streamable-endpoint dispatch. Timeouts and the streamable list
+        // come from the same config knobs the daemon respects, so warm
+        // path and daemon path use identical streaming semantics.
+        let batch_daemon_cfg = &config.background_services.batch_daemon;
+        let multi_step_http_client: Arc<fusillade::ReqwestHttpClient> = Arc::new(fusillade::ReqwestHttpClient::new(
+            std::time::Duration::from_millis(batch_daemon_cfg.first_chunk_timeout_ms),
+            std::time::Duration::from_millis(batch_daemon_cfg.chunk_timeout_ms),
+            std::time::Duration::from_millis(batch_daemon_cfg.body_timeout_ms),
+            batch_daemon_cfg.streamable_endpoints.clone(),
+        ));
         let multi_step_loop_config = onwards::LoopConfig {
             max_response_step_depth: config.responses.max_response_step_depth,
             max_response_iterations: config.responses.max_response_iterations,

--- a/dwctl/src/responses/loop_http_client.rs
+++ b/dwctl/src/responses/loop_http_client.rs
@@ -19,8 +19,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use fusillade::http::{HttpClient as FusilladeHttpClient, HttpResponse};
-use fusillade::{FusilladeError, PoolProvider as FusilladePool, RequestData, Result as FusilladeResult};
-use onwards::client::HttpClient as OnwardsHttpClient;
+use fusillade::{FusilladeError, PoolProvider as FusilladePool, RequestData, ReqwestHttpClient, Result as FusilladeResult};
 use onwards::traits::{RequestContext, ToolExecutor};
 use onwards::{LoopConfig, LoopError, MultiStepStore, UpstreamTarget};
 
@@ -40,7 +39,13 @@ where
 {
     pub response_store: Arc<FusilladeResponseStore<P>>,
     pub tool_executor: Arc<T>,
-    pub inner_http: Arc<dyn OnwardsHttpClient + Send + Sync>,
+    /// Same `fusillade::ReqwestHttpClient` instance the batch / single-
+    /// step paths use. Going through fusillade for per-step model
+    /// fires (instead of an onwards `HyperClient`) is what gets the
+    /// `X-Fusillade-Request-Id` header — and therefore correct
+    /// analytics attribution — stamped on each outgoing call without
+    /// any extra plumbing on this side.
+    pub inner_http: Arc<ReqwestHttpClient>,
     pub tool_resolver: Option<Arc<dyn DaemonToolResolver>>,
     pub loop_config: LoopConfig,
 }
@@ -131,11 +136,13 @@ where
         // dwctl rewrites /v1/responses → /v1/chat/completions on the wire
         // since most upstreams speak chat-completions (transition.rs builds
         // the messages array). The row's `endpoint` carries the base URL.
+        // Splitting endpoint + path (rather than concatenating into a
+        // single URL) lets fusillade key its streaming-vs-buffered
+        // dispatch on `path` — passing the whole thing in `endpoint`
+        // would force every per-step fire down the non-streaming path.
         let upstream = UpstreamTarget {
-            url: {
-                let base = request.endpoint.trim_end_matches('/');
-                format!("{base}/v1/chat/completions")
-            },
+            endpoint: request.endpoint.trim_end_matches('/').to_string(),
+            path: "/v1/chat/completions".to_string(),
             api_key: api_key_opt,
         };
 

--- a/dwctl/src/responses/middleware.rs
+++ b/dwctl/src/responses/middleware.rs
@@ -49,7 +49,7 @@ pub struct ResponsesMiddlewareState<P: PoolProvider + Clone = sqlx_pool_router::
     /// [`super::streaming::run_inline_streaming`] using these.
     pub response_store: Arc<super::store::FusilladeResponseStore<P>>,
     pub multi_step_tool_executor: Arc<crate::tool_executor::HttpToolExecutor>,
-    pub multi_step_http_client: Arc<dyn onwards::client::HttpClient + Send + Sync>,
+    pub multi_step_http_client: Arc<fusillade::ReqwestHttpClient>,
     pub loop_config: onwards::LoopConfig,
 }
 
@@ -827,8 +827,12 @@ async fn warm_path_setup<P: PoolProvider + Clone + Send + Sync + 'static>(
         return None;
     }
 
+    // Endpoint + path are split (not pre-concatenated) so fusillade
+    // can match `/v1/chat/completions` against its streamable_endpoints
+    // list and pick the streaming branch when the user requested SSE.
     let upstream = onwards::UpstreamTarget {
-        url: format!("{}/v1/chat/completions", state.loopback_base_url),
+        endpoint: state.loopback_base_url.clone(),
+        path: "/v1/chat/completions".to_string(),
         api_key: Some(api_key.to_string()),
     };
 

--- a/dwctl/src/responses/processor.rs
+++ b/dwctl/src/responses/processor.rs
@@ -36,9 +36,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use fusillade::request::{Canceled, Claimed, Request, RequestCompletionResult};
-use fusillade::{CancellationFuture, DefaultRequestProcessor, PoolProvider as FusilladePool, RequestProcessor, ShouldRetry, Storage};
+use fusillade::{
+    CancellationFuture, DefaultRequestProcessor, PoolProvider as FusilladePool, RequestProcessor, ReqwestHttpClient, ShouldRetry, Storage,
+};
 use onwards::LoopConfig;
-use onwards::client::HttpClient;
 use onwards::traits::ToolExecutor;
 
 use crate::responses::loop_http_client::ResponseLoopHttpClient;
@@ -61,7 +62,7 @@ where
 {
     pub response_store: Arc<FusilladeResponseStore<P>>,
     pub tool_executor: Arc<T>,
-    pub http_client: Arc<dyn HttpClient + Send + Sync>,
+    pub http_client: Arc<ReqwestHttpClient>,
     pub loop_config: LoopConfig,
     /// Tool resolver for the daemon path. Tools today are scoped per
     /// (api_key, model alias) — same as the realtime middleware path —
@@ -109,7 +110,7 @@ where
     pub fn new(
         response_store: Arc<FusilladeResponseStore<P>>,
         tool_executor: Arc<T>,
-        http_client: Arc<dyn HttpClient + Send + Sync>,
+        http_client: Arc<ReqwestHttpClient>,
         loop_config: LoopConfig,
     ) -> Self {
         Self {

--- a/dwctl/src/responses/store.rs
+++ b/dwctl/src/responses/store.rs
@@ -1000,6 +1000,15 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> MultiStepStore for Fusilla
         Ok(RecordedStep {
             id: id.0.to_string(),
             sequence,
+            // Hand the sub-request fusillade row id back to onwards so
+            // its loop can stamp it as `X-Fusillade-Request-Id` on the
+            // outgoing HTTP fire — that's how the resulting
+            // `http_analytics` row gets attributed to the right row in
+            // `fusillade.requests`. `tool_call` steps don't get a
+            // sub-request row (analytics live in `tool_call_analytics`
+            // keyed on response_step_id), so this stays `None` for
+            // them per the DB CHECK constraint.
+            sub_request_id: req_id,
         })
     }
 

--- a/dwctl/src/responses/streaming.rs
+++ b/dwctl/src/responses/streaming.rs
@@ -32,8 +32,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::response::sse::{Event, KeepAlive, Sse};
+use fusillade::ReqwestHttpClient;
 use futures::stream::Stream;
-use onwards::client::HttpClient;
 use onwards::traits::RequestContext;
 use onwards::{EventSink, EventSinkError, LoopConfig, LoopError, LoopEvent, MultiStepStore, UpstreamTarget};
 use serde_json::Value;
@@ -92,7 +92,7 @@ pub fn run_inline_streaming<P>(
     response_store: Arc<FusilladeResponseStore<P>>,
     tool_executor: Arc<HttpToolExecutor>,
     tool_resolved: Arc<crate::tool_executor::ResolvedToolSet>,
-    http_client: Arc<dyn HttpClient + Send + Sync>,
+    http_client: Arc<ReqwestHttpClient>,
     upstream: UpstreamTarget,
     loop_config: LoopConfig,
     request_id: String,
@@ -208,7 +208,7 @@ pub async fn run_inline_blocking<P>(
     response_store: Arc<FusilladeResponseStore<P>>,
     tool_executor: Arc<HttpToolExecutor>,
     tool_resolved: Arc<crate::tool_executor::ResolvedToolSet>,
-    http_client: Arc<dyn HttpClient + Send + Sync>,
+    http_client: Arc<ReqwestHttpClient>,
     upstream: UpstreamTarget,
     loop_config: LoopConfig,
     request_id: String,

--- a/dwctl/src/test/multi_step_executor.rs
+++ b/dwctl/src/test/multi_step_executor.rs
@@ -27,7 +27,6 @@ use async_trait::async_trait;
 use fusillade::{
     PoolProvider as FusilladePoolProvider, PostgresRequestManager, PostgresResponseStepManager, ReqwestHttpClient, TestDbPools,
 };
-use onwards::client::HttpClient;
 use onwards::traits::RequestContext;
 use onwards::{
     ChainStep, LoopConfig, MultiStepStore, NextAction, RecordedStep, StepDescriptor, StepKind, StepState, StoreError, UpstreamTarget,
@@ -184,8 +183,21 @@ impl<P: FusilladePoolProvider + Clone + Send + Sync + 'static> MultiStepStore fo
     }
 }
 
-fn http_client_for_tests() -> Arc<dyn HttpClient + Send + Sync> {
-    Arc::new(onwards::client::create_hyper_client(10, 30))
+fn http_client_for_tests() -> Arc<ReqwestHttpClient> {
+    // `streamable_endpoints` is empty so this test's wiremock — which
+    // returns plain JSON, not SSE — goes through the buffered branch.
+    // Marking `/v1/chat/completions` streamable would route through
+    // fusillade's reassembler, which expects `data: …` events and would
+    // empty out the response_payload (no `wants_tool` field) and trip
+    // the transition function's unexpected-chain-state arm. The
+    // streaming behaviour itself is exercised by onwards' own
+    // response_loop tests against an SSE-emitting wiremock.
+    Arc::new(ReqwestHttpClient::new(
+        std::time::Duration::from_secs(60),
+        std::time::Duration::from_secs(60),
+        std::time::Duration::from_secs(120),
+        Vec::new(),
+    ))
 }
 
 async fn store_with_real_fusillade(pool: PgPool) -> FusilladeResponseStore<TestDbPools> {
@@ -252,7 +264,8 @@ async fn loop_drives_real_tool_and_model_calls_through_production_executor(pool:
     // Real onwards HyperClient for the model fire path.
     let http_client = http_client_for_tests();
     let upstream = UpstreamTarget {
-        url: format!("{}/v1/chat/completions", model_server.uri()),
+        endpoint: model_server.uri(),
+        path: "/v1/chat/completions".to_string(),
         api_key: None,
     };
 


### PR DESCRIPTION
## Summary

Collapse the multi-step warm + daemon paths onto the **same `fusillade::ReqwestHttpClient` instance** the batch / single-step paths already use, instead of carrying a parallel `Arc<dyn onwards::HttpClient>` (an onwards `HyperClient`) just for per-step model fires. One trait, one fire site, one place that stamps the `X-Fusillade-Request-Id` header.

## Why

Before this PR, every `/v1/responses` multi-step request wrote **two** rows to `fusillade.requests` per model_call step:

1. The head sub-request row that `record_step` creates and `response_steps[head].request_id` points at — the row the dashboard's response detail view joins to.
2. An orphan row produced when the loop's loopback `/v1/chat/completions` fire hit dwctl's own `responses_middleware`. That middleware's short-circuit at `middleware.rs:69` only triggers when the inbound request carries `x-fusillade-request-id` — but onwards' hyper client doesn't know about that header, so the middleware fell through and synthesised a fresh row.

Effect:
- **Dashboard listing duplicates.** The anti-join `WHERE NOT EXISTS (… parent_step_id IS NOT NULL)` keeps both rows (head's `response_steps` row has `parent_step_id IS NULL`; the orphan has none at all).
- **Analytics attributed to the orphan.** `http_analytics.fusillade_request_id` ends up pointing at the orphan, so `requests → http_analytics` JOINs from the head row return nothing — token counts and cost surface as NULL on the response detail page.

Going through fusillade's `ReqwestHttpClient` fixes both — it stamps the header from `RequestData.id`, the middleware short-circuits, and the analytics linkage lines up with the row `response_steps` points at.

## What changes

| File | Change |
|---|---|
| `dwctl/src/responses/loop_http_client.rs` | `inner_http: Arc<dyn OnwardsHttpClient>` → `Arc<ReqwestHttpClient>`. `UpstreamTarget { url: … }` → `{ endpoint, path }` (fusillade keys streaming dispatch on `path`). |
| `dwctl/src/responses/processor.rs` | `DwctlRequestProcessor.http_client` type swap (field + `new()` arg). |
| `dwctl/src/responses/middleware.rs` | `ResponsesMiddlewareState.multi_step_http_client` type swap. Warm-path `UpstreamTarget` literal moves to `endpoint`/`path`. |
| `dwctl/src/responses/streaming.rs` | `run_inline_streaming` / `run_inline_blocking` http_client param type swap. |
| `dwctl/src/responses/store.rs` | `FusilladeResponseStore::record_step` returns the sub-request fusillade row id in `RecordedStep.sub_request_id` — that's the id onwards' loop stamps on its outgoing call. |
| `dwctl/src/lib.rs` | `multi_step_http_client` construction now builds `Arc<ReqwestHttpClient>` from the daemon's existing timeout + streamable-endpoints config, so warm and daemon paths use identical streaming semantics. |
| `dwctl/src/test/multi_step_executor.rs` | Fixture client uses `Arc<ReqwestHttpClient>` with empty `streamable_endpoints` (the wiremock here serves plain JSON; the SSE branch is covered by onwards' own response_loop tests). |
| `Cargo.toml` / `dwctl/Cargo.toml` | Enables `features = ["multi-step"]` on the `onwards` dep + temporary local `[patch.*]` overrides for dev (see "Before merge" below). |

## Out of scope (deferred)

- **`http_analytics.response_step_id` extraction** in `request_logging/analytics_handler.rs` and `X-Response-Step-Id` stamping at the loop fire site. Needs an additional `fusillade::RequestData` field + an onwards-loop tweak to thread the step id alongside `sub_request_id`. Independent of the header-alignment win this PR delivers, and the column is unused today.
- **`tool_call_analytics.response_step_id`** — same shape of gap (column added in dwctl migration 096 but never populated by `HttpToolExecutor`). Tracked separately.

## Related PRs

- fusillade [#263 — streaming event callback](https://github.com/doublewordai/fusillade/pull/263) (merged): adds the per-event SSE callback so the warm streaming path keeps live token-delta forwarding when switching to fusillade for the fire.
- onwards [#188 — multi-step feature flag use of fusillade](https://github.com/doublewordai/onwards/pull/188): puts the multi-step orchestration loop behind a Cargo feature, threads `sub_request_id` through `RecordedStep` → `execute_step` → `fire_model_call`, splits `UpstreamTarget` into `endpoint`/`path`, and bridges fusillade's sync callback into onwards' async `EventSink` over a bounded mpsc.

## Before merge

This branch currently depends on:

- fusillade `main` (post-#263) being on crates.io as `17.0.2+` with the new `StreamEvent` / `StreamEventCallback` / `execute_with_event_callback` types.
- onwards (post-#188) being on crates.io as `0.28+` with the `multi-step` feature.

Until both are published the branch carries `[patch.crates-io]` and `[patch."https://github.com/doublewordai/fusillade"]` blocks in the root `Cargo.toml` so local dev resolves through sibling checkouts. **CI will not pass with those patches in place** (CI runners have no sibling fusillade/onwards checkouts).

Two ways to unblock CI:
1. **Recommended**: land the fusillade + onwards releases, drop the patch blocks, re-push.
2. **Workaround**: flip dwctl's `fusillade` / `onwards` deps to `{ git = "…", branch = "…" }` (same approach the onwards PR uses while it's mid-flight).

## Test plan

- [x] `just lint rust` — clean (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo sqlx prepare --check`).
- [x] `just test rust` — 1305 pass / 0 fail / 1 ignored.
- [ ] End-to-end against staging: fire one `/v1/responses` request, query `fusillade.requests` + `http_analytics` and confirm only the head sub-request row exists per model_call step and `http_analytics.fusillade_request_id` matches it.
- [ ] Streaming response: warm-path `/v1/responses` with `stream:true` still forwards token deltas live to the SSE channel (covered structurally by onwards #188's `streaming_model_call_forwards_token_deltas_and_emits_terminals` test).