### PR TITLE
feat(email): add HTTP transport abstraction with Resend client

### DIFF
--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -829,11 +829,58 @@ pub struct EmailConfig {
     pub templates_dir: Option<String>,
 }
 
-/// Email transport configuration - either SMTP or file-based for testing.
+/// Per-provider configuration for HTTP-based transactional email.
+///
+/// Each variant captures exactly the inputs that provider needs. New
+/// providers (Mailgun, SES, Postmark, …) are added as additional variants
+/// alongside a matching client in [`crate::email_http`] — no need to widen
+/// a one-size-fits-all `Http { … }` struct or invent overloaded fields.
+///
+/// YAML uses `provider` as the discriminator (e.g. `provider: resend`);
+/// thanks to `#[serde(flatten)]` on [`EmailTransportConfig::Http`], the
+/// per-provider fields sit at the same indentation as `type: http`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "provider", rename_all = "lowercase")]
+pub enum HttpProviderConfig {
+    /// Resend (https://resend.com).
+    Resend {
+        /// Bearer API key, e.g. `re_xxx`.
+        api_key: String,
+        /// Optional base URL override (for tests or custom Resend deployments).
+        /// Defaults to the public Resend endpoint when unset.
+        #[serde(default)]
+        base_url: Option<String>,
+    },
+    // Future providers — add a variant here plus a struct in
+    // `email_http.rs` that implements `HttpEmailClient`:
+    //
+    // Mailgun {
+    //     api_key: String,
+    //     sending_domain: String,
+    //     #[serde(default)]
+    //     region: MailgunRegion,  // Us / Eu
+    // },
+    //
+    // Ses {
+    //     access_key_id: String,
+    //     secret_access_key: String,
+    //     region: String,
+    // },
+    //
+    // Postmark {
+    //     server_token: String,
+    // },
+}
+
+/// Email transport configuration — SMTP, file-based (for development), or a
+/// transactional provider's HTTP API.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum EmailTransportConfig {
-    /// Send emails via SMTP server
+    /// Send emails via SMTP server.
+    ///
+    /// Kept for backward compatibility; new deployments should prefer the
+    /// `Http` transport with a transactional provider.
     Smtp {
         /// SMTP server hostname
         host: String,
@@ -846,10 +893,31 @@ pub enum EmailTransportConfig {
         /// Use TLS encryption
         use_tls: bool,
     },
-    /// Write emails to files (for development/testing)
+    /// Write emails to files (for development/testing).
     File {
         /// Directory path where email files will be written
         path: String,
+    },
+    /// Send emails via a transactional provider's HTTP API.
+    ///
+    /// Preferred over SMTP for hosted providers: a single API key (or
+    /// equivalent), no per-send TLS handshake cost, and structured error
+    /// responses that can be classified as transient vs permanent for
+    /// retry.
+    ///
+    /// The inner [`HttpProviderConfig`] is flattened into the YAML so the
+    /// per-provider fields sit alongside `type: http`:
+    ///
+    /// ```yaml
+    /// email:
+    ///   transport:
+    ///     type: http
+    ///     provider: resend
+    ///     api_key: "re_..."
+    /// ```
+    Http {
+        #[serde(flatten)]
+        provider: HttpProviderConfig,
     },
 }
 
@@ -2254,6 +2322,78 @@ impl Config {
 mod tests {
     use super::*;
     use figment::Jail;
+
+    /// Round-trip the HTTP transport YAML through the real config loader to
+    /// pin the wire format.
+    ///
+    /// `EmailTransportConfig::Http` carries `#[serde(flatten)]` on
+    /// `HttpProviderConfig`, which is internally tagged on `provider`. Both
+    /// tags (`type` outer, `provider` inner) need to sit at the same YAML
+    /// indentation. If a future refactor breaks that flattening these tests
+    /// catch it before a deployed `config.yaml` does.
+    #[test]
+    fn http_transport_yaml_uses_flat_provider_field() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "test.yaml",
+                r#"
+secret_key: hello
+email:
+  type: http
+  provider: resend
+  api_key: re_test_xxx
+  from_email: noreply@example.com
+  from_name: Tester
+"#,
+            )?;
+
+            let config = Config::load(&Args {
+                config: "test.yaml".into(),
+                validate: false,
+            })?;
+            match config.email.transport {
+                EmailTransportConfig::Http {
+                    provider: HttpProviderConfig::Resend { api_key, base_url },
+                } => {
+                    assert_eq!(api_key, "re_test_xxx");
+                    assert!(base_url.is_none(), "base_url should default to None when omitted");
+                }
+                other => panic!("expected EmailTransportConfig::Http(Resend), got {other:?}"),
+            }
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn http_transport_yaml_carries_optional_base_url() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "test.yaml",
+                r#"
+secret_key: hello
+email:
+  type: http
+  provider: resend
+  api_key: re_test_xxx
+  base_url: https://staging.example.com
+  from_email: noreply@example.com
+  from_name: Tester
+"#,
+            )?;
+
+            let config = Config::load(&Args {
+                config: "test.yaml".into(),
+                validate: false,
+            })?;
+            match config.email.transport {
+                EmailTransportConfig::Http {
+                    provider: HttpProviderConfig::Resend { base_url, .. },
+                } => assert_eq!(base_url.as_deref(), Some("https://staging.example.com")),
+                other => panic!("expected EmailTransportConfig::Http(Resend), got {other:?}"),
+            }
+            Ok(())
+        });
+    }
 
     #[test]
     fn test_model_sources_config() {

--- a/dwctl/src/email.rs
+++ b/dwctl/src/email.rs
@@ -1,14 +1,25 @@
-//! Email service for sending password reset emails and notifications
+//! Email service for sending password reset emails and notifications.
+//!
+//! Transport selection is config-driven via [`crate::config::EmailTransportConfig`]:
+//! `Smtp` (legacy / self-hosted), `File` (development), and `Http` (hosted
+//! transactional providers via [`crate::email_http`]). All transports route
+//! through [`EmailService::dispatch`], which records the
+//! `dwctl_email_send_total{provider, template, outcome}` counter.
 
-use crate::notifications::{BatchNotificationInfo, BatchOutcome};
-use crate::{config::Config, errors::Error};
+use std::path::Path;
+use std::sync::Arc;
+
 use lettre::{
     AsyncFileTransport, AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor,
     message::{Mailbox, header::ContentType},
     transport::smtp::authentication::Credentials,
 };
 use minijinja::{Environment, context};
-use std::path::Path;
+
+use crate::config::HttpProviderConfig;
+use crate::email_http::{HttpEmailClient, ResendClient};
+use crate::notifications::{BatchNotificationInfo, BatchOutcome};
+use crate::{config::Config, errors::Error};
 
 struct EmailTemplates {
     password_reset: String,
@@ -77,9 +88,41 @@ pub struct EmailService {
     templates: EmailTemplates,
 }
 
+/// Backend used by [`EmailService`] to deliver a built [`EmailEnvelope`].
+///
+/// `Smtp` and `File` are lettre-backed (existing behavior). `Http` delegates
+/// to a provider-specific [`HttpEmailClient`] (e.g. [`ResendClient`]).
 enum EmailTransport {
     Smtp(AsyncSmtpTransport<Tokio1Executor>),
     File(AsyncFileTransport<Tokio1Executor>),
+    Http(Arc<dyn HttpEmailClient>),
+}
+
+/// Transport-independent representation of a prepared email.
+///
+/// Built by the public `send_*` methods on [`EmailService`] and consumed by
+/// [`EmailService::dispatch`]. The SMTP/File paths turn this back into a
+/// `lettre::Message`; the HTTP path serializes it to the provider's JSON shape.
+///
+/// `template_id` is a stable identifier (e.g. `"password_reset"`) used as a
+/// label on the `dwctl_email_send_total` Prometheus counter.
+#[derive(Debug, Clone)]
+pub(crate) struct EmailEnvelope {
+    pub template_id: &'static str,
+    pub from: Mailbox,
+    pub to: Mailbox,
+    pub reply_to: Option<Mailbox>,
+    pub subject: String,
+    pub body: EmailBody,
+}
+
+/// Body of an email — either HTML or plain text. Determines the
+/// `Content-Type` for SMTP/File transports and which field is populated
+/// in the provider JSON body for HTTP transports.
+#[derive(Debug, Clone)]
+pub(crate) enum EmailBody {
+    Html(String),
+    Text(String),
 }
 
 impl EmailService {
@@ -123,6 +166,19 @@ impl EmailService {
                 let file_transport = AsyncFileTransport::<Tokio1Executor>::new(emails_dir);
                 EmailTransport::File(file_transport)
             }
+            crate::config::EmailTransportConfig::Http { provider } => {
+                // Hosted transactional provider over HTTPS. Each provider
+                // implements `HttpEmailClient` in `email_http`; add a match
+                // arm here when introducing a new one.
+                let client: Arc<dyn HttpEmailClient> = match provider {
+                    HttpProviderConfig::Resend { api_key, base_url } => {
+                        Arc::new(ResendClient::new(api_key.clone(), base_url.clone()).map_err(|e| Error::Internal {
+                            operation: format!("create Resend client: {e}"),
+                        })?)
+                    }
+                };
+                EmailTransport::Http(client)
+            }
         };
 
         let templates = match &email_config.templates_dir {
@@ -155,50 +211,114 @@ impl EmailService {
             operation: format!("render email template: {e}"),
         })?;
 
-        self.send_email(to_email, to_name, subject, &body).await
+        self.send_email("password_reset", to_email, to_name, subject, &body).await
     }
 
-    async fn send_email(&self, to_email: &str, to_name: Option<&str>, subject: &str, body: &str) -> Result<(), Error> {
-        // Create from mailbox
+    /// Build a standard HTML-body envelope for one recipient and dispatch it.
+    ///
+    /// Used by every template-driven sender. `template_id` is a stable string
+    /// (e.g. `"password_reset"`) that becomes the `template` label on the
+    /// `dwctl_email_send_total` counter.
+    async fn send_email(
+        &self,
+        template_id: &'static str,
+        to_email: &str,
+        to_name: Option<&str>,
+        subject: &str,
+        body: &str,
+    ) -> Result<(), Error> {
+        let envelope = self.build_envelope(template_id, to_email, to_name, subject, EmailBody::Html(body.to_string()))?;
+        self.dispatch(envelope).await
+    }
+
+    /// Construct an [`EmailEnvelope`] with this service's `from` / `reply_to`
+    /// configuration applied. Shared by `send_email` and `send_support_request`.
+    fn build_envelope(
+        &self,
+        template_id: &'static str,
+        to_email: &str,
+        to_name: Option<&str>,
+        subject: &str,
+        body: EmailBody,
+    ) -> Result<EmailEnvelope, Error> {
         let from_address = self.from_email.parse().map_err(|e| Error::Internal {
             operation: format!("Failed to parse from email: {e}"),
         })?;
         let from = Mailbox::new(Some(self.from_name.clone()), from_address);
 
-        // Create to mailbox
         let to_address = to_email.parse().map_err(|e| Error::Internal {
             operation: format!("Failed to parse to email: {e}"),
         })?;
         let to = Mailbox::new(to_name.map(|n| n.to_string()), to_address);
 
-        let mut builder = Message::builder().from(from).to(to).subject(subject).header(ContentType::TEXT_HTML);
+        let reply_to = self
+            .reply_to
+            .as_deref()
+            .map(|email| -> Result<Mailbox, Error> {
+                let addr = email.parse().map_err(|e| Error::Internal {
+                    operation: format!("Failed to parse reply-to email: {e}"),
+                })?;
+                Ok(Mailbox::new(Some(self.from_name.clone()), addr))
+            })
+            .transpose()?;
 
-        if let Some(ref reply_to_email) = self.reply_to {
-            let reply_to_address = reply_to_email.parse().map_err(|e| Error::Internal {
-                operation: format!("Failed to parse reply-to email: {e}"),
-            })?;
-            let reply_to = Mailbox::new(Some(self.from_name.clone()), reply_to_address);
-            builder = builder.reply_to(reply_to);
-        }
-
-        let message = builder.body(body.to_string()).map_err(|e| Error::Internal {
-            operation: format!("build email message: {e}"),
-        })?;
-
-        self.dispatch(message).await
+        Ok(EmailEnvelope {
+            template_id,
+            from,
+            to,
+            reply_to,
+            subject: subject.to_string(),
+            body,
+        })
     }
 
-    /// Send a pre-built message via the configured transport.
-    async fn dispatch(&self, message: Message) -> Result<(), Error> {
+    /// Dispatch a prepared envelope via the configured transport and record
+    /// the `dwctl_email_send_total{provider, template, outcome}` counter.
+    ///
+    /// `outcome` is `"sent"` on success and `"failed"` on any error.
+    async fn dispatch(&self, envelope: EmailEnvelope) -> Result<(), Error> {
+        let template_id = envelope.template_id;
+        let provider = transport_label(&self.transport);
+
+        let result = self.dispatch_inner(envelope).await;
+        let outcome = if result.is_ok() { "sent" } else { "failed" };
+        metrics::counter!(
+            "dwctl_email_send_total",
+            "provider" => provider,
+            "template" => template_id,
+            "outcome" => outcome,
+        )
+        .increment(1);
+        result
+    }
+
+    async fn dispatch_inner(&self, envelope: EmailEnvelope) -> Result<(), Error> {
         match &self.transport {
             EmailTransport::Smtp(smtp) => {
+                let message = build_lettre_message(&envelope)?;
                 smtp.send(message).await.map_err(|e| Error::Internal {
                     operation: format!("send SMTP email: {e}"),
                 })?;
             }
             EmailTransport::File(file) => {
+                let message = build_lettre_message(&envelope)?;
                 file.send(message).await.map_err(|e| Error::Internal {
                     operation: format!("send file email: {e}"),
+                })?;
+            }
+            EmailTransport::Http(client) => {
+                client.send(&envelope).await.map_err(|e| {
+                    // is_transient is preserved in tracing so callers (worker
+                    // contexts in particular) can decide whether to retry.
+                    tracing::warn!(
+                        provider = client.provider_name(),
+                        transient = e.is_transient(),
+                        error = %e,
+                        "HTTP email send failed",
+                    );
+                    Error::Internal {
+                        operation: format!("send HTTP email via {}: {e}", client.provider_name()),
+                    }
                 })?;
             }
         }
@@ -229,7 +349,8 @@ impl EmailService {
             .map_err(|e| Error::Internal {
                 operation: format!("render email template: {e}"),
             })?;
-        self.send_email(to_email, to_name, &subject, &body).await
+        let template_id = if first_batch { "first_batch" } else { "batch_complete" };
+        self.send_email(template_id, to_email, to_name, &subject, &body).await
     }
 
     pub fn render_batch_completion_body(
@@ -324,7 +445,7 @@ impl EmailService {
         let body = self.render_low_balance_body(name, balance).map_err(|e| Error::Internal {
             operation: format!("render email template: {e}"),
         })?;
-        self.send_email(to_email, to_name, subject, &body).await
+        self.send_email("low_balance", to_email, to_name, subject, &body).await
     }
 
     fn render_low_balance_body(&self, to_name: &str, balance: &rust_decimal::Decimal) -> Result<String, minijinja::Error> {
@@ -360,7 +481,7 @@ impl EmailService {
             .map_err(|e| Error::Internal {
                 operation: format!("render email template: {e}"),
             })?;
-        self.send_email(to_email, to_name, &subject, &body).await
+        self.send_email("auto_topup_success", to_email, to_name, &subject, &body).await
     }
 
     pub async fn send_auto_topup_failed_email(
@@ -377,7 +498,7 @@ impl EmailService {
             .map_err(|e| Error::Internal {
                 operation: format!("render email template: {e}"),
             })?;
-        self.send_email(to_email, to_name, subject, &body).await
+        self.send_email("auto_topup_failed", to_email, to_name, subject, &body).await
     }
 
     pub async fn send_auto_topup_limit_reached_email(
@@ -416,7 +537,8 @@ impl EmailService {
                 operation: format!("render email template: {e}"),
             })?;
 
-        self.send_email(to_email, to_name, &subject, &body).await
+        self.send_email("auto_topup_limit_reached", to_email, to_name, &subject, &body)
+            .await
     }
 
     fn render_auto_topup_body(
@@ -459,10 +581,15 @@ impl EmailService {
                 operation: format!("render email template: {e}"),
             })?;
 
-        self.send_email(to_email, None, &subject, &body).await
+        self.send_email("org_invite", to_email, None, &subject, &body).await
     }
 
-    /// Send a support request email to the configured support address, with reply-to set to the user's email.
+    /// Send a support request email to the configured support address, with
+    /// reply-to set to the user's email so the support team can reply directly.
+    ///
+    /// Note this overrides the service's default `reply_to`; the address the
+    /// support team replies to should always be the requesting user, not the
+    /// no-reply sender.
     pub async fn send_support_request(
         &self,
         support_email: &str,
@@ -471,39 +598,24 @@ impl EmailService {
         subject: &str,
         message: &str,
     ) -> Result<(), Error> {
-        // Build from mailbox
-        let from_address = self.from_email.parse().map_err(|e| Error::Internal {
-            operation: format!("Failed to parse from email: {e}"),
-        })?;
-        let from = Mailbox::new(Some(self.from_name.clone()), from_address);
+        let display_name = user_name.unwrap_or(user_email);
+        let body = format!("Support request from {} ({}):\n\n{}", display_name, user_email, message);
 
-        // Build to mailbox (support address)
-        let to_address = support_email.parse().map_err(|e| Error::Internal {
-            operation: format!("Failed to parse support email: {e}"),
-        })?;
-        let to = Mailbox::new(Some("Doubleword Support".to_string()), to_address);
-
-        // Reply-to is the user's email
+        // Build the standard envelope, then override reply-to with the user's
+        // address so support can reply directly to the requester.
+        let mut envelope = self.build_envelope(
+            "support_request",
+            support_email,
+            Some("Doubleword Support"),
+            subject,
+            EmailBody::Text(body),
+        )?;
         let reply_to_address = user_email.parse().map_err(|e| Error::Internal {
             operation: format!("Failed to parse user email for reply-to: {e}"),
         })?;
-        let reply_to = Mailbox::new(user_name.map(|n| n.to_string()), reply_to_address);
+        envelope.reply_to = Some(Mailbox::new(user_name.map(|n| n.to_string()), reply_to_address));
 
-        let display_name = user_name.unwrap_or(user_email);
-        let body = format!("Support request from {} ({}):\n\n{}", display_name, user_email, message,);
-
-        let msg = Message::builder()
-            .from(from)
-            .to(to)
-            .reply_to(reply_to)
-            .subject(subject)
-            .header(ContentType::TEXT_PLAIN)
-            .body(body)
-            .map_err(|e| Error::Internal {
-                operation: format!("build support email message: {e}"),
-            })?;
-
-        self.dispatch(msg).await
+        self.dispatch(envelope).await
     }
 
     fn render_org_invite_body(
@@ -535,7 +647,8 @@ impl EmailService {
                 operation: format!("render email template: {e}"),
             })?;
 
-        self.send_email(to_email, None, &subject, &body).await
+        self.send_email("org_email_change_verify_new", to_email, None, &subject, &body)
+            .await
     }
 
     /// Send the verification link to the *current* contact address — the
@@ -556,7 +669,8 @@ impl EmailService {
                 operation: format!("render email template: {e}"),
             })?;
 
-        self.send_email(to_email, None, &subject, &body).await
+        self.send_email("org_email_change_verify_old", to_email, None, &subject, &body)
+            .await
     }
 
     fn render_org_email_change_verify_new_body(&self, org_name: &str, confirm_link: &str) -> Result<String, minijinja::Error> {
@@ -586,6 +700,45 @@ impl EmailService {
             support_email,
         })
     }
+}
+
+/// Static identifier for the configured transport, used as the `provider`
+/// label on `dwctl_email_send_total`. SMTP/File use literal strings;
+/// HTTP defers to the provider client (e.g. `"resend"`).
+fn transport_label(t: &EmailTransport) -> &'static str {
+    match t {
+        EmailTransport::Smtp(_) => "smtp",
+        EmailTransport::File(_) => "file",
+        EmailTransport::Http(client) => client.provider_name(),
+    }
+}
+
+/// Convert a transport-independent [`EmailEnvelope`] into a `lettre::Message`
+/// for the SMTP and File transports. The HTTP transport bypasses this and
+/// serializes the envelope directly to its provider's wire format.
+fn build_lettre_message(envelope: &EmailEnvelope) -> Result<Message, Error> {
+    let content_type = match &envelope.body {
+        EmailBody::Html(_) => ContentType::TEXT_HTML,
+        EmailBody::Text(_) => ContentType::TEXT_PLAIN,
+    };
+
+    let mut builder = Message::builder()
+        .from(envelope.from.clone())
+        .to(envelope.to.clone())
+        .subject(&envelope.subject)
+        .header(content_type);
+
+    if let Some(reply_to) = &envelope.reply_to {
+        builder = builder.reply_to(reply_to.clone());
+    }
+
+    let body_str = match &envelope.body {
+        EmailBody::Html(s) | EmailBody::Text(s) => s.clone(),
+    };
+
+    builder.body(body_str).map_err(|e| Error::Internal {
+        operation: format!("build email message: {e}"),
+    })
 }
 
 #[cfg(test)]
@@ -742,7 +895,9 @@ mod tests {
         ];
 
         for (name, email) in cases {
-            let result = email_service.send_email(email, name, "Test Subject", "<p>Hello</p>").await;
+            let result = email_service
+                .send_email("test_recipients", email, name, "Test Subject", "<p>Hello</p>")
+                .await;
             assert!(
                 result.is_ok(),
                 "send_email failed for name={name:?}, email={email:?}: {:?}",

--- a/dwctl/src/email_http.rs
+++ b/dwctl/src/email_http.rs
@@ -1,0 +1,313 @@
+//! HTTP-API email transport clients.
+//!
+//! Used by [`crate::email::EmailService`] when the configured transport is
+//! `EmailTransportConfig::Http`. Each provider implements [`HttpEmailClient`];
+//! the [`crate::config::EmailProvider`] enum selects which.
+//!
+//! Hosted transactional providers typically offer a single API key (no
+//! per-host TLS handshake) and structured JSON error responses we can
+//! classify as permanent vs transient for retry logic.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::email::EmailEnvelope;
+
+/// Error returned by an [`HttpEmailClient`].
+///
+/// The `is_transient` distinction is the input a retrying worker needs to
+/// decide whether to re-enqueue: permanent errors (validation failures,
+/// unverified sender domain) shouldn't be retried; transient errors
+/// (provider 5xx, rate-limit, network blip) should.
+#[derive(Debug, Error)]
+pub enum HttpEmailError {
+    /// Provider permanently rejected the request (4xx other than 429).
+    /// E.g. unverified sender domain, invalid recipient, malformed payload.
+    /// A retrying worker should NOT re-enqueue.
+    #[error("provider permanent error (HTTP {status}): {message}")]
+    Permanent { status: u16, message: String },
+    /// Provider transiently failed (5xx or 429 rate-limit).
+    /// A retrying worker should re-enqueue with backoff.
+    #[error("provider transient error (HTTP {status}): {message}")]
+    Transient { status: u16, message: String },
+    /// Network / TLS / DNS failure before any response was received.
+    /// Treated as transient.
+    #[error("network error contacting provider: {0}")]
+    Network(String),
+    /// Local construction error (a bug in this module or its caller).
+    #[error("client error: {0}")]
+    Client(String),
+}
+
+impl HttpEmailError {
+    /// Whether a retry worker should re-enqueue the job after this error.
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Transient { .. } | Self::Network(_))
+    }
+}
+
+/// Abstract transactional-email HTTP client.
+///
+/// Implementations translate between [`EmailEnvelope`] and the provider's
+/// wire format. The trait stays small on purpose — adding a provider means
+/// one new struct, not a refactor.
+#[async_trait]
+pub trait HttpEmailClient: Send + Sync + std::fmt::Debug {
+    /// Provider identifier for metrics/logging (e.g. `"resend"`).
+    fn provider_name(&self) -> &'static str;
+    /// Send a prepared email envelope.
+    async fn send(&self, envelope: &EmailEnvelope) -> Result<(), HttpEmailError>;
+}
+
+/// Resend's public API base URL. Overridable via
+/// `EmailTransportConfig::Http { base_url: Some(...) }` for tests.
+const DEFAULT_RESEND_BASE_URL: &str = "https://api.resend.com";
+
+/// HTTP client for the Resend transactional email API.
+///
+/// API reference: <https://resend.com/docs/api-reference/emails/send-email>.
+#[derive(Debug, Clone)]
+pub struct ResendClient {
+    http: Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl ResendClient {
+    pub fn new(api_key: impl Into<String>, base_url: Option<String>) -> Result<Self, HttpEmailError> {
+        // 15s covers provider response time comfortably. Transient timeouts
+        // surface as `HttpEmailError::Network`.
+        let http = Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()
+            .map_err(|e| HttpEmailError::Client(format!("build reqwest client: {e}")))?;
+        Ok(Self {
+            http,
+            api_key: api_key.into(),
+            base_url: base_url.unwrap_or_else(|| DEFAULT_RESEND_BASE_URL.to_string()),
+        })
+    }
+}
+
+/// Resend send-email request body (subset of the documented fields).
+#[derive(Serialize)]
+struct ResendSendBody<'a> {
+    from: String,
+    to: Vec<String>,
+    subject: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    html: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reply_to: Option<Vec<String>>,
+}
+
+/// Resend error response body. `name` is a stable error code (e.g.
+/// `validation_error`); `message` is human-readable.
+#[derive(Deserialize, Default)]
+struct ResendErrorBody {
+    #[serde(default)]
+    message: String,
+    #[serde(default)]
+    name: String,
+}
+
+#[async_trait]
+impl HttpEmailClient for ResendClient {
+    fn provider_name(&self) -> &'static str {
+        "resend"
+    }
+
+    async fn send(&self, envelope: &EmailEnvelope) -> Result<(), HttpEmailError> {
+        let (html, text) = match &envelope.body {
+            crate::email::EmailBody::Html(b) => (Some(b.as_str()), None),
+            crate::email::EmailBody::Text(b) => (None, Some(b.as_str())),
+        };
+
+        let body = ResendSendBody {
+            from: envelope.from.to_string(),
+            to: vec![envelope.to.to_string()],
+            subject: envelope.subject.as_str(),
+            html,
+            text,
+            reply_to: envelope.reply_to.as_ref().map(|m| vec![m.to_string()]),
+        };
+
+        let resp = self
+            .http
+            .post(format!("{}/emails", self.base_url.trim_end_matches('/')))
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| HttpEmailError::Network(e.to_string()))?;
+
+        let status = resp.status();
+        if status.is_success() {
+            return Ok(());
+        }
+
+        let code = status.as_u16();
+        let err: ResendErrorBody = resp.json().await.unwrap_or_default();
+        let message = if err.message.is_empty() {
+            format!("HTTP {code}")
+        } else if err.name.is_empty() {
+            err.message
+        } else {
+            format!("{}: {}", err.name, err.message)
+        };
+
+        // 429 (rate-limit) and 5xx are transient; other 4xx are permanent.
+        if code == 429 || (500..600).contains(&code) {
+            Err(HttpEmailError::Transient { status: code, message })
+        } else {
+            Err(HttpEmailError::Permanent { status: code, message })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::email::{EmailBody, EmailEnvelope};
+    use lettre::message::Mailbox;
+    use wiremock::matchers::{body_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_envelope() -> EmailEnvelope {
+        EmailEnvelope {
+            template_id: "test_template",
+            from: Mailbox::new(Some("Doubleword".to_string()), "noreply@doubleword.ai".parse().unwrap()),
+            to: Mailbox::new(Some("Alice".to_string()), "alice@example.com".parse().unwrap()),
+            reply_to: None,
+            subject: "hello".to_string(),
+            body: EmailBody::Html("<p>hi</p>".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn resend_client_success_sends_expected_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/emails"))
+            .and(header("authorization", "Bearer test-key"))
+            .and(body_json(serde_json::json!({
+                "from": "Doubleword <noreply@doubleword.ai>",
+                "to": ["Alice <alice@example.com>"],
+                "subject": "hello",
+                "html": "<p>hi</p>",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "id": "abc" })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = ResendClient::new("test-key", Some(server.uri())).unwrap();
+        client.send(&test_envelope()).await.expect("send succeeds");
+    }
+
+    #[tokio::test]
+    async fn resend_client_text_body_sets_text_field() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(body_json(serde_json::json!({
+                "from": "Doubleword <noreply@doubleword.ai>",
+                "to": ["Alice <alice@example.com>"],
+                "subject": "hello",
+                "text": "hi",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "id": "abc" })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut env = test_envelope();
+        env.body = EmailBody::Text("hi".to_string());
+        let client = ResendClient::new("k", Some(server.uri())).unwrap();
+        client.send(&env).await.expect("send succeeds");
+    }
+
+    #[tokio::test]
+    async fn resend_client_includes_reply_to_when_set() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(body_json(serde_json::json!({
+                "from": "Doubleword <noreply@doubleword.ai>",
+                "to": ["Alice <alice@example.com>"],
+                "subject": "hello",
+                "html": "<p>hi</p>",
+                "reply_to": ["user@example.com"],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "id": "abc" })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut env = test_envelope();
+        env.reply_to = Some(Mailbox::new(None, "user@example.com".parse().unwrap()));
+        let client = ResendClient::new("k", Some(server.uri())).unwrap();
+        client.send(&env).await.expect("send succeeds with reply-to");
+    }
+
+    #[tokio::test]
+    async fn resend_client_permanent_error_on_422() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "name": "validation_error",
+                "message": "from address is unverified"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ResendClient::new("test-key", Some(server.uri())).unwrap();
+        let err = client.send(&test_envelope()).await.unwrap_err();
+        assert!(matches!(err, HttpEmailError::Permanent { status: 422, .. }), "got: {err:?}");
+        assert!(!err.is_transient());
+    }
+
+    #[tokio::test]
+    async fn resend_client_transient_error_on_429() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(429).set_body_json(serde_json::json!({
+                "name": "rate_limit",
+                "message": "too many requests"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ResendClient::new("test-key", Some(server.uri())).unwrap();
+        let err = client.send(&test_envelope()).await.unwrap_err();
+        assert!(matches!(err, HttpEmailError::Transient { status: 429, .. }), "got: {err:?}");
+        assert!(err.is_transient());
+    }
+
+    #[tokio::test]
+    async fn resend_client_transient_error_on_5xx() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let client = ResendClient::new("test-key", Some(server.uri())).unwrap();
+        let err = client.send(&test_envelope()).await.unwrap_err();
+        assert!(matches!(err, HttpEmailError::Transient { status: 503, .. }), "got: {err:?}");
+        assert!(err.is_transient());
+    }
+
+    #[tokio::test]
+    async fn resend_client_network_error_is_transient() {
+        // Point the client at a port that's almost certainly not listening.
+        let client = ResendClient::new("k", Some("http://127.0.0.1:1".to_string())).unwrap();
+        let err = client.send(&test_envelope()).await.unwrap_err();
+        assert!(matches!(err, HttpEmailError::Network(_)), "got: {err:?}");
+        assert!(err.is_transient());
+    }
+}

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -148,6 +148,7 @@ pub mod connections;
 mod crypto;
 pub mod db;
 mod email;
+mod email_http;
 pub mod encryption;
 mod error_enrichment;
 pub mod errors;


### PR DESCRIPTION
## Summary

Adds an `Http` variant to `EmailTransportConfig` so transactional email can be sent via a provider's HTTP API in addition to SMTP. First provider implemented: **Resend**.

Behavior-preserving when `transport.type` stays `"smtp"` — every existing caller works unchanged. The new `dwctl_email_send_total` counter gains a `provider="smtp"` series.

### What changed

- New `EmailTransportConfig::Http { provider: HttpProviderConfig }` variant. The inner enum carries exactly the fields each provider needs (currently just `Resend { api_key, base_url }`). Adding Mailgun (needs `sending_domain` + region), SES (needs access-key pair + region), or Postmark is a new `HttpProviderConfig` variant plus a struct in `email_http.rs` — no need to widen a one-size-fits-all shape.
- New `email_http.rs` with `HttpEmailClient` trait and `ResendClient` implementation. No new dependencies.
- Send pipeline refactored to flow through a transport-independent `EmailEnvelope`. SMTP/File rebuild a `lettre::Message`; the HTTP transport serializes to provider JSON.
- `dwctl_email_send_total{provider, template, outcome}` Prometheus counter on every dispatch. Templates: `password_reset`, `batch_complete`, `first_batch`, `low_balance`, `auto_topup_{success,failed,limit_reached}`, `org_invite`, `org_email_change_verify_{new,old}`, `support_request`.
- HTTP error classification: 5xx + 429 = transient, other 4xx = permanent, network = transient.

### YAML shape

`#[serde(flatten)]` on the `Http` variant keeps the inner provider fields at the same indentation as `type`:

```yaml
email:
  transport:
    type: http
    provider: resend
    api_key: re_...
    # base_url: optional, for testing
```

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --lib email::` — 12 existing tests pass after the envelope refactor
- [x] `cargo test --lib email_http::` — 7 new tests cover the Resend wire format (success body shape including reply_to, text-vs-html bodies), 422 → permanent, 429 → transient, 5xx → transient, network → transient
- [x] `cargo test --lib config::tests::http_transport` — 2 new tests pin the flat YAML shape so a future refactor that breaks the `#[serde(flatten)]` fails CI rather than a deployed `config.yaml`
- [ ] CI: `just lint rust`, `just test rust`, `just lint ts`, `just test ts`
