### PR TITLE
feat(support): per-user rate limit on support-request submissions

### DIFF
--- a/.sqlx/query-ab9e2c8b8b1c69b182e64ddcf44336af540f0001854d70502296772e56cd6a60.json
+++ b/.sqlx/query-ab9e2c8b8b1c69b182e64ddcf44336af540f0001854d70502296772e56cd6a60.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) FROM support_request_submissions\n         WHERE user_id = $1\n           AND created_at > NOW() - make_interval(secs => $2::int)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "ab9e2c8b8b1c69b182e64ddcf44336af540f0001854d70502296772e56cd6a60"
+}

--- a/.sqlx/query-b0598a361d8b284f12e572217231ac997f173c4f0c0004b7b5890b3934895256.json
+++ b/.sqlx/query-b0598a361d8b284f12e572217231ac997f173c4f0c0004b7b5890b3934895256.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO support_request_submissions (user_id) VALUES ($1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b0598a361d8b284f12e572217231ac997f173c4f0c0004b7b5890b3934895256"
+}

--- a/dwctl/migrations/098_support_request_submissions.sql
+++ b/dwctl/migrations/098_support_request_submissions.sql
@@ -1,0 +1,24 @@
+-- Audit + rate-limit table for POST /admin/api/v1/support/requests.
+--
+-- One row per accepted submission. The handler queries this table for a
+-- per-user sliding-window count to cap how many support requests a single
+-- account can submit per hour. This prevents one user (script error,
+-- automation, or compromised credentials) from draining the shared
+-- transactional-email quota.
+--
+-- Only metadata is stored — the subject and body of the request are sent
+-- via the email path and never persisted here, to avoid this table
+-- accumulating support content.
+
+CREATE TABLE support_request_submissions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Compound index supports the per-user, last-window-hours COUNT query the
+-- handler runs on every submission to enforce the rate limit. The DESC
+-- ordering on created_at lets the planner pick the index for both the
+-- COUNT (range scan) and any future "list my recent submissions" lookups.
+CREATE INDEX idx_support_request_submissions_user_recent
+    ON support_request_submissions (user_id, created_at DESC);

--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -828,6 +828,9 @@ async fn reserve_capacity_for_batch<P: PoolProvider>(
                 "Insufficient capacity for {} completion window. The following models are currently at capacity: {}. Try again later or use a longer completion window.",
                 completion_window, models
             ),
+            // 60s aligns with the previous default; tune if batch capacity
+            // turnaround is consistently faster or slower than that.
+            retry_after_seconds: 60,
         },
         CapacityError::Internal(msg) => Error::Internal { operation: msg },
     })

--- a/dwctl/src/api/handlers/files.rs
+++ b/dwctl/src/api/handlers/files.rs
@@ -2903,7 +2903,7 @@ mod tests {
         let result = limiter.acquire().await;
         assert!(result.is_err(), "Third request should be rejected when queue is full");
 
-        if let Err(crate::errors::Error::TooManyRequests { message }) = result {
+        if let Err(crate::errors::Error::TooManyRequests { message, .. }) = result {
             assert!(message.contains("Too many file uploads"));
         } else {
             panic!("Expected TooManyRequests error");

--- a/dwctl/src/api/handlers/support.rs
+++ b/dwctl/src/api/handlers/support.rs
@@ -12,6 +12,17 @@ use crate::{
     errors::{Error, Result},
 };
 
+/// Per-user submission cap inside [`SUPPORT_REQUEST_WINDOW_SECS`].
+///
+/// Defends against a single account (script, accidental retry loop, or
+/// compromised credentials) draining the shared transactional-email
+/// allowance. The limit is intentionally generous for a human reporting an
+/// issue and tight enough that automated abuse trips it quickly.
+const SUPPORT_REQUEST_LIMIT: i64 = 5;
+
+/// Sliding-window length in seconds for the [`SUPPORT_REQUEST_LIMIT`] cap.
+const SUPPORT_REQUEST_WINDOW_SECS: u64 = 3600;
+
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct SupportRequest {
     /// Subject line for the support request
@@ -34,6 +45,12 @@ pub struct SupportResponse {
 /// see a 5xx when the upstream provider is unavailable or rate-limiting.
 /// The actual delivery runs in the `send-email` worker with retry on
 /// transient errors.
+///
+/// Per-user rate limit: [`SUPPORT_REQUEST_LIMIT`] accepted submissions per
+/// [`SUPPORT_REQUEST_WINDOW_SECS`] window. Excess submissions get HTTP 429
+/// with a `Retry-After` header. The limit is enforced via a row count
+/// against the `support_request_submissions` audit table so it applies
+/// uniformly across replicas.
 #[utoipa::path(
     post,
     path = "/support/requests",
@@ -41,11 +58,12 @@ pub struct SupportResponse {
     responses(
         (status = 200, description = "Support request accepted for delivery", body = SupportResponse),
         (status = 400, description = "Subject or message missing"),
+        (status = 429, description = "Per-user submission rate limit exceeded"),
         (status = 500, description = "Failed to enqueue support request"),
     ),
     security(("BearerAuth" = []), ("CookieAuth" = []), ("X-Doubleword-User" = [])),
 )]
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, fields(user_id = %current_user.id))]
 pub async fn submit_support_request<P: PoolProvider>(
     State(state): State<AppState<P>>,
     current_user: CurrentUser,
@@ -61,6 +79,46 @@ pub async fn submit_support_request<P: PoolProvider>(
         });
     }
 
+    // Rate-limit check + audit-row insert in a single transaction so the
+    // count and the new row stay consistent under concurrent submissions
+    // from the same user. The audit row is what the next request's COUNT
+    // query observes; without the same transaction the second of two
+    // concurrent requests could read a stale count and slip past the cap.
+    let window_secs = SUPPORT_REQUEST_WINDOW_SECS as i32;
+    let mut tx = state.db.write().begin().await.map_err(|e| Error::Database(e.into()))?;
+    let recent_count: i64 = sqlx::query_scalar!(
+        "SELECT COUNT(*) FROM support_request_submissions
+         WHERE user_id = $1
+           AND created_at > NOW() - make_interval(secs => $2::int)",
+        current_user.id,
+        window_secs,
+    )
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| Error::Database(e.into()))?
+    .unwrap_or(0);
+
+    if recent_count >= SUPPORT_REQUEST_LIMIT {
+        // Don't insert the audit row on rejection — the row records accepted
+        // submissions, not attempts. Rolling back the empty transaction is
+        // free; the explicit drop is documentation.
+        drop(tx);
+        return Err(Error::TooManyRequests {
+            message: format!("support request limit reached ({SUPPORT_REQUEST_LIMIT} per hour); please wait before submitting again"),
+            retry_after_seconds: SUPPORT_REQUEST_WINDOW_SECS,
+        });
+    }
+
+    sqlx::query!("INSERT INTO support_request_submissions (user_id) VALUES ($1)", current_user.id,)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| Error::Database(e.into()))?;
+    tx.commit().await.map_err(|e| Error::Database(e.into()))?;
+
+    // Enqueue after the audit row is committed. If the enqueue fails the
+    // caller sees 500 and the audit row remains; on retry they'll be one
+    // step closer to the limit. That's acceptable — enqueue failures are
+    // pool-down events, not steady state.
     state
         .task_runner
         .send_email_job
@@ -77,4 +135,128 @@ pub async fn submit_support_request<P: PoolProvider>(
         })?;
 
     Ok(Json(SupportResponse { sent: true }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::models::users::Role;
+    use crate::test::utils::{add_auth_headers, create_test_app, create_test_user};
+    use serde_json::json;
+    use sqlx::PgPool;
+
+    /// Helper: POST a support request body, returning the axum-test response.
+    async fn post_support_request(
+        server: &axum_test::TestServer,
+        headers: &[(String, String)],
+        subject: &str,
+        message: &str,
+    ) -> axum_test::TestResponse {
+        let mut req = server
+            .post("/admin/api/v1/support/requests")
+            .json(&json!({ "subject": subject, "message": message }));
+        for (k, v) in headers {
+            req = req.add_header(k, v);
+        }
+        req.await
+    }
+
+    #[sqlx::test]
+    async fn submit_succeeds_and_records_audit_row(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+        let headers = add_auth_headers(&user);
+
+        let resp = post_support_request(&server, &headers, "Help me", "I can't log in").await;
+        resp.assert_status_ok();
+
+        let count: i64 = sqlx::query_scalar!("SELECT COUNT(*) FROM support_request_submissions WHERE user_id = $1", user.id,)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .unwrap_or(0);
+        assert_eq!(count, 1, "exactly one audit row per accepted submission");
+    }
+
+    #[sqlx::test]
+    async fn rejects_after_limit_with_429_and_retry_after(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+        let headers = add_auth_headers(&user);
+
+        // Fill the bucket.
+        for i in 0..SUPPORT_REQUEST_LIMIT {
+            let resp = post_support_request(&server, &headers, &format!("subj {i}"), "body").await;
+            resp.assert_status_ok();
+        }
+
+        // The next one must be rejected.
+        let resp = post_support_request(&server, &headers, "one too many", "body").await;
+        resp.assert_status(axum::http::StatusCode::TOO_MANY_REQUESTS);
+
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .expect("Retry-After header on 429")
+            .to_str()
+            .expect("Retry-After header is ascii")
+            .to_string();
+        assert_eq!(retry_after, SUPPORT_REQUEST_WINDOW_SECS.to_string());
+
+        // No audit row recorded for the rejection.
+        let count: i64 = sqlx::query_scalar!("SELECT COUNT(*) FROM support_request_submissions WHERE user_id = $1", user.id,)
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .unwrap_or(0);
+        assert_eq!(count, SUPPORT_REQUEST_LIMIT, "rejection must not insert an audit row");
+    }
+
+    #[sqlx::test]
+    async fn limit_is_per_user(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let user_a = create_test_user(&pool, Role::StandardUser).await;
+        let user_b = create_test_user(&pool, Role::StandardUser).await;
+        let headers_a = add_auth_headers(&user_a);
+        let headers_b = add_auth_headers(&user_b);
+
+        // User A fills their bucket.
+        for _ in 0..SUPPORT_REQUEST_LIMIT {
+            post_support_request(&server, &headers_a, "subj", "body").await.assert_status_ok();
+        }
+        post_support_request(&server, &headers_a, "blocked", "body")
+            .await
+            .assert_status(axum::http::StatusCode::TOO_MANY_REQUESTS);
+
+        // User B is unaffected.
+        post_support_request(&server, &headers_b, "first for B", "body")
+            .await
+            .assert_status_ok();
+    }
+
+    #[sqlx::test]
+    async fn submissions_outside_window_dont_count(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+        let headers = add_auth_headers(&user);
+
+        // Seed SUPPORT_REQUEST_LIMIT old rows just outside the window. The
+        // handler should NOT see them in its count and should accept the
+        // next submission.
+        for _ in 0..SUPPORT_REQUEST_LIMIT {
+            sqlx::query!(
+                "INSERT INTO support_request_submissions (user_id, created_at)
+                 VALUES ($1, NOW() - make_interval(secs => $2::int))",
+                user.id,
+                (SUPPORT_REQUEST_WINDOW_SECS as i32) + 60,
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        post_support_request(&server, &headers, "should pass", "body")
+            .await
+            .assert_status_ok();
+    }
 }

--- a/dwctl/src/errors.rs
+++ b/dwctl/src/errors.rs
@@ -136,9 +136,15 @@ pub enum Error {
         message: String,
     },
 
-    /// Too many concurrent requests - rate limiting
+    /// Too many requests — rate limiting or capacity rejection.
+    ///
+    /// `retry_after_seconds` is surfaced both in the `Retry-After` HTTP header
+    /// and in the JSON body so clients with retry logic can wait the right
+    /// amount. Callers should pass a value calibrated to the limit they hit
+    /// (e.g. 60s for a short-term concurrency cap; the full window length
+    /// for a sliding-window per-user limit).
     #[error("Too many requests: {message}")]
-    TooManyRequests { message: String },
+    TooManyRequests { message: String, retry_after_seconds: u64 },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -230,7 +236,7 @@ impl Error {
             Error::InsufficientCredits { message, .. } => message.clone(),
             Error::ModelAccessDenied { message, .. } => message.clone(),
             Error::ModalityAccessDenied { message, .. } => message.clone(),
-            Error::TooManyRequests { message } => message.clone(),
+            Error::TooManyRequests { message, .. } => message.clone(),
         }
     }
 }
@@ -329,20 +335,21 @@ impl IntoResponse for Error {
 
                 (status, axum::response::Json(body)).into_response()
             }
-            Error::TooManyRequests { message } => {
+            Error::TooManyRequests {
+                message,
+                retry_after_seconds,
+            } => {
                 use axum::http::header::RETRY_AFTER;
                 use serde_json::json;
 
-                // Suggest retry after 60 seconds for capacity-based rejections
-                let retry_after_secs = "60";
-
+                let retry_after_str = retry_after_seconds.to_string();
                 let body = json!({
                     "error": "too_many_requests",
                     "message": message,
-                    "retry_after_seconds": 30
+                    "retry_after_seconds": retry_after_seconds,
                 });
 
-                (status, [(RETRY_AFTER, retry_after_secs)], axum::response::Json(body)).into_response()
+                (status, [(RETRY_AFTER, retry_after_str.as_str())], axum::response::Json(body)).into_response()
             }
             _ => {
                 // For all other errors, return simple text message (unchanged)

--- a/dwctl/src/limits.rs
+++ b/dwctl/src/limits.rs
@@ -106,6 +106,7 @@ impl UploadLimiter {
             self.waiting_count.fetch_sub(1, Ordering::SeqCst);
             return Err(Error::TooManyRequests {
                 message: "Too many file uploads in progress. Please retry later.".to_string(),
+                retry_after_seconds: 60,
             });
         }
 
@@ -127,6 +128,7 @@ impl UploadLimiter {
             // Zero timeout means reject immediately if not available
             Err(Error::TooManyRequests {
                 message: "Too many file uploads in progress. Please retry later.".to_string(),
+                retry_after_seconds: 60,
             })
         } else {
             match tokio::time::timeout(self.max_wait, self.semaphore.clone().acquire_owned()).await {
@@ -135,12 +137,14 @@ impl UploadLimiter {
                     // Semaphore closed (shouldn't happen in normal operation)
                     Err(Error::TooManyRequests {
                         message: "Upload service temporarily unavailable.".to_string(),
+                        retry_after_seconds: 60,
                     })
                 }
                 Err(_) => {
                     // Timeout elapsed
                     Err(Error::TooManyRequests {
                         message: "Timed out waiting for upload slot. Please retry later.".to_string(),
+                        retry_after_seconds: 60,
                     })
                 }
             }
@@ -235,7 +239,7 @@ mod tests {
         // Second waiter should be rejected (queue full)
         let result = limiter.acquire().await;
         assert!(result.is_err());
-        if let Err(Error::TooManyRequests { message }) = result {
+        if let Err(Error::TooManyRequests { message, .. }) = result {
             assert!(message.contains("Too many file uploads"));
         } else {
             panic!("Expected TooManyRequests error");
@@ -259,7 +263,7 @@ mod tests {
         assert!(elapsed >= Duration::from_secs(1));
         assert!(elapsed < Duration::from_secs(2));
 
-        if let Err(Error::TooManyRequests { message }) = result {
+        if let Err(Error::TooManyRequests { message, .. }) = result {
             assert!(message.contains("Timed out"));
         } else {
             panic!("Expected TooManyRequests error");


### PR DESCRIPTION
## Summary

Caps `POST /admin/api/v1/support/requests` at **5 accepted submissions per hour per user**. The next submission inside the window returns `429 Too Many Requests` with a `Retry-After: 3600` header.

**Base branch:** `feat/email-async-enqueue` — sits on top of #1093 (which sits on top of #1092). Merge order: #1092 → #1093 → this PR.

### What changed

- New migration `098_support_request_submissions.sql` — minimal audit table (`user_id`, `created_at`). Stores only metadata; subject/body never persisted here.
- Handler check + insert run in **one transaction** so concurrent submissions from the same user can't both observe a stale count and slip past the cap.
- `Error::TooManyRequests` grows a `retry_after_seconds: u64` field so the error-response formatter emits an accurate `Retry-After` header (was hardcoded to 60s). Existing concurrency-based 429s in `limits.rs` and the batch-capacity rejection in `handlers/batches.rs` keep their 60s default.
- `dwctl_email_send_total` (added in #1092) plus the audit-table row count gives operators an at-a-glance read on legit support volume vs rate-limit trips.

### Tuning knobs

`SUPPORT_REQUEST_LIMIT` and `SUPPORT_REQUEST_WINDOW_SECS` are file-level consts at the top of `support.rs`. If we want them runtime-configurable later, pull them into `LimitsConfig` — the change is mechanical.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --lib support` — 4 new tests pass: happy path, 429 after limit (with `Retry-After` assertion), per-user isolation, sliding-window aging
- [x] Existing limits.rs tests still pass after the `TooManyRequests` field addition
- [x] `cargo sqlx prepare --workspace` to refresh offline metadata; new query JSONs committed
- [ ] CI: `just lint rust`, `just test rust`, `just lint ts`, `just test ts`
