### PR TITLE
feat: single request deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,7 +2383,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "17.0.2"
+version = "17.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99dfb7043acf8e2fba87a5c97bc839e63ad193d28f2a2b5b980995e62af75ff4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,8 +2384,6 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "fusillade"
 version = "17.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba270cfbceca4ece0a85b337a8d8599e16548a104077097631a1ce81bb6a636"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = ["dwctl"]
 resolver = "2"
+
+[patch.crates-io]
+fusillade = { path = "../fusillade" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
 [workspace]
 members = ["dwctl"]
 resolver = "2"
-
-[patch.crates-io]
-fusillade = { path = "../fusillade" }

--- a/dashboard/src/components/modals/CreateAsyncModal/CreateAsyncModal.tsx
+++ b/dashboard/src/components/modals/CreateAsyncModal/CreateAsyncModal.tsx
@@ -105,10 +105,13 @@ export function CreateAsyncModal({
     return base.endsWith("/v1") ? base : `${base}/v1`;
   }, [config?.ai_api_base_url]);
 
-  // Submit URL — routed through the dashboard's own origin to avoid CORS.
-  // In dev the Vite proxy forwards /ai → dwctl on :3001; in prod app.doubleword.ai
-  // serves /ai/v1 from the same host as the dashboard.
-  const submitUrl = "/ai/v1/responses";
+  // Submit URL — routed through `/admin/api/v1/ai/v1` so dwctl's
+  // `admin_ai_proxy_middleware` can resolve the current user from the
+  // session cookie, mint a hidden playground API key, and forward to
+  // onwards as `POST /ai/v1/responses`. Posting directly to `/ai/v1/...`
+  // would hit onwards, which only accepts Bearer-key auth and 401s on a
+  // bare cookie. Same pattern the Playground uses for chat completions.
+  const submitUrl = "/admin/api/v1/ai/v1/responses";
 
   const buildResponseBody = useCallback(() => {
     const body: Record<string, unknown> = {
@@ -241,10 +244,6 @@ export function CreateAsyncModal({
   const handleSubmit = async () => {
     setError(null);
 
-    if (!apiKey) {
-      setError("Enter an API key before submitting");
-      return;
-    }
     if (!model) {
       setError("Please select a model");
       return;
@@ -256,14 +255,15 @@ export function CreateAsyncModal({
 
     setIsSubmitting(true);
     try {
-      // Call the Open Responses API the same way the snippet shows, but via
-      // the dashboard's same-origin /ai/v1 path so the browser doesn't block
-      // it on CORS. The backend responses middleware turns this into a
-      // tracked async/realtime request that surfaces on the Responses page.
+      // Same-origin POST — dwctl accepts the session cookie on /ai/v1 the
+      // same way the Playground does, so the user doesn't need to mint a
+      // Bearer key just to submit from inside the dashboard. (The Snippet
+      // tab still surfaces a Bearer key because that snippet is meant to be
+      // copy-pasted into the user's own app.)
       const res = await fetch(submitUrl, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${apiKey}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(buildResponseBody()),
@@ -273,7 +273,7 @@ export function CreateAsyncModal({
         const text = await res.text().catch(() => "");
         if (res.status === 401 || res.status === 403) {
           throw new Error(
-            "API key was rejected — try minting a new one with the button above",
+            "Your session has expired — please reload and sign in again",
           );
         }
         throw new Error(
@@ -316,10 +316,7 @@ export function CreateAsyncModal({
   };
 
   const canSubmit =
-    Boolean(apiKey) &&
-    Boolean(model) &&
-    userPrompt.trim().length > 0 &&
-    !isSubmitting;
+    Boolean(model) && userPrompt.trim().length > 0 && !isSubmitting;
 
   const renderApiKeyPopover = (trigger: React.ReactNode) => (
     <Popover open={showCreateForm} onOpenChange={setShowCreateForm}>
@@ -393,44 +390,6 @@ export function CreateAsyncModal({
           </DialogDescription>
         </DialogHeader>
 
-        {/* Shared API key bar — both the Compose submit and the Snippet tab
-            use the same key, so a single source of truth at the top is
-            clearer than duplicating the affordance. */}
-        <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/30 px-3 py-2">
-          <div className="flex items-center gap-2 min-w-0">
-            <KeyRound className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-            <span className="text-sm font-medium text-doubleword-neutral-700">
-              API key
-            </span>
-            <span className="text-sm font-mono text-muted-foreground truncate">
-              {apiKey
-                ? `${apiKey.slice(0, 6)}…${apiKey.slice(-4)}`
-                : "not set"}
-            </span>
-          </div>
-          <div className="flex items-center gap-1">
-            {apiKey && (
-              <button
-                type="button"
-                onClick={() => handleCopy(apiKey, "api-key")}
-                className="flex items-center gap-1 px-2 py-1 text-xs text-green-600 hover:text-green-700 hover:bg-green-50 rounded transition-colors"
-              >
-                <Copy className="w-3 h-3" />
-                {copiedCode === "api-key" ? "Copied!" : "Copy"}
-              </button>
-            )}
-            {renderApiKeyPopover(
-              <button
-                type="button"
-                className="flex items-center gap-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors"
-              >
-                <Plus className="w-3 h-3" />
-                {apiKey ? "Replace" : "Fill API key"}
-              </button>,
-            )}
-          </div>
-        </div>
-
         <Tabs
           value={activeTab}
           onValueChange={(v) => setActiveTab(v as "compose" | "snippet")}
@@ -502,6 +461,45 @@ export function CreateAsyncModal({
           </TabsContent>
 
           <TabsContent value="snippet" className="space-y-3 mt-4">
+            {/* API key bar — only relevant to the snippet, since the Compose
+                tab submits same-origin and authenticates via session cookie.
+                Users mint a key here so the copy-pasteable snippet they take
+                to their own app has a real Bearer token baked in. */}
+            <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/30 px-3 py-2">
+              <div className="flex items-center gap-2 min-w-0">
+                <KeyRound className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                <span className="text-sm font-medium text-doubleword-neutral-700">
+                  API key
+                </span>
+                <span className="text-sm font-mono text-muted-foreground truncate">
+                  {apiKey
+                    ? `${apiKey.slice(0, 6)}…${apiKey.slice(-4)}`
+                    : "not set"}
+                </span>
+              </div>
+              <div className="flex items-center gap-1">
+                {apiKey && (
+                  <button
+                    type="button"
+                    onClick={() => handleCopy(apiKey, "api-key")}
+                    className="flex items-center gap-1 px-2 py-1 text-xs text-green-600 hover:text-green-700 hover:bg-green-50 rounded transition-colors"
+                  >
+                    <Copy className="w-3 h-3" />
+                    {copiedCode === "api-key" ? "Copied!" : "Copy"}
+                  </button>
+                )}
+                {renderApiKeyPopover(
+                  <button
+                    type="button"
+                    className="flex items-center gap-1 px-2 py-1 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors"
+                  >
+                    <Plus className="w-3 h-3" />
+                    {apiKey ? "Replace" : "Fill API key"}
+                  </button>,
+                )}
+              </div>
+            </div>
+
             <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
               <div className="bg-gray-50 px-4 py-2 border-b border-gray-200 flex items-center justify-between">
                 <div className="flex items-center gap-2">

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "17.0.2" }
+fusillade = { version = "17.1.0" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/dwctl/src/api/handlers/batch_requests.rs
+++ b/dwctl/src/api/handlers/batch_requests.rs
@@ -24,9 +24,7 @@ use crate::{
         pagination::PaginatedResponse,
         users::CurrentUser,
     },
-    auth::permissions::{
-        RequiresPermission, can_delete_all_resources, can_read_all_resources, operation, resource,
-    },
+    auth::permissions::{RequiresPermission, can_delete_all_resources, can_read_all_resources, operation, resource},
     errors::{Error, Result},
     types::Resource,
 };
@@ -324,9 +322,21 @@ pub async fn get_batch_request<P: PoolProvider>(
 
 /// Delete a response (batchless fusillade request) by ID.
 ///
-/// Hard-deletes the row for right-to-erasure compliance: response_steps
-/// cascade via FK; `http_analytics` and `credits_transactions` are denormalized
-/// and survive the delete so billing/usage metrics remain intact.
+/// Hard-deletes for right-to-erasure compliance. The fusillade primitive
+/// (`Storage::delete_request`) removes:
+/// * the `requests` row,
+/// * its dedicated batchless `request_templates` row (carrying the prompt
+///   body — 1:1 with the request when `file_id IS NULL`), and
+/// * all `response_steps` whose `request_id` matches (via FK cascade).
+///
+/// **Preserved**: `http_analytics` (token counts, cost, status code — no FK
+/// to requests) and `credits_transactions` (immutable; denormalizes
+/// `fusillade_batch_id` only, not `fusillade_request_id`). Billing and
+/// usage records survive the erasure.
+///
+/// Multi-step Open Responses (with a step tree) are deleted via
+/// `DELETE /ai/v1/responses/{id}` instead — that handler walks the chain
+/// and calls this primitive for every backing sub-request.
 #[utoipa::path(
     delete,
     path = "/admin/api/v1/batches/requests/{request_id}",

--- a/dwctl/src/api/handlers/batch_requests.rs
+++ b/dwctl/src/api/handlers/batch_requests.rs
@@ -10,6 +10,7 @@
 
 use axum::{
     extract::{Path, Query, State},
+    http::StatusCode,
     response::Json,
 };
 use fusillade::Storage;
@@ -23,7 +24,9 @@ use crate::{
         pagination::PaginatedResponse,
         users::CurrentUser,
     },
-    auth::permissions::{RequiresPermission, can_read_all_resources, operation, resource},
+    auth::permissions::{
+        RequiresPermission, can_delete_all_resources, can_read_all_resources, operation, resource,
+    },
     errors::{Error, Result},
     types::Resource,
 };
@@ -319,6 +322,78 @@ pub async fn get_batch_request<P: PoolProvider>(
     }))
 }
 
+/// Delete a response (batchless fusillade request) by ID.
+///
+/// Hard-deletes the row for right-to-erasure compliance: response_steps
+/// cascade via FK; `http_analytics` and `credits_transactions` are denormalized
+/// and survive the delete so billing/usage metrics remain intact.
+#[utoipa::path(
+    delete,
+    path = "/admin/api/v1/batches/requests/{request_id}",
+    params(
+        ("request_id" = Uuid, Path, description = "The request ID"),
+    ),
+    responses(
+        (status = 204, description = "Response deleted"),
+        (status = 404, description = "Response not found"),
+        (status = 403, description = "Insufficient permissions"),
+        (status = 500, description = "Internal server error"),
+    ),
+    tag = "batch_requests",
+)]
+#[tracing::instrument(skip_all, fields(user_id = %current_user.id, request_id = %request_id))]
+pub async fn delete_batch_request<P: PoolProvider>(
+    State(state): State<AppState<P>>,
+    Path(request_id): Path<Uuid>,
+    current_user: CurrentUser,
+    _: RequiresPermission<resource::Batches, operation::DeleteOwn>,
+) -> Result<StatusCode> {
+    // Fetch first to verify existence + ownership. `get_request_detail` filters
+    // batched rows (WHERE r.created_by IS NOT NULL), so we can't accidentally
+    // delete a row that belongs to a batch via this endpoint.
+    let detail = state
+        .request_manager
+        .get_request_detail(fusillade::RequestId(request_id))
+        .await
+        .map_err(|e| match e {
+            fusillade::FusilladeError::RequestNotFound(_) => Error::NotFound {
+                resource: "Response".to_string(),
+                id: request_id.to_string(),
+            },
+            other => {
+                tracing::error!(request_id = %request_id, error = %other, "failed to fetch response for delete");
+                Error::Internal {
+                    operation: format!("get response for delete: {}", other),
+                }
+            }
+        })?;
+
+    // 404 (not 403) avoids leaking existence of other users' responses.
+    let can_delete_all = can_delete_all_resources(&current_user, Resource::Batches);
+    if !can_delete_all && !is_batch_owner(&current_user, &detail.created_by) {
+        return Err(Error::NotFound {
+            resource: "Response".to_string(),
+            id: request_id.to_string(),
+        });
+    }
+
+    state
+        .request_manager
+        .delete_request(fusillade::RequestId(request_id))
+        .await
+        .map_err(|e| match e {
+            fusillade::FusilladeError::RequestNotFound(_) => Error::NotFound {
+                resource: "Response".to_string(),
+                id: request_id.to_string(),
+            },
+            other => Error::Internal {
+                operation: format!("delete response: {}", other),
+            },
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// Analytics data from http_analytics (dwctl-owned, not fusillade schema)
 #[derive(sqlx::FromRow)]
 struct AnalyticsRow {
@@ -444,5 +519,97 @@ mod tests {
         let body: serde_json::Value = response.json();
         assert_eq!(body["id"], request_id.to_string());
         assert_eq!(body["created_by_email"], user.email);
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_delete_batch_request_removes_row(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user_with_roles(&pool, vec![Role::StandardUser, Role::BatchAPIUser]).await;
+        let auth = add_auth_headers(&user);
+
+        let template_id = uuid::Uuid::new_v4();
+        let request_id = uuid::Uuid::new_v4();
+        let body = serde_json::json!({"model": "test-model", "messages": [{"role": "user", "content": "hi"}]});
+
+        sqlx::query(
+            "INSERT INTO fusillade.request_templates (id, file_id, model, api_key, endpoint, path, body, custom_id, method) VALUES ($1, NULL, 'test-model', 'test-key', 'http://test', '/v1/chat/completions', $2, NULL, 'POST')",
+        )
+        .bind(template_id)
+        .bind(serde_json::to_string(&body).unwrap())
+        .execute(&pool)
+        .await
+        .expect("insert template");
+
+        sqlx::query(
+            "INSERT INTO fusillade.requests (id, batch_id, template_id, model, state, created_at, created_by) VALUES ($1, NULL, $2, 'test-model', 'pending', NOW(), $3)",
+        )
+        .bind(request_id)
+        .bind(template_id)
+        .bind(user.id.to_string())
+        .execute(&pool)
+        .await
+        .expect("insert request");
+
+        let response = app
+            .delete(&format!("/admin/api/v1/batches/requests/{}", request_id))
+            .add_header(&auth[0].0, &auth[0].1)
+            .add_header(&auth[1].0, &auth[1].1)
+            .await;
+        response.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM fusillade.requests WHERE id = $1")
+            .bind(request_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0, "fusillade row should be hard-deleted");
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_delete_batch_request_404_for_other_users_row(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let owner = create_test_user_with_roles(&pool, vec![Role::StandardUser, Role::BatchAPIUser]).await;
+        let intruder = create_test_user_with_roles(&pool, vec![Role::StandardUser, Role::BatchAPIUser]).await;
+        let intruder_auth = add_auth_headers(&intruder);
+
+        let template_id = uuid::Uuid::new_v4();
+        let request_id = uuid::Uuid::new_v4();
+        let body = serde_json::json!({"model": "test-model", "messages": []});
+
+        sqlx::query(
+            "INSERT INTO fusillade.request_templates (id, file_id, model, api_key, endpoint, path, body, custom_id, method) VALUES ($1, NULL, 'test-model', 'test-key', 'http://test', '/v1/chat/completions', $2, NULL, 'POST')",
+        )
+        .bind(template_id)
+        .bind(serde_json::to_string(&body).unwrap())
+        .execute(&pool)
+        .await
+        .expect("insert template");
+
+        sqlx::query(
+            "INSERT INTO fusillade.requests (id, batch_id, template_id, model, state, created_at, created_by) VALUES ($1, NULL, $2, 'test-model', 'pending', NOW(), $3)",
+        )
+        .bind(request_id)
+        .bind(template_id)
+        .bind(owner.id.to_string())
+        .execute(&pool)
+        .await
+        .expect("insert request");
+
+        let response = app
+            .delete(&format!("/admin/api/v1/batches/requests/{}", request_id))
+            .add_header(&intruder_auth[0].0, &intruder_auth[0].1)
+            .add_header(&intruder_auth[1].0, &intruder_auth[1].1)
+            .await;
+        response.assert_status_not_found();
+
+        // Row is still there — intruder couldn't delete it.
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM fusillade.requests WHERE id = $1")
+            .bind(request_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 1, "row should remain — ownership check should reject");
     }
 }

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1246,6 +1246,10 @@ pub async fn build_router(
             "/batches/requests/{request_id}",
             get(api::handlers::batch_requests::get_batch_request),
         )
+        .route(
+            "/batches/requests/{request_id}",
+            delete(api::handlers::batch_requests::delete_batch_request),
+        )
         .route("/requests", get(api::handlers::requests::list_requests))
         .route("/requests/aggregate", get(api::handlers::requests::aggregate_requests))
         .route("/requests/aggregate-by-user", get(api::handlers::requests::aggregate_by_user))
@@ -1359,6 +1363,7 @@ pub async fn build_router(
                 .route("/files/{file_id}/cost-estimate", get(api::handlers::files::get_file_cost_estimate))
                 // Responses retrieval (Open Responses API)
                 .route("/responses/{response_id}", get(crate::responses::handler::get_response))
+                .route("/responses/{response_id}", delete(crate::responses::handler::delete_response))
                 // Batches management
                 .route("/batches", post(api::handlers::batches::create_batch))
                 .route("/batches", get(api::handlers::batches::list_batches))

--- a/dwctl/src/openapi/ai.rs
+++ b/dwctl/src/openapi/ai.rs
@@ -185,6 +185,8 @@ fn create_response() {}
         list_models,
         get_model,
         create_response,
+        // Responses API delete (actual handler)
+        crate::responses::handler::delete_response,
         // Batch API endpoints (actual handlers)
         api::handlers::files::upload_file,
         api::handlers::files::list_files,

--- a/dwctl/src/responses/handler.rs
+++ b/dwctl/src/responses/handler.rs
@@ -120,13 +120,48 @@ pub async fn get_response<P: PoolProvider>(
 /// Delete a response by ID.
 ///
 /// Right-to-erasure: hard-deletes every `fusillade.requests` row that backs
-/// the response. For multi-step responses, walks the `response_steps` chain
-/// from the head step and deletes each step's sub-request — the `response_steps`
-/// rows themselves cascade via FK. For single-step responses (chat completions
+/// the response (and each row's dedicated batchless `request_templates`
+/// row carrying the prompt body — see `fusillade::Storage::delete_request`).
+/// For multi-step responses, walks the `response_steps` chain from the head
+/// step and deletes each step's sub-request — the `response_steps` rows
+/// themselves cascade via FK. For single-step responses (chat completions
 /// / embeddings retrieved via the same GET surface), deletes the one row.
 ///
-/// `http_analytics` has no FK to requests and is preserved so billing / usage
-/// records survive.
+/// **Preserved by design**: `http_analytics` has no FK to requests (token
+/// counts, cost, status code), and `credits_transactions` is immutable
+/// (denormalized `fusillade_batch_id` only, no request-id link). Billing
+/// and usage records survive an erasure of the inference data.
+///
+/// **Auth pattern** mirrors `get_response`: direct lookup against
+/// `public.api_keys` for the Bearer key. Session/cookie-authed dashboard
+/// deletes flow through `DELETE /admin/api/v1/batches/requests/{id}`
+/// instead (uses the standard `RequiresPermission` middleware) — the
+/// `admin_ai_proxy_middleware` rewrite path used by chat-completions /
+/// responses POST can't cover GET/DELETE because it requires a request body
+/// to extract the model name.
+#[utoipa::path(
+    delete,
+    path = "/responses/{response_id}",
+    tag = "responses-api",
+    summary = "Delete response",
+    description = "Hard-deletes a response and every fusillade row that backs it (\
+including the dedicated request_templates row carrying the prompt body). \
+Provided for right-to-erasure compliance.
+
+Token / cost analytics in `http_analytics` and billing transactions in \
+`credits_transactions` are preserved — they are denormalized off the fusillade \
+schema and survive the erasure.",
+    params(
+        ("response_id" = String, Path, description = "The response ID returned when the response was created (with or without the `resp_` prefix).")
+    ),
+    responses(
+        (status = 204, description = "Response deleted."),
+        (status = 401, description = "Invalid or missing API key. Ensure your `Authorization` header is set to `Bearer YOUR_API_KEY`."),
+        (status = 404, description = "Response not found or you don't have access to it."),
+        (status = 500, description = "An unexpected error occurred. Retry the request or contact support if the issue persists.")
+    ),
+    security(("BearerAuth" = []))
+)]
 #[tracing::instrument(skip_all, fields(response_id = %response_id))]
 pub async fn delete_response<P: PoolProvider>(
     State(state): State<AppState<P>>,
@@ -155,55 +190,52 @@ pub async fn delete_response<P: PoolProvider>(
     // Resolve which fusillade.requests rows back this response, mirroring
     // `get_response`'s resolution:
     //   * Multi-step — head_step exists; walk the chain and collect every
-    //     `request_id` from its rows (None on tool_call steps).
+    //     `request_id` from its rows (`None` on tool_call steps, which have
+    //     no backing fusillade row — tool dispatch lives in
+    //     `tool_call_analytics`).
     //   * Single-step — head_step_uuid is itself the fusillade.requests id.
     //
     // For the ownership check we use the head row's `created_by` (same row
     // `get_response` authorizes against): the chain is owned end-to-end by
     // the user who initiated the response, so authorizing the head implies
     // authorizing every sub-request in it.
-    let (auth_request_id, request_ids_to_delete): (
-        fusillade::RequestId,
-        Vec<fusillade::RequestId>,
-    ) = match state.response_step_manager.as_ref() {
-        Some(step_manager) => match step_manager
-            .get_step(fusillade::StepId(head_step_uuid))
-            .await
-            .map_err(|e| {
-                Error::Database(crate::db::errors::DbError::Other(anyhow::anyhow!("{e}")))
-            })? {
-            Some(head_step) => {
-                let chain = step_manager
-                    .list_chain(fusillade::StepId(head_step_uuid))
-                    .await
-                    .map_err(|e| {
-                        Error::Database(crate::db::errors::DbError::Other(anyhow::anyhow!("{e}")))
-                    })?;
-                let ids: Vec<fusillade::RequestId> = chain
-                    .iter()
-                    .filter_map(|s| s.request_id)
-                    .collect::<HashSet<_>>()
-                    .into_iter()
-                    .collect();
-                let auth_id = head_step
-                    .request_id
-                    .unwrap_or(fusillade::RequestId(head_step_uuid));
-                // Fall back to the auth id if the chain query returned nothing
-                // (head with no model_call sub-request, e.g. a pure tool_call
-                // head — unusual but not impossible).
-                let ids = if ids.is_empty() { vec![auth_id] } else { ids };
-                (auth_id, ids)
-            }
+    let (auth_request_id, request_ids_to_delete): (fusillade::RequestId, Vec<fusillade::RequestId>) =
+        match state.response_step_manager.as_ref() {
+            Some(step_manager) => match step_manager
+                .get_step(fusillade::StepId(head_step_uuid))
+                .await
+                .map_err(|e| Error::Database(crate::db::errors::DbError::Other(anyhow::anyhow!("{e}"))))?
+            {
+                Some(head_step) => {
+                    let chain = step_manager
+                        .list_chain(fusillade::StepId(head_step_uuid))
+                        .await
+                        .map_err(|e| Error::Database(crate::db::errors::DbError::Other(anyhow::anyhow!("{e}"))))?;
+                    let ids: Vec<fusillade::RequestId> = chain
+                        .iter()
+                        .filter_map(|s| s.request_id)
+                        .collect::<HashSet<_>>()
+                        .into_iter()
+                        .collect();
+                    // Fallback: a pure tool_call head with no model_call descendants
+                    // has an empty chain (no `request_id`s anywhere). Treat the head
+                    // step uuid as a fusillade.requests id — the delete loop below
+                    // tolerates `RequestNotFound` so this resolves to a 404 on the
+                    // ownership check rather than a 500.
+                    let auth_id = head_step.request_id.unwrap_or(fusillade::RequestId(head_step_uuid));
+                    let ids = if ids.is_empty() { vec![auth_id] } else { ids };
+                    (auth_id, ids)
+                }
+                None => {
+                    let id = fusillade::RequestId(head_step_uuid);
+                    (id, vec![id])
+                }
+            },
             None => {
                 let id = fusillade::RequestId(head_step_uuid);
                 (id, vec![id])
             }
-        },
-        None => {
-            let id = fusillade::RequestId(head_step_uuid);
-            (id, vec![id])
-        }
-    };
+        };
 
     // Ownership check against the head row's created_by. 404 (not 403) to
     // avoid leaking existence of other users' responses.
@@ -226,19 +258,49 @@ pub async fn delete_response<P: PoolProvider>(
         });
     }
 
-    // Delete each backing row. response_steps cascade via FK as each request
-    // is removed. We tolerate `RequestNotFound` on individual rows so retries
-    // of a partial-failure delete are idempotent.
+    // Best-effort multi-row deletion. Each delete_request call is atomic in
+    // fusillade (single transaction), but the loop itself isn't — if a row
+    // delete fails partway through a chain, earlier rows are already gone.
+    // We continue past failures (instead of bailing on the first one) so the
+    // erasure makes maximum progress; remaining rows can be cleaned up by a
+    // retry of the DELETE call (RequestNotFound is tolerated for already-
+    // deleted rows). Per-row failures are logged at error level so partial
+    // states are reconcilable from logs.
+    //
+    // A future fusillade primitive that accepts `Vec<RequestId>` and deletes
+    // them in one transaction would close this gap entirely.
+    let total = request_ids_to_delete.len();
+    let mut failed: Vec<fusillade::RequestId> = Vec::new();
     for id in request_ids_to_delete {
         match state.request_manager.delete_request(id).await {
             Ok(()) => {}
             Err(fusillade::FusilladeError::RequestNotFound(_)) => {}
             Err(e) => {
-                return Err(Error::Database(crate::db::errors::DbError::Other(
-                    anyhow::anyhow!("{e}"),
-                )));
+                tracing::error!(
+                    response_id = %response_id,
+                    request_id = %*id,
+                    error = %e,
+                    "delete_response: per-row delete failed; continuing to maximize erasure progress",
+                );
+                failed.push(id);
             }
         }
+    }
+
+    if !failed.is_empty() {
+        tracing::error!(
+            response_id = %response_id,
+            failed_count = failed.len(),
+            total_count = total,
+            "delete_response: partial failure; client may retry the DELETE to clean up remaining rows",
+        );
+        return Err(Error::Database(crate::db::errors::DbError::Other(anyhow::anyhow!(
+            "deleted {}/{} backing rows for response {}; {} remain — retry to complete erasure",
+            total - failed.len(),
+            total,
+            response_id,
+            failed.len(),
+        ))));
     }
 
     Ok(StatusCode::NO_CONTENT)

--- a/dwctl/src/responses/handler.rs
+++ b/dwctl/src/responses/handler.rs
@@ -10,11 +10,12 @@
 use axum::{
     Json,
     extract::{Path, State},
-    http::HeaderMap,
+    http::{HeaderMap, StatusCode},
 };
 use fusillade::{ResponseStepStore, Storage};
 use onwards::StoreError;
 use sqlx_pool_router::PoolProvider;
+use std::collections::HashSet;
 
 use crate::AppState;
 use crate::errors::{Error, Result};
@@ -114,4 +115,131 @@ pub async fn get_response<P: PoolProvider>(
         })?;
 
     Ok(Json(resp))
+}
+
+/// Delete a response by ID.
+///
+/// Right-to-erasure: hard-deletes every `fusillade.requests` row that backs
+/// the response. For multi-step responses, walks the `response_steps` chain
+/// from the head step and deletes each step's sub-request — the `response_steps`
+/// rows themselves cascade via FK. For single-step responses (chat completions
+/// / embeddings retrieved via the same GET surface), deletes the one row.
+///
+/// `http_analytics` has no FK to requests and is preserved so billing / usage
+/// records survive.
+#[tracing::instrument(skip_all, fields(response_id = %response_id))]
+pub async fn delete_response<P: PoolProvider>(
+    State(state): State<AppState<P>>,
+    headers: HeaderMap,
+    Path(response_id): Path<String>,
+) -> Result<StatusCode> {
+    let api_key = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .ok_or_else(|| Error::Unauthenticated { message: None })?;
+
+    let owner_id: String = sqlx::query_scalar("SELECT user_id::text FROM public.api_keys WHERE secret = $1 AND is_deleted = false LIMIT 1")
+        .bind(api_key)
+        .fetch_optional(state.db.read())
+        .await
+        .map_err(|e| Error::Database(e.into()))?
+        .ok_or_else(|| Error::Unauthenticated { message: None })?;
+
+    let uuid_str = response_id.strip_prefix("resp_").unwrap_or(&response_id);
+    let head_step_uuid = uuid::Uuid::parse_str(uuid_str).map_err(|_| Error::NotFound {
+        resource: "response".to_string(),
+        id: response_id.clone(),
+    })?;
+
+    // Resolve which fusillade.requests rows back this response, mirroring
+    // `get_response`'s resolution:
+    //   * Multi-step — head_step exists; walk the chain and collect every
+    //     `request_id` from its rows (None on tool_call steps).
+    //   * Single-step — head_step_uuid is itself the fusillade.requests id.
+    //
+    // For the ownership check we use the head row's `created_by` (same row
+    // `get_response` authorizes against): the chain is owned end-to-end by
+    // the user who initiated the response, so authorizing the head implies
+    // authorizing every sub-request in it.
+    let (auth_request_id, request_ids_to_delete): (
+        fusillade::RequestId,
+        Vec<fusillade::RequestId>,
+    ) = match state.response_step_manager.as_ref() {
+        Some(step_manager) => match step_manager
+            .get_step(fusillade::StepId(head_step_uuid))
+            .await
+            .map_err(|e| {
+                Error::Database(crate::db::errors::DbError::Other(anyhow::anyhow!("{e}")))
+            })? {
+            Some(head_step) => {
+                let chain = step_manager
+                    .list_chain(fusillade::StepId(head_step_uuid))
+                    .await
+                    .map_err(|e| {
+                        Error::Database(crate::db::errors::DbError::Other(anyhow::anyhow!("{e}")))
+                    })?;
+                let ids: Vec<fusillade::RequestId> = chain
+                    .iter()
+                    .filter_map(|s| s.request_id)
+                    .collect::<HashSet<_>>()
+                    .into_iter()
+                    .collect();
+                let auth_id = head_step
+                    .request_id
+                    .unwrap_or(fusillade::RequestId(head_step_uuid));
+                // Fall back to the auth id if the chain query returned nothing
+                // (head with no model_call sub-request, e.g. a pure tool_call
+                // head — unusual but not impossible).
+                let ids = if ids.is_empty() { vec![auth_id] } else { ids };
+                (auth_id, ids)
+            }
+            None => {
+                let id = fusillade::RequestId(head_step_uuid);
+                (id, vec![id])
+            }
+        },
+        None => {
+            let id = fusillade::RequestId(head_step_uuid);
+            (id, vec![id])
+        }
+    };
+
+    // Ownership check against the head row's created_by. 404 (not 403) to
+    // avoid leaking existence of other users' responses.
+    let detail = state
+        .request_manager
+        .get_request_detail(auth_request_id)
+        .await
+        .map_err(|e| match e {
+            fusillade::FusilladeError::RequestNotFound(_) => Error::NotFound {
+                resource: "response".to_string(),
+                id: response_id.clone(),
+            },
+            _ => Error::Database(crate::db::errors::DbError::Other(anyhow::anyhow!("{e}"))),
+        })?;
+
+    if detail.created_by.as_str() != owner_id {
+        return Err(Error::NotFound {
+            resource: "response".to_string(),
+            id: response_id,
+        });
+    }
+
+    // Delete each backing row. response_steps cascade via FK as each request
+    // is removed. We tolerate `RequestNotFound` on individual rows so retries
+    // of a partial-failure delete are idempotent.
+    for id in request_ids_to_delete {
+        match state.request_manager.delete_request(id).await {
+            Ok(()) => {}
+            Err(fusillade::FusilladeError::RequestNotFound(_)) => {}
+            Err(e) => {
+                return Err(Error::Database(crate::db::errors::DbError::Other(
+                    anyhow::anyhow!("{e}"),
+                )));
+            }
+        }
+    }
+
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/dwctl/src/test/responses.rs
+++ b/dwctl/src/test/responses.rs
@@ -499,6 +499,88 @@ async fn test_fusillade_header_skips_row_creation(pool: PgPool) {
     );
 }
 
+/// DELETE /ai/v1/responses/{id} hard-deletes the underlying fusillade row,
+/// and a subsequent GET returns 404.
+#[sqlx::test]
+#[test_log::test]
+async fn test_delete_response_removes_fusillade_row(pool: PgPool) {
+    let mock_server = wiremock::MockServer::start().await;
+    mount_chat_completions_mock(&mock_server).await;
+
+    let (server, api_key, _bg) = setup_ai_test(pool.clone(), &mock_server, true).await;
+
+    // Create a chat completion (priority/realtime tier → batchless fusillade row).
+    server
+        .post("/ai/v1/chat/completions")
+        .add_header("Authorization", &format!("Bearer {}", api_key))
+        .add_header("Content-Type", "application/json")
+        .json(&serde_json::json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "service_tier": "priority"
+        }))
+        .await;
+
+    // Poll for the row to reach completed (outlet writes asynchronously).
+    let start = std::time::Instant::now();
+    let mut id = uuid::Uuid::nil();
+    while start.elapsed() < std::time::Duration::from_secs(5) {
+        if let Some(row) = sqlx::query(
+            "SELECT id, state FROM fusillade.requests WHERE model = 'gpt-4o' ORDER BY created_at DESC LIMIT 1",
+        )
+        .fetch_optional(&pool)
+        .await
+        .unwrap()
+            && sqlx::Row::get::<String, _>(&row, "state") == "completed"
+        {
+            id = sqlx::Row::get(&row, "id");
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+    assert_ne!(id, uuid::Uuid::nil(), "row should reach completed state");
+
+    // DELETE the response.
+    let response_id = format!("resp_{}", id);
+    let resp = server
+        .delete(&format!("/ai/v1/responses/{}", response_id))
+        .add_header("Authorization", &format!("Bearer {}", api_key))
+        .await;
+    assert_eq!(resp.status_code(), 204);
+
+    // Row is gone from fusillade.requests.
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM fusillade.requests WHERE id = $1")
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count.0, 0, "fusillade row should be hard-deleted");
+
+    // GET now returns 404.
+    let get = server
+        .get(&format!("/ai/v1/responses/{}", response_id))
+        .add_header("Authorization", &format!("Bearer {}", api_key))
+        .await;
+    assert_eq!(get.status_code(), 404);
+}
+
+/// DELETE /ai/v1/responses/{id} returns 404 for a non-existent id.
+#[sqlx::test]
+#[test_log::test]
+async fn test_delete_response_404_for_unknown_id(pool: PgPool) {
+    let mock_server = wiremock::MockServer::start().await;
+    mount_chat_completions_mock(&mock_server).await;
+
+    let (server, api_key, _bg) = setup_ai_test(pool.clone(), &mock_server, true).await;
+
+    let fake_id = format!("resp_{}", uuid::Uuid::new_v4());
+    let resp = server
+        .delete(&format!("/ai/v1/responses/{}", fake_id))
+        .add_header("Authorization", &format!("Bearer {}", api_key))
+        .await;
+    assert_eq!(resp.status_code(), 404);
+}
+
 // Removed: `test_flex_background_returns_202_with_queued_status`,
 // `test_flex_blocking_waits_for_completion`,
 // `test_priority_background_completes_and_is_retrievable`.

--- a/dwctl/src/test/responses.rs
+++ b/dwctl/src/test/responses.rs
@@ -525,12 +525,10 @@ async fn test_delete_response_removes_fusillade_row(pool: PgPool) {
     let start = std::time::Instant::now();
     let mut id = uuid::Uuid::nil();
     while start.elapsed() < std::time::Duration::from_secs(5) {
-        if let Some(row) = sqlx::query(
-            "SELECT id, state FROM fusillade.requests WHERE model = 'gpt-4o' ORDER BY created_at DESC LIMIT 1",
-        )
-        .fetch_optional(&pool)
-        .await
-        .unwrap()
+        if let Some(row) = sqlx::query("SELECT id, state FROM fusillade.requests WHERE model = 'gpt-4o' ORDER BY created_at DESC LIMIT 1")
+            .fetch_optional(&pool)
+            .await
+            .unwrap()
             && sqlx::Row::get::<String, _>(&row, "state") == "completed"
         {
             id = sqlx::Row::get(&row, "id");


### PR DESCRIPTION
## Summary

Adds single-response deletion across two surfaces, for right-to-erasure compliance:

- **`DELETE /ai/v1/responses/{response_id}`** — public Bearer-key endpoint. Resolves single-step or multi-step responses, ownership-checks the head row's `created_by`, then walks the `response_steps` chain and calls `fusillade::Storage::delete_request` for every backing sub-request.
- **`DELETE /admin/api/v1/batches/requests/{request_id}`** — dashboard / session-authed endpoint via the standard `RequiresPermission<Batches, DeleteOwn>` middleware. Single-row operation.

Both wrap the new `fusillade 17.1.0` primitive (released from doublewordai/fusillade#268), which hard-deletes the `requests` row plus its dedicated batchless `request_templates` row (the row carrying the prompt body). `response_steps` cascade via FK. `http_analytics` and `credits_transactions` are preserved by design — billing/usage records survive erasure.

Dashboard: `CreateAsyncModal` now submits same-origin via `/admin/api/v1/ai/v1/responses` with session cookies, so dashboard users no longer need to mint an API key for in-dashboard async response creation. The Bearer-key bar is relocated from Compose to the Snippet tab (where it's still useful for copy-pasted code).

## Behavior notes

- **Multi-step erasure.** For Open Responses chains, `delete_response` walks `list_chain(head_step)` to collect every sub-request id and deletes them all. Tool-call steps have no backing fusillade row (`request_id: None`) and are skipped. The loop is best-effort: per-row failures are logged at error level (with request_id + response_id) and continue, so the erasure makes maximum progress; a retry of the DELETE will clean up any remaining rows (`RequestNotFound` is tolerated for already-deleted rows). A future fusillade primitive accepting `Vec<RequestId>` in one transaction would close this gap entirely.
- **Auth pattern on `/ai/v1/responses/{id}`.** Mirrors the existing `get_response`: direct lookup of the Bearer key against `public.api_keys`. Dashboard deletes go through the admin endpoint instead — `admin_ai_proxy_middleware` can't cover GET/DELETE because it requires a request body to extract the model name.

## Tests

- `test_delete_response_removes_fusillade_row` — end-to-end: chat completion → DELETE → 204 → GET returns 404 → fusillade row gone.
- `test_delete_response_404_for_unknown_id` — bogus id returns 404.
- `test_delete_batch_request_removes_row` — admin endpoint happy path.
- `test_delete_batch_request_404_for_other_users_row` — ownership rejection returns 404 (not 403) to avoid leaking existence.

Per-row cascade behavior (response_steps, batchless template cleanup, file-backed template preservation, escalation FK SET NULL) is covered in fusillade's test suite — see doublewordai/fusillade#268.

## Review feedback addressed

- **Cargo patch dropped, fusillade bumped to 17.1.0** (now published).
- **OpenAPI annotation added** to `delete_response`, registered in `AiApiDoc.paths`.
- **Partial-failure handling improved**: the multi-step delete loop logs per-row failures and surfaces a reconcilable error message instead of bailing on the first failure.
- **Docstrings expanded**: cascade-preserved tables (`http_analytics`, `credits_transactions`) called out explicitly; pure-tool_call-head fallback documented.
- Auth-pattern divergence between `delete_response` (Bearer) and `delete_batch_request` (session via standard middleware) explained in the docstring.

## Test plan

- [x] `just lint rust` (fmt, clippy, sqlx-prepare --check)
- [x] `just test rust` for delete-related tests
- [ ] Full backend-test + build CI green