### PR TITLE
perf(sync): raise onwards fallback resync default 10s->5min

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -395,6 +395,11 @@ background_services:
   # Disabling this will prevent the AI proxy from receiving config updates
   onwards_sync:
     enabled: true # Default: true (recommended)
+    # Periodic full-resync safety net (milliseconds). LISTEN/NOTIFY propagates real config
+    # changes in real time; this fallback only guards against dropped notifications. Each tick
+    # triggers a full routing-table reload (heavy DB egress), so keep it in minutes, not seconds.
+    # Default: 300000 (5 min). Set to 0 to disable (not recommended).
+    fallback_interval_milliseconds: 300000
 
   # Probe scheduler - periodically checks inference endpoint health
   # When leader_election is enabled, only runs on the elected leader

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1609,10 +1609,15 @@ impl Default for PoolMetricsSamplerConfig {
 pub struct OnwardsSyncConfig {
     /// Enable onwards config sync service (default: true)
     pub enabled: bool,
-    /// Fallback sync interval in milliseconds (default: 10000ms = 10 seconds)
+    /// Fallback sync interval in milliseconds (default: 300000ms = 5 minutes)
     ///
     /// Even when LISTEN/NOTIFY is working, this provides periodic full syncs to guarantee
     /// eventual consistency. Prevents issues from dropped notifications or connection problems.
+    ///
+    /// Each fallback tick triggers a FULL routing-table reload (all models, endpoints,
+    /// secrets, and authorized keys), which is expensive in DB egress. Because LISTEN/NOTIFY
+    /// already propagates real changes in real time, this only needs to be frequent enough to
+    /// recover from a *missed* notification — minutes, not seconds.
     ///
     /// Set to `0` to disable periodic fallback syncs entirely. Disabling the fallback interval
     /// removes protection against missed notifications and is generally not recommended
@@ -1624,7 +1629,7 @@ impl Default for OnwardsSyncConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            fallback_interval_milliseconds: 10_000, // 10 seconds
+            fallback_interval_milliseconds: 300_000, // 5 minutes (NOTIFY handles real changes; this is only a missed-notification safety net)
         }
     }
 }


### PR DESCRIPTION
## What
Raise the onwards config-sync **fallback resync interval** default from **10s → 5min** (`OnwardsSyncConfig::fallback_interval_milliseconds`) and document the knob in `config.yaml`.

## Why
The fallback timer triggers a *full* routing-table reload (all models, endpoints, secrets, authorized keys) on every tick, regardless of whether anything changed. Metrics (`dwctl_cache_sync_total{source="fallback"}`) show the fallback timer is the largest single source of onwards sync reloads, and each reload is a sizable read over the database's network egress.

LISTEN/NOTIFY already propagates real config changes in real time, so the fallback only needs to catch *missed* notifications — minutes, not seconds.

## Risk
Low. Worst case: a silently-dropped NOTIFY now self-heals in ≤5 min (was ≤10 s). The listener still performs a full reload on (re)connect, so connection drops are covered immediately. The interval remains env-overridable (`DWCTL_BACKGROUND_SERVICES__ONWARDS_SYNC__FALLBACK_INTERVAL_MILLISECONDS`).

## Verification
- `cargo clippy` clean.
- After deploy: `sum by (source)(rate(dwctl_cache_sync_total{source="fallback"}[15m]))` drops substantially.
