### PR TITLE
fix(deps): override brace-expansion to ^5.0.6 (CVE-2026-45149)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -104,7 +104,8 @@
       "rollup": "npm:@rollup/wasm-node",
       "lodash": "^4.18.0",
       "mdast-util-to-hast": "^13.2.1",
-      "minimatch@<3.1.3": "^3.1.3"
+      "minimatch@<3.1.3": "^3.1.3",
+      "brace-expansion@>=5.0.0 <5.0.6": "^5.0.6"
     },
     "onlyBuiltDependencies": [
       "esbuild",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   lodash: ^4.18.0
   mdast-util-to-hast: ^13.2.1
   minimatch@<3.1.3: ^3.1.3
+  brace-expansion@>=5.0.0 <5.0.6: ^5.0.6
 
 importers:
 
@@ -1794,8 +1795,8 @@ packages:
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -5346,7 +5347,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6741,7 +6742,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:


### PR DESCRIPTION
## Summary
Closes the only remaining Oneleet finding from the latest dependency scan that wasn't already remediated by prior PRs (#1114, #1116). Adds a pnpm override to bump `brace-expansion` from `5.0.5` → `5.0.6` (transitive via `minimatch@10.2.5`).

## Finding remediated by this PR
| CVE | Package | Was | Now |
|---|---|---|---|
| **CVE-2026-45149** | `brace-expansion` (large numeric range defeats `max` DoS protection) | 5.0.5 | 5.0.6 |

## Findings from the same scan already remediated (no action needed here)
| CVE / GHSA | Package | Notes |
|---|---|---|
| CVE-2026-26996, CVE-2026-27903, CVE-2026-27904 | `minimatch` ReDoS | Already at 3.1.5 (via existing override) and 10.2.5 (via #1114) |
| CVE-2026-33671, CVE-2026-33672 | `picomatch` ReDoS + method injection | Already at 4.0.4 (via #1114) |
| CVE-2025-64756 | `glob` CLI shell injection | `glob` package no longer in the lockfile (vitest 4.1 bump in #1114) |
| CVE-2026-33750 | `brace-expansion` zero-step hang | 1.1.13 and 5.0.5 both at/above the patched versions for their lines |
| GHSA-q2qq-hmj6-3wpp | `hickory-proto` O(n²) name compression | Already at 0.26.1 (via #1116) |
| GHSA-rhfx-m35p-ff5j | `lru` IterMut Stacked Borrows | Already at 0.16.4 (via #1116) |

## Test plan
- [x] `pnpm install` succeeds, lockfile resolves with `brace-expansion: 5.0.6`
- [x] `pnpm build` clean
- [x] `pnpm test --run` — 572/572 passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)