### PR TITLE
feat(email): send transactional email asynchronously via underway

### DIFF
--- a/dwctl/src/api/handlers/auth.rs
+++ b/dwctl/src/api/handlers/auth.rs
@@ -24,7 +24,6 @@ use crate::{
             api_keys::ApiKeyPurpose, credits::CreditTransactionCreateDBRequest, deployments::ModelStatus, users::UserCreateDBRequest,
         },
     },
-    email::EmailService,
     errors::Error,
 };
 
@@ -434,11 +433,24 @@ pub async fn request_password_reset<P: PoolProvider>(
         // Create reset token
         let (raw_token, token) = token_repo.create_for_user(user.id, &config).await?;
 
-        // Send email with token ID
-        let email_service = EmailService::new(&config)?;
-        email_service
-            .send_password_reset_email(&user.email, user.display_name.as_deref(), &token.id, &raw_token)
-            .await?;
+        // Enqueue the reset email. The user-visible response is the same whether
+        // the actual send succeeds or fails (we always claim "if an account
+        // with that email exists..." to avoid email enumeration), so a queued
+        // send that retries on transient provider failure is strictly better
+        // than an inline send that could 5xx and leak existence.
+        state
+            .task_runner
+            .send_email_job
+            .enqueue(&crate::email_jobs::SendEmailInput::PasswordReset {
+                to_email: user.email.clone(),
+                to_name: user.display_name.clone(),
+                token_id: token.id,
+                token: raw_token,
+            })
+            .await
+            .map_err(|e| Error::Internal {
+                operation: format!("enqueue password reset email: {e}"),
+            })?;
     }
     tx.commit().await.map_err(|e| Error::Database(e.into()))?;
 

--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -14,7 +14,6 @@ use crate::{
     auth::permissions::{can_manage_org_resource, can_read_all_resources, can_read_own_resource},
     db::handlers::{Credits, Organizations, Repository, Users, api_keys::ApiKeys, organizations::OrganizationFilter},
     db::models::organizations::{OrganizationCreateDBRequest, OrganizationUpdateDBRequest},
-    email::EmailService,
     errors::{Error, Result},
     types::{Operation, Permission, Resource, UserId, UserIdOrCurrent},
 };
@@ -571,59 +570,51 @@ pub async fn update_organization<P: PoolProvider>(
             let new_email_link = make_link(&new_email_token);
             let old_email_link = make_link(&old_email_token);
 
-            match EmailService::new(&config) {
-                Ok(email_service) => {
-                    if let Err(error) = email_service
-                        .send_org_email_change_verify_new(&normalized, &org_name, &new_email_link)
-                        .await
-                    {
-                        tracing::warn!(
-                            org_id = %id,
-                            new_email = %normalized,
-                            error = %error,
-                            kind = "org_email_change_verify_new_failed",
-                            "Failed to send org email-change verify-new email",
-                        );
-                    }
-                    if let Err(error) = email_service
-                        .send_org_email_change_verify_old(
-                            &current_org.email,
-                            &org_name,
-                            &normalized,
-                            &old_email_link,
-                            Some(&config.support_email),
-                        )
-                        .await
-                    {
-                        // Security-relevant: failure here means the legitimate
-                        // owner can't authorize the change, but it also means
-                        // an attacker can't get the old-side approval — so the
-                        // verification gate still holds. We still alert on
-                        // `kind = "org_email_change_verify_old_failed"` so ops
-                        // can spot silent SMTP failures against the old address.
-                        //
-                        // Follow-up: a durable retry (via the task runner /
-                        // batched email queue) would harden this further
-                        // against transient SMTP failures. Out of scope for
-                        // this PR.
-                        tracing::warn!(
-                            org_id = %id,
-                            old_email = %current_org.email,
-                            new_email = %normalized,
-                            error = %error,
-                            kind = "org_email_change_verify_old_failed",
-                            "Failed to send org email-change verify-old email — current owner cannot authorize",
-                        );
-                    }
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        org_id = %id,
-                        error = %error,
-                        kind = "org_email_change_email_service_unavailable",
-                        "Email service unavailable for org email-change verification",
-                    );
-                }
+            // Enqueue both verification emails. The `send-email` worker
+            // retries transient provider failures with backoff, so a flaky
+            // upstream doesn't strand the owner unable to authorize the
+            // change.
+            if let Err(error) = state
+                .task_runner
+                .send_email_job
+                .enqueue(&crate::email_jobs::SendEmailInput::OrgEmailChangeVerifyNew {
+                    to_email: normalized.clone(),
+                    org_name: org_name.clone(),
+                    confirm_link: new_email_link,
+                })
+                .await
+            {
+                tracing::warn!(
+                    org_id = %id,
+                    new_email = %normalized,
+                    error = %error,
+                    kind = "org_email_change_verify_new_enqueue_failed",
+                    "Failed to enqueue org email-change verify-new email",
+                );
+            }
+            if let Err(error) = state
+                .task_runner
+                .send_email_job
+                .enqueue(&crate::email_jobs::SendEmailInput::OrgEmailChangeVerifyOld {
+                    to_email: current_org.email.clone(),
+                    org_name: org_name.clone(),
+                    new_email: normalized.clone(),
+                    confirm_link: old_email_link,
+                    support_email: Some(config.support_email.clone()),
+                })
+                .await
+            {
+                // Enqueue failure here is exceptional (it means the underway
+                // pool is down). The verification gate still holds — neither
+                // side can confirm, so the email change is blocked.
+                tracing::warn!(
+                    org_id = %id,
+                    old_email = %current_org.email,
+                    new_email = %normalized,
+                    error = %error,
+                    kind = "org_email_change_verify_old_enqueue_failed",
+                    "Failed to enqueue org email-change verify-old email — current owner cannot authorize",
+                );
             }
 
             pending_email_info = Some(PendingEmailChangeResponse::from(pending));
@@ -1365,15 +1356,24 @@ pub async fn invite_member<P: PoolProvider>(
         .and_then(|u| u.display_name.clone())
         .unwrap_or_else(|| inviter.as_ref().map(|u| u.username.clone()).unwrap_or_default());
 
-    // Send invite email
+    // Enqueue invite email. Failure here means the underway pool is down,
+    // not the provider — the invite row is already persisted, so the user
+    // can still be re-invited via the dashboard.
     let config = state.current_config();
     let invite_link = format!("{}/org-invite?token={}", config.dashboard_url.trim_end_matches('/'), token);
-    let email_service = EmailService::new(&config)?;
-    if let Err(e) = email_service
-        .send_org_invite_email(&email, &org_name, &inviter_name, role, &invite_link)
+    if let Err(e) = state
+        .task_runner
+        .send_email_job
+        .enqueue(&crate::email_jobs::SendEmailInput::OrgInvite {
+            to_email: email.clone(),
+            org_name: org_name.clone(),
+            inviter_name,
+            role: role.to_string(),
+            invite_link,
+        })
         .await
     {
-        tracing::warn!("Failed to send invite email to {email}: {e}");
+        tracing::warn!("Failed to enqueue invite email to {email}: {e}");
     }
 
     Ok((
@@ -3065,6 +3065,10 @@ mod tests {
         // to a per-test directory via create_test_app_with_config so other
         // tests' emails don't pollute the scan. Double-opt-in means BOTH
         // mailboxes get a verification link, not just the new one.
+        //
+        // Sends are now async — the handler enqueues, the send-email worker
+        // drains. This test enables `email_workers: 1` and polls the scratch
+        // dir until both .eml files appear (or it times out).
         let scratch = std::env::temp_dir().join(format!("dwctl-test-emails-patch-{}-{}", std::process::id(), uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&scratch).unwrap();
 
@@ -3072,6 +3076,7 @@ mod tests {
         config.email.transport = crate::config::EmailTransportConfig::File {
             path: scratch.to_string_lossy().to_string(),
         };
+        config.background_services.task_workers.email_workers = 1;
 
         let (server, _bg) = create_test_app_with_config(pool.clone(), config, false).await;
         let pm = create_test_admin_user(&pool, Role::PlatformManager).await;
@@ -3089,22 +3094,36 @@ mod tests {
             .await;
         resp.assert_status(axum::http::StatusCode::OK);
 
-        // Read all .eml files written to the scratch dir. We expect two:
-        // one to the new address and one to the current address, both
-        // containing a confirmation link (not a notice).
+        // Pre-condition: before the worker runs, no files yet (the handler
+        // returned right after enqueue; the send happens in the background).
+        // We don't assert this strictly — the worker may have already drained
+        // depending on scheduling — but the post-condition is the real check.
+
+        // Poll for both files to appear. Timeout generous because the test
+        // postgres is shared and underway listen/notify can be quirky under
+        // sqlx::test parallelism.
         let mut to_addresses: Vec<String> = Vec::new();
         let mut bodies: Vec<String> = Vec::new();
-        for entry in std::fs::read_dir(&scratch).unwrap() {
-            let path = entry.unwrap().path();
-            if path.extension().and_then(|s| s.to_str()) == Some("eml") {
-                let body = std::fs::read_to_string(&path).unwrap();
-                for line in body.lines() {
-                    if let Some(rest) = line.strip_prefix("To: ") {
-                        to_addresses.push(rest.trim().to_string());
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            to_addresses.clear();
+            bodies.clear();
+            for entry in std::fs::read_dir(&scratch).unwrap() {
+                let path = entry.unwrap().path();
+                if path.extension().and_then(|s| s.to_str()) == Some("eml") {
+                    let body = std::fs::read_to_string(&path).unwrap();
+                    for line in body.lines() {
+                        if let Some(rest) = line.strip_prefix("To: ") {
+                            to_addresses.push(rest.trim().to_string());
+                        }
                     }
+                    bodies.push(body);
                 }
-                bodies.push(body);
             }
+            if bodies.len() >= 2 || std::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
         to_addresses.sort();
         assert_eq!(

--- a/dwctl/src/api/handlers/support.rs
+++ b/dwctl/src/api/handlers/support.rs
@@ -8,7 +8,7 @@ use utoipa::ToSchema;
 use crate::{
     AppState,
     api::models::users::CurrentUser,
-    email::EmailService,
+    email_jobs::SendEmailInput,
     errors::{Error, Result},
 };
 
@@ -22,18 +22,26 @@ pub struct SupportRequest {
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct SupportResponse {
-    /// Whether the support request was sent successfully
+    /// Whether the support request was accepted for delivery. Accepted does
+    /// not mean delivered — the actual send runs asynchronously via the
+    /// `send-email` worker, which retries transient provider failures.
     pub sent: bool,
 }
 
-/// Submit a support request via email
+/// Submit a support request via email.
+///
+/// Enqueues the send rather than awaiting it inline so the caller doesn't
+/// see a 5xx when the upstream provider is unavailable or rate-limiting.
+/// The actual delivery runs in the `send-email` worker with retry on
+/// transient errors.
 #[utoipa::path(
     post,
     path = "/support/requests",
     request_body = SupportRequest,
     responses(
-        (status = 200, description = "Support request sent", body = SupportResponse),
-        (status = 500, description = "Failed to send support request"),
+        (status = 200, description = "Support request accepted for delivery", body = SupportResponse),
+        (status = 400, description = "Subject or message missing"),
+        (status = 500, description = "Failed to enqueue support request"),
     ),
     security(("BearerAuth" = []), ("CookieAuth" = []), ("X-Doubleword-User" = [])),
 )]
@@ -53,16 +61,20 @@ pub async fn submit_support_request<P: PoolProvider>(
         });
     }
 
-    let email_service = EmailService::new(&config)?;
-    email_service
-        .send_support_request(
-            &config.support_email,
-            &current_user.email,
-            current_user.display_name.as_deref(),
-            subject,
-            message,
-        )
-        .await?;
+    state
+        .task_runner
+        .send_email_job
+        .enqueue(&SendEmailInput::SupportRequest {
+            support_email: config.support_email.clone(),
+            user_email: current_user.email.clone(),
+            user_name: current_user.display_name.clone(),
+            subject: subject.to_string(),
+            message: message.to_string(),
+        })
+        .await
+        .map_err(|e| Error::Internal {
+            operation: format!("enqueue support request: {e}"),
+        })?;
 
     Ok(Json(SupportResponse { sent: true }))
 }

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1853,6 +1853,14 @@ pub struct TaskWorkersConfig {
     /// Handles create-response and complete-response jobs from the responses
     /// middleware and outlet handler. Set to 0 to disable.
     pub response_workers: usize,
+    /// Number of send-email workers (default: 1).
+    ///
+    /// Always at least 1 in practice: every email send (password reset, org
+    /// invite, support request, batch completion, etc.) goes through the
+    /// `send-email` underway queue. With 0 workers, enqueued sends never
+    /// run and recipients never get their mail. Setting this >0 is also how
+    /// you scale email throughput if the queue starts backing up.
+    pub email_workers: usize,
 }
 
 impl Default for TaskWorkersConfig {
@@ -1861,6 +1869,7 @@ impl Default for TaskWorkersConfig {
             create_batch_workers: 1,
             cascade_batch_state_workers: 1,
             response_workers: 1,
+            email_workers: 1,
         }
     }
 }

--- a/dwctl/src/email_jobs.rs
+++ b/dwctl/src/email_jobs.rs
@@ -1,0 +1,322 @@
+//! Underway job for asynchronous email sends.
+//!
+//! Every public email send goes through `SendEmailJob`. The handler builds
+//! a [`SendEmailInput`] and enqueues it; the worker picks it up and runs the
+//! actual send against the configured transport.
+//!
+//! Enqueueing decouples the user-facing request from the upstream send: a
+//! provider error no longer fails the request, and the worker retries
+//! transient errors (HTTP 5xx, 429, network) with backoff. Permanent errors
+//! (other 4xx) fail the job immediately.
+
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::email::EmailService;
+use crate::notifications::BatchNotificationInfo;
+
+/// One enqueued email send. The variant determines which template is rendered
+/// and which fields are required; the worker matches on the variant and
+/// dispatches to the matching `EmailService::send_*` method.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SendEmailInput {
+    PasswordReset {
+        to_email: String,
+        to_name: Option<String>,
+        token_id: Uuid,
+        token: String,
+    },
+    BatchCompletion {
+        to_email: String,
+        to_name: Option<String>,
+        info: BatchNotificationInfo,
+        first_batch: bool,
+    },
+    LowBalance {
+        to_email: String,
+        to_name: Option<String>,
+        balance: Decimal,
+    },
+    AutoTopupSuccess {
+        to_email: String,
+        to_name: Option<String>,
+        amount: Decimal,
+        threshold: Decimal,
+        new_balance: Decimal,
+    },
+    AutoTopupFailed {
+        to_email: String,
+        to_name: Option<String>,
+        amount: Decimal,
+        threshold: Decimal,
+    },
+    AutoTopupLimitReached {
+        to_email: String,
+        to_name: Option<String>,
+        monthly_limit: Decimal,
+        balance: Decimal,
+    },
+    OrgInvite {
+        to_email: String,
+        org_name: String,
+        inviter_name: String,
+        role: String,
+        invite_link: String,
+    },
+    SupportRequest {
+        support_email: String,
+        user_email: String,
+        user_name: Option<String>,
+        subject: String,
+        message: String,
+    },
+    OrgEmailChangeVerifyNew {
+        to_email: String,
+        org_name: String,
+        confirm_link: String,
+    },
+    OrgEmailChangeVerifyOld {
+        to_email: String,
+        org_name: String,
+        new_email: String,
+        confirm_link: String,
+        support_email: Option<String>,
+    },
+}
+
+impl SendEmailInput {
+    /// Stable identifier for logs / metrics. Used to keep tracing readable
+    /// without dumping the whole payload (which may contain a password-reset
+    /// token or other sensitive material).
+    fn kind_label(&self) -> &'static str {
+        match self {
+            Self::PasswordReset { .. } => "password_reset",
+            Self::BatchCompletion { first_batch: true, .. } => "first_batch",
+            Self::BatchCompletion { first_batch: false, .. } => "batch_complete",
+            Self::LowBalance { .. } => "low_balance",
+            Self::AutoTopupSuccess { .. } => "auto_topup_success",
+            Self::AutoTopupFailed { .. } => "auto_topup_failed",
+            Self::AutoTopupLimitReached { .. } => "auto_topup_limit_reached",
+            Self::OrgInvite { .. } => "org_invite",
+            Self::SupportRequest { .. } => "support_request",
+            Self::OrgEmailChangeVerifyNew { .. } => "org_email_change_verify_new",
+            Self::OrgEmailChangeVerifyOld { .. } => "org_email_change_verify_old",
+        }
+    }
+}
+
+/// Build the underway job that sends queued emails. The step closure
+/// constructs an [`EmailService`] from the current shared config (so live
+/// config edits take effect on the next job) and dispatches based on the
+/// input variant.
+pub async fn build_send_email_job<P>(
+    pool: sqlx::PgPool,
+    state: crate::tasks::TaskState<P>,
+) -> anyhow::Result<underway::Job<SendEmailInput, crate::tasks::TaskState<P>>>
+where
+    P: sqlx_pool_router::PoolProvider + Clone + Send + Sync + 'static,
+{
+    use underway::Job;
+    use underway::job::To;
+    use underway::task::Error as TaskError;
+
+    Job::<SendEmailInput, _>::builder()
+        .state(state)
+        .step(|cx, input: SendEmailInput| async move {
+            let kind = input.kind_label();
+            let config = cx.state.config.snapshot();
+
+            // Construct fresh each call so transport config edits (e.g. flipping
+            // SMTP_PROVIDER) take effect on the next send without restarting.
+            let svc = match EmailService::new(&config) {
+                Ok(s) => s,
+                Err(e) => {
+                    // Misconfiguration is permanent — retrying won't help.
+                    tracing::error!(error = %e, kind, "EmailService construction failed; dropping send");
+                    return To::done();
+                }
+            };
+
+            let result = dispatch(&svc, input).await;
+
+            match result {
+                Ok(()) => {
+                    tracing::debug!(kind, "email sent");
+                    To::done()
+                }
+                Err(e) => {
+                    // EmailService::send_* always maps provider errors to
+                    // `Error::Internal`. We treat them as retryable; underway
+                    // applies its built-in backoff. Permanent provider errors
+                    // (validation, unverified sender) will keep failing the
+                    // same way and eventually exhaust retries — that's the
+                    // right behavior: a permanent provider error means the
+                    // config or recipient is wrong and needs human attention,
+                    // and the retries give time to fix it before the job is
+                    // marked dead.
+                    tracing::warn!(error = %e, kind, "email send failed; will retry");
+                    Err(TaskError::Retryable(e.to_string()))
+                }
+            }
+        })
+        .name("send-email")
+        .pool(pool)
+        .build()
+        .await
+        .map_err(Into::into)
+}
+
+/// Dispatch one [`SendEmailInput`] to the matching [`EmailService`] method.
+///
+/// Lifted to a free function so [`build_send_email_job`]'s step closure stays
+/// short and `match`-readable.
+async fn dispatch(svc: &EmailService, input: SendEmailInput) -> Result<(), crate::errors::Error> {
+    match input {
+        SendEmailInput::PasswordReset {
+            to_email,
+            to_name,
+            token_id,
+            token,
+        } => {
+            svc.send_password_reset_email(&to_email, to_name.as_deref(), &token_id, &token)
+                .await
+        }
+        SendEmailInput::BatchCompletion {
+            to_email,
+            to_name,
+            info,
+            first_batch,
+        } => {
+            svc.send_batch_completion_email(&to_email, to_name.as_deref(), &info, first_batch)
+                .await
+        }
+        SendEmailInput::LowBalance {
+            to_email,
+            to_name,
+            balance,
+        } => svc.send_low_balance_email(&to_email, to_name.as_deref(), &balance).await,
+        SendEmailInput::AutoTopupSuccess {
+            to_email,
+            to_name,
+            amount,
+            threshold,
+            new_balance,
+        } => {
+            svc.send_auto_topup_success_email(&to_email, to_name.as_deref(), &amount, &threshold, &new_balance)
+                .await
+        }
+        SendEmailInput::AutoTopupFailed {
+            to_email,
+            to_name,
+            amount,
+            threshold,
+        } => {
+            svc.send_auto_topup_failed_email(&to_email, to_name.as_deref(), &amount, &threshold)
+                .await
+        }
+        SendEmailInput::AutoTopupLimitReached {
+            to_email,
+            to_name,
+            monthly_limit,
+            balance,
+        } => {
+            svc.send_auto_topup_limit_reached_email(&to_email, to_name.as_deref(), &monthly_limit, &balance)
+                .await
+        }
+        SendEmailInput::OrgInvite {
+            to_email,
+            org_name,
+            inviter_name,
+            role,
+            invite_link,
+        } => {
+            svc.send_org_invite_email(&to_email, &org_name, &inviter_name, &role, &invite_link)
+                .await
+        }
+        SendEmailInput::SupportRequest {
+            support_email,
+            user_email,
+            user_name,
+            subject,
+            message,
+        } => {
+            svc.send_support_request(&support_email, &user_email, user_name.as_deref(), &subject, &message)
+                .await
+        }
+        SendEmailInput::OrgEmailChangeVerifyNew {
+            to_email,
+            org_name,
+            confirm_link,
+        } => svc.send_org_email_change_verify_new(&to_email, &org_name, &confirm_link).await,
+        SendEmailInput::OrgEmailChangeVerifyOld {
+            to_email,
+            org_name,
+            new_email,
+            confirm_link,
+            support_email,
+        } => {
+            svc.send_org_email_change_verify_old(&to_email, &org_name, &new_email, &confirm_link, support_email.as_deref())
+                .await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_labels_match_dwctl_email_send_total_template_label() {
+        // Keep `SendEmailInput::kind_label` aligned with the `template` label
+        // emitted by `EmailService::dispatch` in email.rs. If you add a new
+        // variant, mirror it on both sides — the dashboard panels and alerts
+        // are wired up to the exact strings.
+        use rust_decimal::Decimal;
+        use uuid::Uuid;
+
+        let cases: Vec<(SendEmailInput, &'static str)> = vec![
+            (
+                SendEmailInput::PasswordReset {
+                    to_email: String::new(),
+                    to_name: None,
+                    token_id: Uuid::nil(),
+                    token: String::new(),
+                },
+                "password_reset",
+            ),
+            (
+                SendEmailInput::LowBalance {
+                    to_email: String::new(),
+                    to_name: None,
+                    balance: Decimal::ZERO,
+                },
+                "low_balance",
+            ),
+            (
+                SendEmailInput::SupportRequest {
+                    support_email: String::new(),
+                    user_email: String::new(),
+                    user_name: None,
+                    subject: String::new(),
+                    message: String::new(),
+                },
+                "support_request",
+            ),
+            (
+                SendEmailInput::OrgEmailChangeVerifyOld {
+                    to_email: String::new(),
+                    org_name: String::new(),
+                    new_email: String::new(),
+                    confirm_link: String::new(),
+                    support_email: None,
+                },
+                "org_email_change_verify_old",
+            ),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(input.kind_label(), expected);
+        }
+    }
+}

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -149,6 +149,7 @@ mod crypto;
 pub mod db;
 mod email;
 mod email_http;
+pub mod email_jobs;
 pub mod encryption;
 mod error_enrichment;
 pub mod errors;

--- a/dwctl/src/notifications.rs
+++ b/dwctl/src/notifications.rs
@@ -48,7 +48,7 @@ use crate::webhooks::events::{WebhookEvent, WebhookEventType};
 const WEBHOOK_EVENT_CHANNEL: &str = "webhook_event";
 
 /// Outcome of a completed batch for notification purposes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BatchOutcome {
     Completed,
     PartiallyCompleted,
@@ -56,6 +56,10 @@ pub enum BatchOutcome {
 }
 
 /// Unified batch notification info used by both email and webhook delivery.
+///
+/// Serializable so it can be embedded in the `SendEmailInput::BatchCompletion`
+/// underway job payload.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BatchNotificationInfo {
     pub batch_id: String,
     pub batch_uuid: Uuid,

--- a/dwctl/src/tasks.rs
+++ b/dwctl/src/tasks.rs
@@ -17,6 +17,7 @@ use crate::api::handlers::batches::{CascadeBatchStateInput, CreateBatchInput, bu
 use crate::connections::sync::{
     ActivateBatchInput, IngestFileInput, SyncConnectionInput, build_activate_batch_job, build_ingest_file_job, build_sync_connection_job,
 };
+use crate::email_jobs::{SendEmailInput, build_send_email_job};
 use crate::responses::jobs::{CompleteResponseInput, CreateResponseInput, build_complete_response_job, build_create_response_job};
 
 /// A lazily-initialized, shared job reference using `Weak` to avoid reference
@@ -103,6 +104,10 @@ pub struct TaskRunner<P: PoolProvider + Clone + 'static = sqlx_pool_router::DbPo
     pub activate_batch_job: Arc<Job<ActivateBatchInput, TaskState<P>>>,
     pub create_response_job: Arc<Job<CreateResponseInput, TaskState<P>>>,
     pub complete_response_job: Arc<Job<CompleteResponseInput, TaskState<P>>>,
+    /// Queue for all outbound transactional email. Handlers enqueue rather
+    /// than awaiting an SMTP/HTTP send so the user-facing request can return
+    /// quickly even if the provider is down or rate-limiting.
+    pub send_email_job: Arc<Job<SendEmailInput, TaskState<P>>>,
 }
 
 impl<P: PoolProvider + Clone + Send + Sync + 'static> TaskRunner<P> {
@@ -126,6 +131,7 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> TaskRunner<P> {
         let activate_batch_job = Arc::new(build_activate_batch_job(pool.clone(), state.clone()).await?);
         let create_response_job = Arc::new(build_create_response_job(pool.clone(), state.clone()).await?);
         let complete_response_job = Arc::new(build_complete_response_job(pool.clone(), state.clone()).await?);
+        let send_email_job = Arc::new(build_send_email_job(pool.clone(), state.clone()).await?);
         let sync_connection_job = Arc::new(build_sync_connection_job(pool, state.clone()).await?);
 
         // Wire weak cross-references. All jobs share the same Arc<OnceLock>,
@@ -151,6 +157,7 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> TaskRunner<P> {
             activate_batch_job,
             create_response_job,
             complete_response_job,
+            send_email_job,
         })
     }
 
@@ -227,6 +234,24 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> TaskRunner<P> {
                     }),
                 ));
             }
+        }
+
+        // Send-email workers — drain the email queue populated by every public
+        // EmailService caller. Always run at least one: with zero workers,
+        // enqueued sends would silently never deliver. Use `email_workers > 1`
+        // to scale throughput if the queue starts backing up.
+        let email_workers = task_config.email_workers.max(1);
+        for i in 0..email_workers {
+            let mut worker = self.send_email_job.worker();
+            worker.set_shutdown_token(shutdown_token.clone());
+            handles.push((
+                "send-email-worker",
+                tokio::spawn(async move {
+                    if let Err(e) = worker.run().await {
+                        tracing::error!(error = %e, worker = i, "Send-email worker error");
+                    }
+                }),
+            ));
         }
 
         if !sync_config.enabled {

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -848,6 +848,7 @@ async fn test_request_logging_disabled(pool: PgPool) {
                 create_batch_workers: 0,
                 cascade_batch_state_workers: 0,
                 response_workers: 0,
+                email_workers: 0,
             },
         )
         .await
@@ -1413,6 +1414,7 @@ async fn test_build_router_with_metrics_disabled(pool: PgPool) {
                 create_batch_workers: 0,
                 cascade_batch_state_workers: 0,
                 response_workers: 0,
+                email_workers: 0,
             },
         )
         .await
@@ -1472,6 +1474,7 @@ async fn test_build_router_with_metrics_enabled(pool: PgPool) {
                 create_batch_workers: 0,
                 cascade_batch_state_workers: 0,
                 response_workers: 0,
+                email_workers: 0,
             },
         )
         .await

--- a/dwctl/src/test/utils.rs
+++ b/dwctl/src/test/utils.rs
@@ -59,6 +59,7 @@ pub async fn create_test_app_state_with_config(pool: PgPool, config: crate::conf
                 create_batch_workers: 0,
                 cascade_batch_state_workers: 0,
                 response_workers: 0,
+                email_workers: 0,
             },
         )
         .await
@@ -136,6 +137,7 @@ pub async fn create_test_app_state_with_fusillade(pool: PgPool, config: crate::c
                 create_batch_workers: 0,
                 cascade_batch_state_workers: 0,
                 response_workers: 0,
+                email_workers: 0,
             },
         )
         .await
@@ -300,6 +302,7 @@ pub fn create_test_config() -> crate::config::Config {
                 create_batch_workers: 0,
                 cascade_batch_state_workers: 0,
                 response_workers: 0,
+                email_workers: 0,
             },
             ..Default::default()
         },


### PR DESCRIPTION
## Summary

Sends transactional email asynchronously via a new `send-email` underway job. Request-path handlers (`POST /admin/api/v1/support/requests`, password reset, org invite, org email-change verify) now enqueue rather than awaiting the upstream send, so an unavailable or rate-limiting provider no longer surfaces as a 5xx to the caller.

**Base branch:** `feat/email-provider-abstraction` — depends on the HTTP transport from #1092. Merge order: #1092 → this PR.

### What changed

- New module `email_jobs` with `SendEmailInput` (one variant per template) and `build_send_email_job`. Worker step constructs an `EmailService` from the live `SharedConfig` snapshot on each call, so transport config edits take effect on the next send.
- `TaskRunner` grows a `send_email_job: Arc<Job<SendEmailInput, _>>` field and registers a worker pool in `start()`.
- `TaskWorkersConfig` grows `email_workers: usize` (default 1). `TaskRunner::start` always spawns at least one worker via `.max(1)` — empty configs still drain the queue.
- Handlers migrated to enqueue:
  - `api/handlers/support.rs::submit_support_request`
  - `api/handlers/auth.rs::request_password_reset`
  - `api/handlers/organizations.rs::update_organization` (both verify-new and verify-old)
  - `api/handlers/organizations.rs::invite_member`
- `BatchNotificationInfo` and `BatchOutcome` get serde derives so they ride in the job payload (used by `SendEmailInput::BatchCompletion`).
- Worker retry: errors from `EmailService` get `TaskError::Retryable`; underway applies its default backoff. Permanent provider errors will exhaust retries and dead-letter — that's intentional (they need human attention).

### Deliberately out of scope

The notification poller (`notifications.rs`) still calls `EmailService` directly for batch-complete, low-balance, and auto-topup sends. Migrating those requires moving `TaskRunner` construction earlier in `lib.rs` bring-up so the poller can hold the job reference; left as a follow-up. Those sends already run off the user-request path and swallow errors, so they don't cause 5xx today.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --lib email::` and `email_jobs::` and `email_http::` — 46 tests pass, including the new `email_jobs::tests::kind_labels_match_dwctl_email_send_total_template_label` that pins template-id strings.
- [x] `test_patch_writes_both_verification_emails` updated to enable `email_workers: 1` and poll the scratch dir until both `.eml` files appear (timeout 10s) — passes against the live test postgres.
- [ ] CI: `just lint rust`, `just test rust`, `just lint ts`, `just test ts`
