### PR TITLE
fix(dashboard): load provider icons via the icon proxy

### DIFF
--- a/dashboard/src/api/control-layer/types.test.ts
+++ b/dashboard/src/api/control-layer/types.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { providerIconUrl } from "./types";
+
+describe("providerIconUrl", () => {
+  it("routes https:// URLs through the icon proxy", () => {
+    expect(
+      providerIconUrl(
+        "openai",
+        "https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openai.svg",
+      ),
+    ).toBe("/admin/api/v1/provider-display-configs/openai/icon");
+  });
+
+  it("URL-encodes the provider key", () => {
+    expect(providerIconUrl("meta llama", "https://example.com/x.svg")).toBe(
+      "/admin/api/v1/provider-display-configs/meta%20llama/icon",
+    );
+  });
+
+  it("passes root-relative paths through unchanged", () => {
+    expect(providerIconUrl("anthropic", "/endpoints/anthropic.svg")).toBe(
+      "/endpoints/anthropic.svg",
+    );
+  });
+
+  it("passes registry-key strings through so CatalogIcon's local registry resolves them", () => {
+    expect(providerIconUrl("anthropic", "anthropic")).toBe("anthropic");
+    expect(providerIconUrl("openai", "openai")).toBe("openai");
+  });
+
+  it("returns undefined for null / empty / whitespace icon values", () => {
+    expect(providerIconUrl("openai", null)).toBeUndefined();
+    expect(providerIconUrl("openai", undefined)).toBeUndefined();
+    expect(providerIconUrl("openai", "")).toBeUndefined();
+    expect(providerIconUrl("openai", "   ")).toBeUndefined();
+  });
+
+  it("trims whitespace before deciding on the path", () => {
+    expect(providerIconUrl("openai", "  https://example.com/x.svg  ")).toBe(
+      "/admin/api/v1/provider-display-configs/openai/icon",
+    );
+  });
+});

--- a/dashboard/src/api/control-layer/types.ts
+++ b/dashboard/src/api/control-layer/types.ts
@@ -185,6 +185,41 @@ export interface ProviderDisplayConfig {
   updated_at?: string | null;
 }
 
+/**
+ * Resolve a provider config's `icon` field to a value safe to render in
+ * `<CatalogIcon icon=...>`.
+ *
+ * - `https://…` URLs (operator-set, point at npmmirror / wikipedia /
+ *   simpleicons / GitHub avatars / arbitrary CDNs) are routed through
+ *   the server-side icon proxy
+ *   (`GET /admin/api/v1/provider-display-configs/{providerKey}/icon`,
+ *   added in control-layer 8.54.0) so the browser only ever loads
+ *   provider logos from the same origin as the dashboard. Lets us keep
+ *   the deployed `img-src 'self' data: blob:` CSP regardless of which
+ *   CDN an admin pastes.
+ * - Root-relative paths (`/endpoints/anthropic.svg`) pass through —
+ *   already same-origin.
+ * - Registry keys (`anthropic`, `google`, `openai`, `onwards`,
+ *   `snowflake`) pass through — `CatalogIcon`'s built-in `ICON_REGISTRY`
+ *   maps them to bundled assets client-side.
+ * - Empty/whitespace/null → `undefined` so `CatalogIcon` falls back.
+ *
+ * Takes `providerKey` separately because the deployment-providers chip
+ * mapping (`providerConfigMap.get(dp)` in ModelCatalog) uses slim configs
+ * keyed by the same `dp` string we already have to hand.
+ */
+export function providerIconUrl(
+  providerKey: string,
+  iconValue: string | null | undefined,
+): string | undefined {
+  const icon = iconValue?.trim();
+  if (!icon) return undefined;
+  if (icon.startsWith("https://")) {
+    return `/admin/api/v1/provider-display-configs/${encodeURIComponent(providerKey)}/icon`;
+  }
+  return icon;
+}
+
 export interface ProviderDisplayConfigCreateRequest {
   provider_key: string;
   display_name?: string;

--- a/dashboard/src/components/features/models/catalog/ModelCatalog.tsx
+++ b/dashboard/src/components/features/models/catalog/ModelCatalog.tsx
@@ -15,7 +15,12 @@ import {
   Code,
   Copy,
 } from "lucide-react";
-import { useModels, useGroups, useProviderDisplayConfigs } from "../../../../api/control-layer";
+import {
+  useModels,
+  useGroups,
+  useProviderDisplayConfigs,
+  providerIconUrl,
+} from "../../../../api/control-layer";
 import type {
   Model,
   ModelDisplayCategory,
@@ -364,7 +369,7 @@ function ModelRow({
                       <TooltipTrigger asChild>
                         <span className="hidden shrink-0 min-[700px]:inline-flex">
                           <CatalogIcon
-                            icon={config.icon || undefined}
+                            icon={providerIconUrl(dp, config.icon)}
                             label={config.display_name}
                             size="sm"
                             fallback="none"
@@ -392,7 +397,7 @@ function ModelRow({
                   return (
                     <CatalogIcon
                       key={dp}
-                      icon={config.icon || undefined}
+                      icon={providerIconUrl(dp, config.icon)}
                       label={config.display_name}
                       size="sm"
                       fallback="none"
@@ -621,7 +626,7 @@ function SectionTable({
         providerConfig?.display_name ||
         model.metadata?.provider?.trim() ||
         "Other",
-      providerIcon: providerConfig?.icon,
+      providerIcon: providerIconUrl(providerKey, providerConfig?.icon),
     };
   };
 

--- a/dashboard/src/components/features/models/manage/MobileModelsView.tsx
+++ b/dashboard/src/components/features/models/manage/MobileModelsView.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from "react";
 import type { Model, ProviderDisplayConfig } from "../../../../api/control-layer/types";
+import { providerIconUrl } from "../../../../api/control-layer/types";
 import { CatalogIcon } from "../catalog/CatalogIcon";
 
 type FilterType = "category" | "capability";
@@ -187,7 +188,10 @@ export const MobileModelsView: React.FC<MobileModelsViewProps> = ({
               <Swimlane
                 key={key}
                 title={displayName}
-                titleIcon={config?.icon ?? key}
+                // Fall back to the registry key string (`anthropic`,
+                // `openai`, …) so CatalogIcon's bundled-asset registry
+                // can resolve it client-side when no operator icon set.
+                titleIcon={providerIconUrl(key, config?.icon) ?? key}
                 models={laneModels}
                 onNavigate={onNavigate}
               />

--- a/dwctl/README.md
+++ b/dwctl/README.md
@@ -263,4 +263,5 @@ Migrations are stored in the `migrations/` directory, and run automatically on s
 - See OpenAPI docs at `/admin/docs` when running
 - AI proxy requests are served under `/ai/v1/*` (e.g. `/ai/v1/chat/completions`, `/ai/v1/responses`) and routed by the embedded `onwards` layer
 - Management API requests are served under `/admin/api/v1/*`
+- Provider display configs (operator-set logos / display names for inference providers) live under `/admin/api/v1/provider-display-configs`, with `GET .../{provider_key}/icon` serving as a same-origin proxy for operator-set icon URLs so the dashboard can keep a tight `img-src` CSP regardless of which CDN an admin pastes
 


### PR DESCRIPTION
## Summary

The legacy dashboard at `app.doubleword.ai` was still passing operator-set icon URLs straight into `<img src>`, so even after 8.54.0 shipped the icon-proxy endpoint, the browser was fetching provider logos direct from external CDNs (npmmirror, wikipedia, simpleicons, …). The new SPA already fixed this in [app-doubleword-private#71](https://github.com/doublewordai/app-doubleword-private/pull/71) — this patches the legacy surface to match.

## Changes

- **New `providerIconUrl(providerKey, iconValue)`** helper next to the `ProviderDisplayConfig` type. Mirrors the SPA helper with one deliberate difference: registry-key strings (`anthropic`, `openai`, `snowflake`, …) and root-relative paths (`/endpoints/anthropic.svg`) pass through unchanged so `CatalogIcon`'s built-in `ICON_REGISTRY` can resolve them client-side from bundled assets. Only `https://…` values get rewritten to `/admin/api/v1/provider-display-configs/{key}/icon`.
- **4 call sites updated** in the model catalog:
  - `ModelCatalog.getProviderData` — primary provider chip per row
  - Two `deployment_providers` chip mappings — the extra "where it's hosted" icons (desktop + mobile)
  - `MobileModelsView` swimlane title — falls back to the registry-key string when no icon is set, so the local registry resolver still kicks in

## Why now

Even after [internal#510](https://github.com/doublewordai/internal/pull/510) cuts `app.doubleword.ai` over to the new SPA, the legacy dashboard will still serve `console.doubleword.ai` — so this gap closes for that surface too rather than waiting for a separate fix later.

## Test plan

- [x] `pnpm vitest run` — 572/572 pass (6 new unit tests for `providerIconUrl` covering: https → proxy URL, URL-encoded key, root-relative passthrough, registry-key passthrough, null/whitespace fallbacks, trim).
- [x] `pnpm eslint .` clean.
- [x] `pnpm tsc -b tsconfig.app.json --noEmit` clean.
- [ ] Manual check after deploy: model catalog renders all provider icons and Network panel shows requests going to `/admin/api/v1/provider-display-configs/<key>/icon` (same-origin) rather than external CDNs.