### PR TITLE
perf(sync): stop api_keys no-op upserts from triggering onwards reloads

### DIFF
--- a/dwctl/migrations/101_scope_api_keys_notify.sql
+++ b/dwctl/migrations/101_scope_api_keys_notify.sql
@@ -1,0 +1,72 @@
+-- Scope the api_keys config-change NOTIFY so it fires at most once per statement,
+-- and only when something the onwards cache actually consumes has changed.
+--
+-- db/handlers/api_keys.rs::get_or_create_hidden_key runs
+--     INSERT INTO api_keys (...) ON CONFLICT (...) DO NOTHING
+-- very frequently; on the common "key already exists" path it writes zero rows,
+-- yet the original FOR EACH STATEMENT trigger fired an AFTER INSERT notification
+-- on every call (statement-level triggers fire even when no rows change). Each
+-- notification drives a full routing-table reload in onwards, so these no-op
+-- upserts were a dominant source of redundant config reloads (and DB egress).
+--
+-- Fix: statement-level triggers with transition tables, notifying only when:
+--   * INSERT -- at least one row was actually inserted (a DO NOTHING no-op leaves
+--              the NEW transition table empty -> no notify),
+--   * DELETE -- at least one row was deleted,
+--   * UPDATE -- at least one row changed a column onwards consumes.
+-- A statement-level trigger fires once per statement, so this also avoids the
+-- per-row notification storm a FOR EACH ROW trigger would cause on bulk
+-- operations (e.g. soft_delete_member_org_keys updates all of a user's keys).
+
+DROP TRIGGER IF EXISTS api_keys_notify ON api_keys;
+
+CREATE OR REPLACE FUNCTION notify_api_keys_config_change() RETURNS trigger AS $$
+DECLARE
+    relevant_change boolean := false;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        relevant_change := EXISTS (SELECT 1 FROM new_rows);
+    ELSIF TG_OP = 'DELETE' THEN
+        relevant_change := EXISTS (SELECT 1 FROM old_rows);
+    ELSIF TG_OP = 'UPDATE' THEN
+        -- Only columns the sync query reads matter; metadata-only updates
+        -- (name, description, last_used) must not reload the cache. Joined on the
+        -- immutable primary key.
+        relevant_change := EXISTS (
+            SELECT 1
+            FROM new_rows n
+            JOIN old_rows o ON o.id = n.id
+            WHERE o.secret              IS DISTINCT FROM n.secret
+               OR o.purpose             IS DISTINCT FROM n.purpose
+               OR o.user_id             IS DISTINCT FROM n.user_id
+               OR o.requests_per_second IS DISTINCT FROM n.requests_per_second
+               OR o.burst_size          IS DISTINCT FROM n.burst_size
+               OR o.is_deleted          IS DISTINCT FROM n.is_deleted
+               OR o.hidden              IS DISTINCT FROM n.hidden
+        );
+    END IF;
+
+    IF relevant_change THEN
+        -- Match notify_config_change()'s payload format (migration 049) so the
+        -- cache-sync lag metric keeps attributing reloads to the api_keys table.
+        PERFORM pg_notify('auth_config_changed',
+            'api_keys:' || (extract(epoch FROM clock_timestamp()) * 1000000)::bigint::text);
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER api_keys_notify_insert
+    AFTER INSERT ON api_keys
+    REFERENCING NEW TABLE AS new_rows
+    FOR EACH STATEMENT EXECUTE FUNCTION notify_api_keys_config_change();
+
+CREATE TRIGGER api_keys_notify_delete
+    AFTER DELETE ON api_keys
+    REFERENCING OLD TABLE AS old_rows
+    FOR EACH STATEMENT EXECUTE FUNCTION notify_api_keys_config_change();
+
+CREATE TRIGGER api_keys_notify_update
+    AFTER UPDATE ON api_keys
+    REFERENCING OLD TABLE AS old_rows NEW TABLE AS new_rows
+    FOR EACH STATEMENT EXECUTE FUNCTION notify_api_keys_config_change();

--- a/dwctl/src/sync/onwards_config/tests.rs
+++ b/dwctl/src/sync/onwards_config/tests.rs
@@ -668,6 +668,100 @@ async fn test_onwards_config_reloads_on_tariff_change(pool: sqlx::PgPool) {
     );
 }
 
+/// Regression test for the api_keys NOTIFY storm.
+///
+/// `get_or_create_hidden_key` runs `INSERT ... ON CONFLICT DO NOTHING` ~15k+
+/// times/day. On the common "key already exists" path it changes nothing, so it
+/// must NOT trigger a full onwards config reload. The statement-level NOTIFY
+/// triggers use transition tables and notify only when rows were actually
+/// inserted/deleted or an auth-relevant column changed, so a no-op upsert
+/// (empty NEW transition table) stays silent.
+///
+/// Covers: no-op upsert (silent), real insert (notify), metadata-only update
+/// (silent), auth-relevant update (notify).
+#[sqlx::test]
+async fn test_api_keys_noop_upsert_does_not_trigger_notify(pool: sqlx::PgPool) {
+    use sqlx::postgres::PgListener;
+
+    use crate::Role;
+    use crate::db::handlers::api_keys::ApiKeys;
+    use crate::db::models::api_keys::ApiKeyPurpose;
+
+    let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
+
+    let mut listener = PgListener::connect_with(&pool).await.unwrap();
+    listener.listen("auth_config_changed").await.unwrap();
+
+    // First call actually inserts the hidden key -> must notify.
+    let key_id = {
+        let mut tx = pool.begin().await.unwrap();
+        let mut repo = ApiKeys::new(&mut tx);
+        let (_secret, id) = repo
+            .get_or_create_hidden_key_with_id(user.id, ApiKeyPurpose::Realtime, user.id)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+        id
+    };
+    let first = timeout(Duration::from_secs(2), listener.recv())
+        .await
+        .expect("first get_or_create_hidden_key (real insert) should notify")
+        .expect("failed to receive notification");
+    assert!(
+        first.payload().contains("api_keys"),
+        "insert notification should reference api_keys, got: {}",
+        first.payload()
+    );
+
+    // Drain anything still pending from the first insert. Loop only while an actual
+    // notification is received -- `.is_ok()` would also be true for Ok(None) (no
+    // notification / closed connection) and could spin.
+    while let Ok(Ok(Some(_))) = timeout(Duration::from_millis(50), listener.try_recv()).await {}
+
+    // Second call hits ON CONFLICT DO NOTHING (0 rows written) -> must NOT notify.
+    {
+        let mut tx = pool.begin().await.unwrap();
+        let mut repo = ApiKeys::new(&mut tx);
+        repo.get_or_create_hidden_key(user.id, ApiKeyPurpose::Realtime, user.id)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+    }
+    match timeout(Duration::from_millis(750), listener.recv()).await {
+        Err(_) => {} // timed out waiting for a notification -> correct: no-op did not notify
+        Ok(Ok(n)) => panic!("no-op upsert must NOT trigger a config-change notification, got: {}", n.payload()),
+        Ok(Err(e)) => panic!("listener error: {e}"),
+    }
+
+    // Metadata-only UPDATE (name) is not consumed by onwards -> must NOT notify.
+    sqlx::query("UPDATE api_keys SET name = 'renamed' WHERE id = $1")
+        .bind(key_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    match timeout(Duration::from_millis(500), listener.recv()).await {
+        Err(_) => {} // correct: metadata-only update did not notify
+        Ok(Ok(n)) => panic!("metadata-only update must NOT notify, got: {}", n.payload()),
+        Ok(Err(e)) => panic!("listener error: {e}"),
+    }
+
+    // Auth-relevant UPDATE (requests_per_second) -> must notify.
+    sqlx::query("UPDATE api_keys SET requests_per_second = 5 WHERE id = $1")
+        .bind(key_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let updated = timeout(Duration::from_secs(2), listener.recv())
+        .await
+        .expect("auth-relevant update should notify")
+        .expect("failed to receive notification");
+    assert!(
+        updated.payload().contains("api_keys"),
+        "update notification should reference api_keys, got: {}",
+        updated.payload()
+    );
+}
+
 /// Test that batch API keys get automatic access to composite escalation targets
 #[sqlx::test]
 async fn test_batch_api_key_access_to_composite_escalation_target(pool: sqlx::PgPool) {


### PR DESCRIPTION
## What
Migration `101` rescopes the `api_keys` config-change NOTIFY trigger to statement-level triggers with transition tables — firing once per statement, and only when an onwards-relevant change actually occurs.

## Why
`get_or_create_hidden_key` (`dwctl/src/db/handlers/api_keys.rs`) runs `INSERT ... ON CONFLICT DO NOTHING` very frequently. On the common "key already exists" path it writes **zero rows** — but a `FOR EACH STATEMENT` AFTER INSERT trigger fires regardless of rows affected, so every call emitted a config-change NOTIFY.

Metrics (`dwctl_cache_sync_lag_seconds_count{table="api_keys"}`) showed `api_keys` was the dominant source of LISTEN/NOTIFY-driven onwards reloads and a top contributor to DB egress. The code even documents the intent (the `DO NOTHING` was chosen specifically "to avoid firing the api_keys_notify trigger"), but a statement-level INSERT trigger defeats it.

## Fix
- **Statement-level triggers with transition tables** (`NEW TABLE`/`OLD TABLE`): one NOTIFY per statement, only when the transition table is non-empty (insert/delete) or an auth-relevant column actually changed (update, joined on the immutable `id` PK).
- Suppresses the no-op `ON CONFLICT DO NOTHING` path **and** fires once for bulk ops like `soft_delete_member_org_keys` instead of once per row.
- Auth-relevant columns: `secret, purpose, user_id, requests_per_second, burst_size, is_deleted, hidden`; metadata-only updates (`name`, `description`, `last_used`) no longer reload the cache.

## Verification
Regression test (`test_api_keys_noop_upsert_does_not_trigger_notify`) covering no-op upsert (silent), real insert (notify), metadata-only update (silent), and auth-relevant update (notify).
