### PR TITLE
fix(tests): poll instead of fixed-delay in batch perms e2e test

### DIFF
--- a/tests/perms/files-and-batches.hurl
+++ b/tests/perms/files-and-batches.hurl
@@ -1154,12 +1154,16 @@ jsonpath "$.input_file_id" == "{{user1_revoke_test_file_id}}"
 jsonpath "$.status" == "validating"
 
 # -----------------------------------------------------------------------------
-# Retrieve batch to get output and error file IDs (wait for processing to complete)
+# Retrieve batch to get output and error file IDs.
+# Poll until the batch reaches a terminal status instead of relying on a fixed
+# delay - batch processing time varies under CI load, so a one-shot check after
+# a fixed delay is flaky. retry re-issues the request until the assert passes.
 # -----------------------------------------------------------------------------
 
 GET http://localhost:3001/ai/v1/batches/{{user1_revoke_test_batch_id}}
 [Options]
-delay: 10000
+retry: 30
+retry-interval: 1000
 [Cookies]
 dwctl_session: {{user_jwt}}
 HTTP 200
@@ -1171,10 +1175,15 @@ user1_revoke_test_error_file_id: jsonpath "$.error_file_id"
 user1_revoke_test_batch_status: jsonpath "$.status"
 
 # -----------------------------------------------------------------------------
-# Debug: Check batch details
+# Check batch request counts. Poll until the counts settle (both requests
+# accounted for) rather than asserting once, since the count fields may lag
+# slightly behind the terminal status transition under load.
 # -----------------------------------------------------------------------------
 
 GET http://localhost:3001/ai/v1/batches/{{user1_revoke_test_batch_id}}
+[Options]
+retry: 30
+retry-interval: 1000
 [Cookies]
 dwctl_session: {{user_jwt}}
 HTTP 200
@@ -1186,9 +1195,15 @@ jsonpath "$.request_counts.failed" exists
 # -----------------------------------------------------------------------------
 # User1 CAN read the output file content
 # Should contain successful response for gpt-4-mock request (line 1 of mixed.jsonl)
+# Poll until the output file is populated - the file row exists from batch
+# creation, but its content is written asynchronously as requests complete, so
+# a one-shot read can race ahead of the worker and see an empty body.
 # -----------------------------------------------------------------------------
 
 GET http://localhost:3001/ai/v1/files/{{user1_revoke_test_output_file_id}}/content
+[Options]
+retry: 30
+retry-interval: 1000
 [Cookies]
 dwctl_session: {{user_jwt}}
 HTTP 200
@@ -1199,9 +1214,15 @@ body contains "gpt-4-mock"
 # -----------------------------------------------------------------------------
 # User1 CAN read the error file content
 # Should contain "Unauthorized" error for mock-gpt-markdown request (line 2 of mixed.jsonl)
+# Poll until the error file is populated - like the output file, its content is
+# written asynchronously as the failing request is processed, so a one-shot read
+# can race ahead of the worker and see an empty body.
 # -----------------------------------------------------------------------------
 
 GET http://localhost:3001/ai/v1/files/{{user1_revoke_test_error_file_id}}/content
+[Options]
+retry: 30
+retry-interval: 1000
 [Cookies]
 dwctl_session: {{user_jwt}}
 HTTP 200


### PR DESCRIPTION
## Problem

The `e2e-test-docker` job (`tests/perms/files-and-batches.hurl`) is intermittently flaky and fails CI across branches (and `main` isn't consistently green). The failures cluster on the model-access-revocation flow's batch post-processing, e.g.:

- `jsonpath "$.status" matches "^(completed|failed|cancelled)$"` — batch not terminal in time
- `body contains "req-2"` / `body matches "403"` — batch error file body still empty
- `body contains "req-1"` / `body contains "gpt-4-mock"` — batch output file body still empty

**Root cause:** those requests used a fixed `[Options] delay: 10000` followed by a *single* assertion (no retry). When async batch processing exceeds ~10s under CI load, the one-shot assertion fails. Different assertions fail on different runs — classic timing flakiness, not a logic bug.

## Fix

Replace the fixed-delay/one-shot pattern with Hurl's retry mechanism on the four async-completion-dependent requests in the revocation test:

```
[Options]
retry: 30
retry-interval: 1000
```

Each request now polls until its own condition is satisfied — the batch reaches a terminal status, the request counts settle, and the output/error file bodies are populated — before asserting, instead of relying on a one-shot fixed delay.

This mirrors the `retry: 10` / `retry-interval: 500` poll already used for the `in_progress` transition earlier in the same file, gives 30s of headroom vs. the old fixed 10s, and returns as soon as the condition is met (so the happy path is typically *faster*, not slower). Genuine failures still surface — a retry that never sees the expected content exhausts and fails.

Scope check: the remaining `delay: 3s` (a `DELETE` that asserts only `HTTP 204`) and the synchronous `validating` / `cancelling|cancelled` assertions are deterministic and were intentionally left unchanged. The earlier `in_progress` poll already retries.

## Verification

- The modified `.hurl` file parses cleanly under the CI-pinned Hurl 7.1.0 (no Rust/TS changed, so the Rust/TS lints and tests are not applicable).
- **The full docker e2e stack could not be run in this remote environment**: its network policy permits container-registry *APIs* but blocks the blob *CDN* hosts (`production.cloudfront.docker.com`, `pkg-containers.githubusercontent.com` → `403`), so neither the base images nor the prebuilt `control-layer` image can be pulled/built locally. The real confirmation is the `e2e-test-docker` CI job — ideally re-run a few times to confirm stability.


---
_Generated by [Claude Code](https://claude.ai/code/session_0147GePczzh1fxGcUohTrdp2)_