### PR TITLE
fix(openapi): use Doubleword-served models in API doc examples

### DIFF
--- a/dwctl/src/openapi/ai.rs
+++ b/dwctl/src/openapi/ai.rs
@@ -121,7 +121,7 @@ fn list_models() {}
     summary = "Retrieve model",
     description = "Retrieves information about a specific model.",
     params(
-        ("model" = String, Path, description = "The model ID (e.g., `gpt-4`, `text-embedding-ada-002`)")
+        ("model" = String, Path, description = "The model ID (e.g., `deepseek-ai/DeepSeek-V4-Pro`, `Qwen/Qwen3-Embedding-8B`)")
     ),
     responses(
         (status = 200, description = "Model details including ID, owner, and creation timestamp.", body = extra_types::ModelObject),

--- a/dwctl/src/openapi/extra_types.rs
+++ b/dwctl/src/openapi/extra_types.rs
@@ -308,12 +308,12 @@ pub struct Usage {
 /// Request body for embeddings.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[schema(example = json!({
-    "model": "Qwen/Qwen3-30B-A3B-FP8",
+    "model": "Qwen/Qwen3-Embedding-8B",
     "input": "What is a doubleword?"
 }))]
 pub struct EmbeddingRequest {
     /// ID of the model to use.
-    #[schema(example = "Qwen/Qwen3-30B-A3B-FP8")]
+    #[schema(example = "Qwen/Qwen3-Embedding-8B")]
     pub model: String,
 
     /// Input text to embed. Can be a string or array of strings.
@@ -353,7 +353,7 @@ pub enum EmbeddingInput {
         "index": 0,
         "embedding": [0.0023, -0.0134, 0.0256]
     }],
-    "model": "Qwen/Qwen3-30B-A3B-FP8",
+    "model": "Qwen/Qwen3-Embedding-8B",
     "usage": {
         "prompt_tokens": 6,
         "total_tokens": 6
@@ -368,7 +368,7 @@ pub struct EmbeddingResponse {
     pub data: Vec<EmbeddingData>,
 
     /// The model used for generating embeddings.
-    #[schema(example = "Qwen/Qwen3-30B-A3B-FP8")]
+    #[schema(example = "Qwen/Qwen3-Embedding-8B")]
     pub model: String,
 
     /// Usage statistics for the request.
@@ -552,14 +552,14 @@ pub struct ResponseItem {
 /// Request body for creating a response.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[schema(example = json!({
-    "model": "gpt-4o",
+    "model": "deepseek-ai/DeepSeek-V4-Pro",
     "input": "What is a doubleword?",
     "temperature": 0.7,
     "max_output_tokens": 256
 }))]
 pub struct ResponseRequest {
     /// ID of the model to use.
-    #[schema(example = "gpt-4o")]
+    #[schema(example = "deepseek-ai/DeepSeek-V4-Pro")]
     pub model: String,
 
     /// The input to generate a response for. Can be a string or array of messages.
@@ -673,7 +673,7 @@ pub struct ResponseRequest {
     "object": "response",
     "created_at": 1703187200,
     "completed_at": 1703187205,
-    "model": "gpt-4o",
+    "model": "deepseek-ai/DeepSeek-V4-Pro",
     "status": "completed",
     "output": [{
         "type": "message",
@@ -706,7 +706,7 @@ pub struct ResponseObject {
     pub completed_at: i64,
 
     /// The model used for generating the response.
-    #[schema(example = "gpt-4o")]
+    #[schema(example = "deepseek-ai/DeepSeek-V4-Pro")]
     pub model: String,
 
     /// The status of the response. Can be "completed", "incomplete", "cancelled", or "failed".


### PR DESCRIPTION
## What

Updates the model names used in the OpenAPI / utoipa **example values** so the rendered API docs reference models we actually serve instead of OpenAI's:

- **Responses API** (`ResponseRequest` / `ResponseObject` examples): `gpt-4o` → `deepseek-ai/DeepSeek-V4-Pro`
- **Embeddings API** (`EmbeddingRequest` / `EmbeddingResponse` examples): `Qwen/Qwen3-30B-A3B-FP8` → `Qwen/Qwen3-Embedding-8B`
- **Retrieve model** endpoint param description: `gpt-4`, `text-embedding-ada-002` → `deepseek-ai/DeepSeek-V4-Pro`, `Qwen/Qwen3-Embedding-8B`

## Why

Our API documentation should showcase the models we serve, not OpenAI model names. As a bonus, the embeddings endpoint examples were previously showing `Qwen/Qwen3-30B-A3B-FP8` — a chat model — as the embedding model; they now use a real embedding model (`Qwen/Qwen3-Embedding-8B`).

## Scope / reviewer notes

- **Documentation-only.** Every change is a `#[schema(example = ...)]` value or a `#[utoipa::path(...)]` param description. No runtime behavior changes, no schema/field changes.
- **Intentionally left unchanged:** chat-completion, model-listing, and batch/files cost examples still use `Qwen/Qwen3-30B-A3B-FP8` (a valid chat model, not an embedding reference). Test fixtures / sample data that reference `text-embedding-*` model names were left alone — they're test code, not docs (and `strict_mode.rs` ties the model name to onwards test setup).
- The only OpenAPI test (`test_openapi_specs_serialize`) just asserts the spec serializes and contains `"openapi"`; it does not assert on example values, so it's unaffected. `cargo fmt --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)