### PR TITLE
feat: standardise error logs into having metric emissions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,13 @@ prevent name clashes.
 - Database errors wrap `DbError` which auto-converts to appropriate HTTP status codes
 - Provide descriptive error messages focused on what went wrong, not implementation details
 
+**Background Error Logging:**
+
+- For failures off the request path (background tasks, pollers, daemon loops, sync jobs), use the `background_error!` macro instead of a bare `tracing::error!`/`warn!`. It emits the log and the `dwctl_background_errors_total` metric together, so the failure shows up on dashboards and alerts instead of being invisible.
+- Example: `crate::background_error!(component::WEBHOOK_DISPATCH, "delivery_create", Critical, error = %e, "Failed to create webhook delivery");`
+- Severity tiers: `Critical` (logs at error, pages), `Error` (logs at error, no page), `Warning` (logs at warn, no page). `component` and `reason` must be `&'static str` literals.
+- Foreground handlers that already return a 5xx do NOT need this - those are counted by `dwctl_http_requests_total{status}`.
+
 **API Handlers:**
 
 - Add `#[tracing::instrument(skip_all)]` to all handler functions for observability

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,9 +2333,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "17.2.0"
+version = "17.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de8e9c67793c484c98a22803ab5bb316428858d9cb76fe02861badf7e97899c0"
+checksum = "a2d7c6a4f2c18f63135407350c4800930d750952266a735e6598b53436707d4e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "17.2.0" }
+fusillade = { version = "17.3.0" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -4,6 +4,7 @@
 //!
 //! Repository methods are delegated to the fusillade/ crate.
 
+use crate::metrics::errors::component::BATCH_POPULATE;
 use sqlx_pool_router::PoolProvider;
 
 use crate::AppState;
@@ -65,14 +66,16 @@ pub async fn build_create_batch_job<P: sqlx_pool_router::PoolProvider + Clone + 
                 .populate_batch(batch_id, fusillade::FileId(input.file_id))
                 .await
             {
-                tracing::error!(
-                    batch_id = %input.batch_id,
-                    error = %e,
-                    "Failed to populate batch"
-                );
-
                 return match &e {
                     fusillade::FusilladeError::ValidationError(_) => {
+                        // Terminal populate failure (no-templates / file-deleted). Should be
+                        // impossible to reach - a validation gap - so it pages.
+                        crate::background_error!(
+                            BATCH_POPULATE, "populate_failed", Critical,
+                            batch_id = %input.batch_id,
+                            error = %e,
+                            "Failed to populate batch"
+                        );
                         if let Err(mark_err) = cx.state.request_manager.mark_batch_failed(batch_id, &e.to_string()).await {
                             tracing::error!(
                                 batch_id = %input.batch_id,
@@ -84,7 +87,16 @@ pub async fn build_create_batch_job<P: sqlx_pool_router::PoolProvider + Clone + 
                             Err(TaskError::Fatal(e.to_string()))
                         }
                     }
-                    _ => Err(TaskError::Retryable(e.to_string())),
+                    _ => {
+                        // Transient DB/other error - the job retries; not a per-event page.
+                        crate::background_error!(
+                            BATCH_POPULATE, "db_error", Error,
+                            batch_id = %input.batch_id,
+                            error = %e,
+                            "Failed to populate batch, will retry"
+                        );
+                        Err(TaskError::Retryable(e.to_string()))
+                    }
                 };
             }
 
@@ -1654,8 +1666,13 @@ pub async fn list_batches<P: PoolProvider>(
             completion_windows,
         })
         .await
-        .map_err(|e| Error::Internal {
-            operation: format!("list batches: {}", e),
+        .map_err(|e| match &e {
+            // Invalid client-supplied filter (e.g. an unsupported ?status= value) is a bad
+            // request, not a server fault - map to 400 so it does not page as a 5xx.
+            fusillade::FusilladeError::ValidationError(msg) => Error::BadRequest { message: msg.clone() },
+            _ => Error::Internal {
+                operation: format!("list batches: {}", e),
+            },
         })?;
 
     // Check if there are more results

--- a/dwctl/src/api/handlers/inference_endpoints.rs
+++ b/dwctl/src/api/handlers/inference_endpoints.rs
@@ -199,16 +199,22 @@ pub async fn update_inference_endpoint<P: PoolProvider>(
                 );
             }
             Err(sync_error) => {
-                tracing::error!("Failed to update aliases for endpoint {}: {}", endpoint.id, sync_error);
-                // Convert SyncError to our Error type
+                // Log per type: an alias conflict is an expected client 409 (warn); a genuine
+                // sync failure is a server 500 (error). Don't blanket error-log the 409.
                 let converted_error = match sync_error {
-                    crate::sync::endpoint_sync::SyncError::AliasConflicts { conflicts } => Error::Conflict {
-                        message: "Alias conflicts detected during endpoint update".to_string(),
-                        conflicts: Some(conflicts),
-                    },
-                    crate::sync::endpoint_sync::SyncError::Other(_) => Error::Internal {
-                        operation: "update endpoint aliases".to_string(),
-                    },
+                    crate::sync::endpoint_sync::SyncError::AliasConflicts { conflicts } => {
+                        tracing::warn!(endpoint_id = %endpoint.id, ?conflicts, "Alias conflicts during endpoint update");
+                        Error::Conflict {
+                            message: "Alias conflicts detected during endpoint update".to_string(),
+                            conflicts: Some(conflicts),
+                        }
+                    }
+                    crate::sync::endpoint_sync::SyncError::Other(e) => {
+                        tracing::error!(endpoint_id = %endpoint.id, error = %e, "Failed to update aliases for endpoint");
+                        Error::Internal {
+                            operation: "update endpoint aliases".to_string(),
+                        }
+                    }
                 };
                 tx.rollback().await.map_err(|e| Error::Database(e.into()))?;
                 return Err(converted_error);
@@ -411,16 +417,18 @@ pub async fn create_inference_endpoint<P: PoolProvider>(
                 tracing::debug!("Sync succeeded: {:?}", result);
             }
             Err(sync_error) => {
-                tracing::error!("Sync failed with error: {:?}", sync_error);
+                // Log per type: an alias conflict is an expected client 409 (warn); a genuine
+                // sync failure is a server 500 (error). Don't blanket error-log the 409.
                 match sync_error {
                     crate::sync::endpoint_sync::SyncError::AliasConflicts { conflicts } => {
+                        tracing::warn!(endpoint_id = %endpoint.id, ?conflicts, "Alias conflicts during endpoint creation");
                         return Err(crate::errors::Error::Conflict {
                             message: "Alias conflicts detected during endpoint creation".to_string(),
                             conflicts: Some(conflicts),
                         });
                     }
                     crate::sync::endpoint_sync::SyncError::Other(e) => {
-                        tracing::error!("Other sync error: {:#}", e);
+                        tracing::error!(endpoint_id = %endpoint.id, error = %e, "Failed to sync endpoint models during creation");
                         return Err(crate::errors::Error::Internal {
                             operation: "sync endpoint models during creation".to_string(),
                         });

--- a/dwctl/src/api/handlers/payments.rs
+++ b/dwctl/src/api/handlers/payments.rs
@@ -79,6 +79,7 @@ use crate::{
     api::models::users::CurrentUser,
     auth::permissions,
     db::{handlers::repository::Repository, handlers::users::Users, models::users::UserUpdateDBRequest},
+    metrics::errors::component::PAYMENTS,
     payment_providers,
 };
 
@@ -301,7 +302,8 @@ pub async fn process_payment<P: PoolProvider>(
                 let detail = format!("{e:?}");
                 let status = StatusCode::from(e);
                 if status.is_server_error() {
-                    tracing::error!(error = %detail, %status, "Failed to process payment session");
+                    crate::background_error!(PAYMENTS, "process_failed", Error,
+                        error = %detail, %status, "Failed to process payment session");
                 } else {
                     tracing::warn!(error = %detail, %status, "Payment session rejected");
                 }

--- a/dwctl/src/api/handlers/payments.rs
+++ b/dwctl/src/api/handlers/payments.rs
@@ -296,9 +296,17 @@ pub async fn process_payment<P: PoolProvider>(
                 .into_response())
             }
             _ => {
-                tracing::error!("Failed to process payment session: {:?}", e);
+                // Map the provider error to its real status. InvalidData / NoCustomerId are
+                // client 400s; hardcoding 500 here pages on a client's bad/expired session id.
+                let detail = format!("{e:?}");
+                let status = StatusCode::from(e);
+                if status.is_server_error() {
+                    tracing::error!(error = %detail, %status, "Failed to process payment session");
+                } else {
+                    tracing::warn!(error = %detail, %status, "Payment session rejected");
+                }
                 Ok((
-                    StatusCode::INTERNAL_SERVER_ERROR,
+                    status,
                     Json(json!({
                         "message": "Unable to process payment. Please contact support."
                     })),

--- a/dwctl/src/config_watcher.rs
+++ b/dwctl/src/config_watcher.rs
@@ -1,10 +1,11 @@
+use crate::metrics::errors::component::CONFIG_WATCHER;
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, anyhow};
 use notify::{Config as NotifyConfig, Event, RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::info;
 
 use crate::{Config, SharedConfig};
 
@@ -88,7 +89,7 @@ fn initialize_watcher(config_path: PathBuf) -> anyhow::Result<WatcherState> {
             }
             Ok(_) => {}
             Err(error) => {
-                error!(path = %callback_config_path.display(), error = %error, "Config watch error");
+                crate::background_error!(CONFIG_WATCHER, "watch_error", Error, path = %callback_config_path.display(), error = %error, "Config watch error");
             }
         },
         NotifyConfig::default(),
@@ -111,7 +112,8 @@ pub async fn watch_config_file(config_path: PathBuf, shared_config: SharedConfig
         mut rx,
         _watcher,
     }) = initialize_watcher(config_path.clone()).map(Some).unwrap_or_else(|error| {
-        warn!(
+        crate::background_error!(
+            CONFIG_WATCHER, "setup_failed", Critical,
             path = %config_path.display(),
             error = %error,
             "Config watcher setup failed; live config reload disabled"
@@ -148,10 +150,10 @@ pub async fn watch_config_file(config_path: PathBuf, shared_config: SharedConfig
                         info!(path = %config_path.display(), "Reloaded config from disk");
                     }
                     Ok(Err(error)) => {
-                        warn!(path = %config_path.display(), error = %error, "Config reload failed; continuing with previous config");
+                        crate::background_error!(CONFIG_WATCHER, "reload_invalid", Warning, path = %config_path.display(), error = %error, "Config reload failed; continuing with previous config");
                     }
                     Err(error) => {
-                        error!(path = %config_path.display(), error = %error, "Config reload task failed");
+                        crate::background_error!(CONFIG_WATCHER, "reload_join", Error, path = %config_path.display(), error = %error, "Config reload task failed");
                     }
                 }
             }

--- a/dwctl/src/db/handlers/organizations.rs
+++ b/dwctl/src/db/handlers/organizations.rs
@@ -535,7 +535,11 @@ impl<'c> Organizations<'c> {
     }
 
     /// Accept an invite: set status to active, set user_id, clear token
-    #[instrument(skip(self), fields(invite_id = %abbrev_uuid(&invite_id), user_id = %abbrev_uuid(&user_id)), err)]
+    ///
+    /// Errors here are expected client conditions (UniqueViolation means already a member,
+    /// a 409; NotFound means invite not pending, a 404), so log at warn rather than error. A
+    /// genuine server error still pages via the 5xx route metric regardless of this log level.
+    #[instrument(skip(self), fields(invite_id = %abbrev_uuid(&invite_id), user_id = %abbrev_uuid(&user_id)), err(level = "warn"))]
     pub async fn accept_invite(&mut self, invite_id: UserId, user_id: UserId) -> Result<OrganizationMemberDBResponse> {
         let row = sqlx::query_as!(
             MemberRow,

--- a/dwctl/src/leader_election.rs
+++ b/dwctl/src/leader_election.rs
@@ -1,5 +1,6 @@
 //! Leader election using PostgreSQL advisory locks for multi-instance deployments.
 
+use crate::metrics::errors::component::LEADER_ELECTION;
 use crate::config;
 use sqlx::PgPool;
 use std::sync::Arc;
@@ -42,7 +43,7 @@ pub async fn leader_election_task<F1, F2, Fut1, Fut2>(
                 if is_leader.load(Ordering::Relaxed) {
                     is_leader.store(false, Ordering::Relaxed);
                     if let Err(e) = on_lose_leadership(pool.clone(), config.clone()).await {
-                        tracing::error!("Failed to execute on_lose_leadership callback during shutdown: {}", e);
+                        crate::background_error!(LEADER_ELECTION, "lose_callback", Error, "Failed to execute on_lose_leadership callback during shutdown: {}", e);
                     }
                 }
                 break;
@@ -68,7 +69,7 @@ pub async fn leader_election_task<F1, F2, Fut1, Fut2>(
                             leader_conn = Some(conn); // Keep connection alive
 
                             if let Err(e) = on_gain_leadership(pool.clone(), config.clone()).await {
-                                tracing::error!("Failed to execute on_gain_leadership callback: {}", e);
+                                crate::background_error!(LEADER_ELECTION, "gain_callback", Error, "Failed to execute on_gain_leadership callback: {}", e);
                             }
                         }
                         Ok(false) => {
@@ -76,12 +77,12 @@ pub async fn leader_election_task<F1, F2, Fut1, Fut2>(
                             debug!("Following - will retry");
                         }
                         Err(e) => {
-                            tracing::error!("Failed to check leader lock: {}", e);
+                            crate::background_error!(LEADER_ELECTION, "lock_check", Warning, "Failed to check leader lock: {}", e);
                         }
                     }
                 }
                 Err(e) => {
-                    tracing::error!("Failed to acquire connection for leader election: {}", e);
+                    crate::background_error!(LEADER_ELECTION, "db_acquire", Warning, "Failed to acquire connection for leader election: {}", e);
                 }
             }
         } else {
@@ -101,13 +102,13 @@ pub async fn leader_election_task<F1, F2, Fut1, Fut2>(
                         leader_conn = None;
 
                         if let Err(e) = on_lose_leadership(pool.clone(), config.clone()).await {
-                            tracing::error!("Failed to execute on_lose_leadership callback: {}", e);
+                            crate::background_error!(LEADER_ELECTION, "lose_callback", Error, "Failed to execute on_lose_leadership callback: {}", e);
                         }
                     }
                 }
             } else {
                 // We think we're leader but have no connection, this can't happen
-                tracing::error!("Inconsistent state: is_leader=true but no connection");
+                crate::background_error!(LEADER_ELECTION, "invariant_violation", Critical, "Inconsistent state: is_leader=true but no connection");
                 is_leader.store(false, Ordering::Relaxed);
             }
         }

--- a/dwctl/src/leader_election.rs
+++ b/dwctl/src/leader_election.rs
@@ -1,7 +1,7 @@
 //! Leader election using PostgreSQL advisory locks for multi-instance deployments.
 
-use crate::metrics::errors::component::LEADER_ELECTION;
 use crate::config;
+use crate::metrics::errors::component::LEADER_ELECTION;
 use sqlx::PgPool;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -69,7 +69,13 @@ pub async fn leader_election_task<F1, F2, Fut1, Fut2>(
                             leader_conn = Some(conn); // Keep connection alive
 
                             if let Err(e) = on_gain_leadership(pool.clone(), config.clone()).await {
-                                crate::background_error!(LEADER_ELECTION, "gain_callback", Error, "Failed to execute on_gain_leadership callback: {}", e);
+                                crate::background_error!(
+                                    LEADER_ELECTION,
+                                    "gain_callback",
+                                    Error,
+                                    "Failed to execute on_gain_leadership callback: {}",
+                                    e
+                                );
                             }
                         }
                         Ok(false) => {
@@ -82,7 +88,13 @@ pub async fn leader_election_task<F1, F2, Fut1, Fut2>(
                     }
                 }
                 Err(e) => {
-                    crate::background_error!(LEADER_ELECTION, "db_acquire", Warning, "Failed to acquire connection for leader election: {}", e);
+                    crate::background_error!(
+                        LEADER_ELECTION,
+                        "db_acquire",
+                        Warning,
+                        "Failed to acquire connection for leader election: {}",
+                        e
+                    );
                 }
             }
         } else {
@@ -102,13 +114,24 @@ pub async fn leader_election_task<F1, F2, Fut1, Fut2>(
                         leader_conn = None;
 
                         if let Err(e) = on_lose_leadership(pool.clone(), config.clone()).await {
-                            crate::background_error!(LEADER_ELECTION, "lose_callback", Error, "Failed to execute on_lose_leadership callback: {}", e);
+                            crate::background_error!(
+                                LEADER_ELECTION,
+                                "lose_callback",
+                                Error,
+                                "Failed to execute on_lose_leadership callback: {}",
+                                e
+                            );
                         }
                     }
                 }
             } else {
                 // We think we're leader but have no connection, this can't happen
-                crate::background_error!(LEADER_ELECTION, "invariant_violation", Critical, "Inconsistent state: is_leader=true but no connection");
+                crate::background_error!(
+                    LEADER_ELECTION,
+                    "invariant_violation",
+                    Critical,
+                    "Inconsistent state: is_leader=true but no connection"
+                );
                 is_leader.store(false, Ordering::Relaxed);
             }
         }

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -175,6 +175,7 @@ pub mod webhooks;
 #[cfg(test)]
 mod test;
 
+use crate::metrics::errors::component::{ONWARDS_HEARTBEAT, SUPERVISOR};
 use crate::{
     api::models::{
         deployments::{DeployedModelCreate, StandardModelCreate},
@@ -1873,7 +1874,7 @@ impl BackgroundServices {
                 }
                 Some(Ok((task_id, Ok(())))) => {
                     let task_name = self.task_names.get(&task_id).copied().unwrap_or("unknown");
-                    tracing::warn!(task = task_name, "Background task completed unexpectedly");
+                    crate::background_error!(SUPERVISOR, "task_exit_unexpected", Error, task = task_name, "Background task completed unexpectedly");
                     anyhow::bail!("Background task '{}' completed early", task_name)
                 }
                 Some(Ok((task_id, Err(e)))) if self.shutdown_token.is_cancelled() => {
@@ -1882,7 +1883,7 @@ impl BackgroundServices {
                 }
                 Some(Ok((task_id, Err(e)))) => {
                     let task_name = self.task_names.get(&task_id).copied().unwrap_or("unknown");
-                    tracing::error!(task = task_name, error = %e, "Background task failed");
+                    crate::background_error!(SUPERVISOR, "task_failed", Error, task = task_name, error = %e, "Background task failed");
                     anyhow::bail!("Background task '{}' failed: {}", task_name, e)
                 }
                 Some(Err(e)) if self.shutdown_token.is_cancelled() => {
@@ -1893,7 +1894,7 @@ impl BackgroundServices {
                 Some(Err(e)) => {
                     let task_id = e.id();
                     let task_name = self.task_names.get(&task_id).copied().unwrap_or("unknown");
-                    tracing::error!(task = task_name, error = %e, "Background task panicked");
+                    crate::background_error!(SUPERVISOR, "task_panicked", Error, task = task_name, error = %e, "Background task panicked");
                     anyhow::bail!("Background task '{}' panicked: {}", task_name, e)
                 }
             }
@@ -2000,12 +2001,12 @@ impl BackgroundServices {
                 }
                 Ok((task_id, Err(e))) => {
                     let task_name = self.task_names.get(&task_id).copied().unwrap_or("unknown");
-                    tracing::error!(task = task_name, error = %e, "Background task failed");
+                    crate::background_error!(SUPERVISOR, "task_failed", Error, task = task_name, error = %e, "Background task failed");
                 }
                 Err(e) => {
                     let task_id = e.id();
                     let task_name = self.task_names.get(&task_id).copied().unwrap_or("unknown");
-                    tracing::error!(task = task_name, error = %e, "Background task panicked");
+                    crate::background_error!(SUPERVISOR, "task_panicked", Error, task = task_name, error = %e, "Background task panicked");
                 }
             }
         }
@@ -2911,7 +2912,7 @@ impl Application {
                 true
             }
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to register onwards daemon (table may not exist yet)");
+                crate::background_error!(ONWARDS_HEARTBEAT, "registration", Warning, error = %e, "Failed to register onwards daemon (table may not exist yet)");
                 false
             }
         };
@@ -2937,7 +2938,7 @@ impl Application {
                             .await;
 
                             if let Err(e) = result {
-                                tracing::warn!(error = %e, "Failed to send onwards daemon heartbeat");
+                                crate::background_error!(ONWARDS_HEARTBEAT, "heartbeat", Warning, error = %e, "Failed to send onwards daemon heartbeat");
                             }
                         }
                         _ = heartbeat_shutdown.cancelled() => {

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1874,7 +1874,13 @@ impl BackgroundServices {
                 }
                 Some(Ok((task_id, Ok(())))) => {
                     let task_name = self.task_names.get(&task_id).copied().unwrap_or("unknown");
-                    crate::background_error!(SUPERVISOR, "task_exit_unexpected", Error, task = task_name, "Background task completed unexpectedly");
+                    crate::background_error!(
+                        SUPERVISOR,
+                        "task_exit_unexpected",
+                        Error,
+                        task = task_name,
+                        "Background task completed unexpectedly"
+                    );
                     anyhow::bail!("Background task '{}' completed early", task_name)
                 }
                 Some(Ok((task_id, Err(e)))) if self.shutdown_token.is_cancelled() => {

--- a/dwctl/src/metrics/errors.rs
+++ b/dwctl/src/metrics/errors.rs
@@ -1,9 +1,12 @@
 //! Unified background-error metric and log.
 //!
 //! `background_error!` emits the `dwctl_background_errors_total` counter AND a `tracing`
-//! event from a single call site, so the metric and the log can never drift. It is ONLY for
-//! background (off-request-path) failures - foreground failures are already counted by
-//! `dwctl_http_requests_total{status}`. See `pr-background-errors.md` for the full plan.
+//! event from a single call site, so the metric and the log can never drift. It is for failures
+//! we want attributed in the unified error metric - primarily background (off-request-path)
+//! failures, since foreground route failures that surface as a 5xx are already counted by
+//! `dwctl_http_requests_total{status}`. A handful of request-path sites also use it for failures
+//! that are swallowed (logged but not returned as the response status), which would otherwise be
+//! invisible.
 
 use metrics::counter;
 
@@ -23,6 +26,7 @@ pub mod component {
     pub const ANALYTICS_BATCHER: &str = "analytics_batcher";
     pub const RESPONSES_WRITER: &str = "responses_writer";
     pub const BATCH_POPULATE: &str = "batch_populate";
+    pub const PAYMENTS: &str = "payments";
 }
 
 /// Increment `dwctl_background_errors_total`. `component`/`reason`/`severity` are `&'static str`

--- a/dwctl/src/metrics/errors.rs
+++ b/dwctl/src/metrics/errors.rs
@@ -1,0 +1,69 @@
+//! Unified background-error metric and log.
+//!
+//! `background_error!` emits the `dwctl_background_errors_total` counter AND a `tracing`
+//! event from a single call site, so the metric and the log can never drift. It is ONLY for
+//! background (off-request-path) failures - foreground failures are already counted by
+//! `dwctl_http_requests_total{status}`. See `pr-background-errors.md` for the full plan.
+
+use metrics::counter;
+
+/// Bounded subsystem labels. Always a `&'static str` so the label set stays low cardinality.
+pub mod component {
+    pub const SUPERVISOR: &str = "supervisor";
+    pub const NOTIFICATIONS: &str = "notifications";
+    pub const AUTO_TOPUP: &str = "auto_topup";
+    pub const WEBHOOK_DISPATCH: &str = "webhook_dispatch";
+    pub const LEADER_ELECTION: &str = "leader_election";
+    pub const CONFIG_WATCHER: &str = "config_watcher";
+    pub const PROBE_SCHEDULER: &str = "probe_scheduler";
+    pub const TASK_WORKER: &str = "task_worker";
+    pub const ONWARDS_SYNC: &str = "onwards_sync";
+    pub const ONWARDS_HEARTBEAT: &str = "onwards_heartbeat";
+    pub const ANALYTICS: &str = "analytics";
+    pub const ANALYTICS_BATCHER: &str = "analytics_batcher";
+    pub const RESPONSES_WRITER: &str = "responses_writer";
+    pub const BATCH_POPULATE: &str = "batch_populate";
+}
+
+/// Increment `dwctl_background_errors_total`. `component`/`reason`/`severity` are `&'static str`
+/// (string literals) - the type forbids dynamic, high-cardinality labels (a `format!` would not
+/// coerce to `&'static str`).
+pub fn record(component: &'static str, reason: &'static str, severity: &'static str) {
+    counter!(
+        "dwctl_background_errors_total",
+        "component" => component,
+        "reason" => reason,
+        "severity" => severity
+    )
+    .increment(1);
+}
+
+/// Record a background failure: increment the metric AND emit a `tracing` event, from one site.
+///
+/// Severity is a literal tier token:
+/// - `Critical` - logs at `error!`, AND pages (the alert keys on `severity="critical"`).
+/// - `Error` - logs at `error!`, does NOT page (dashboard / triage).
+/// - `Warning` - logs at `warn!`, does NOT page.
+///
+/// `component` and `reason` must be `&'static str` literals (e.g. `component::WEBHOOK_DISPATCH`,
+/// `"delivery_create"`). Trailing tokens are forwarded to `tracing` as fields and message:
+///
+/// ```ignore
+/// background_error!(component::WEBHOOK_DISPATCH, "delivery_create", Critical,
+///     error = %e, delivery_id = %id, "Failed to create webhook delivery records");
+/// ```
+#[macro_export]
+macro_rules! background_error {
+    ($component:expr, $reason:expr, Critical, $($arg:tt)+) => {{
+        $crate::metrics::errors::record($component, $reason, "critical");
+        ::tracing::error!(component = $component, reason = $reason, $($arg)+);
+    }};
+    ($component:expr, $reason:expr, Error, $($arg:tt)+) => {{
+        $crate::metrics::errors::record($component, $reason, "error");
+        ::tracing::error!(component = $component, reason = $reason, $($arg)+);
+    }};
+    ($component:expr, $reason:expr, Warning, $($arg:tt)+) => {{
+        $crate::metrics::errors::record($component, $reason, "warning");
+        ::tracing::warn!(component = $component, reason = $reason, $($arg)+);
+    }};
+}

--- a/dwctl/src/metrics/mod.rs
+++ b/dwctl/src/metrics/mod.rs
@@ -7,6 +7,7 @@
 //! facade in the request_logging module.
 
 mod cache_info;
+pub mod errors;
 mod gen_ai;
 mod recorder;
 

--- a/dwctl/src/notifications.rs
+++ b/dwctl/src/notifications.rs
@@ -19,6 +19,7 @@
 //! use a unique partial index on `webhook_deliveries(webhook_id, event_type,
 //! resource_id)` for deduplication.
 
+use crate::metrics::errors::component::{AUTO_TOPUP, NOTIFICATIONS};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -154,7 +155,7 @@ pub async fn run_notification_poller(
                 Some(svc)
             }
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to create email service, email notifications disabled");
+                crate::background_error!(NOTIFICATIONS, "email_service_init", Critical, error = %e, "Failed to create email service, email notifications disabled");
                 None
             }
         }
@@ -171,12 +172,12 @@ pub async fn run_notification_poller(
                     Some(l)
                 }
                 Err(e) => {
-                    tracing::warn!(error = %e, "Failed to subscribe to {WEBHOOK_EVENT_CHANNEL} channel");
+                    crate::background_error!(NOTIFICATIONS, "listener_setup", Critical, error = %e, "Failed to subscribe to {WEBHOOK_EVENT_CHANNEL} channel");
                     None
                 }
             },
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to connect PG listener for webhook events");
+                crate::background_error!(NOTIFICATIONS, "listener_setup", Critical, error = %e, "Failed to connect PG listener for webhook events");
                 None
             }
         }
@@ -252,7 +253,7 @@ pub async fn run_notification_poller(
         let mut conn = match dwctl_pool.acquire().await {
             Ok(c) => c,
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to acquire database connection for notification poller tick");
+                crate::background_error!(NOTIFICATIONS, "db_acquire", Warning, error = %e, "Failed to acquire database connection for notification poller tick");
                 continue;
             }
         };
@@ -262,7 +263,7 @@ pub async fn run_notification_poller(
             let events = std::mem::take(&mut pending_webhook_events);
             let _ = process_platform_events(&mut conn, &events)
                 .await
-                .inspect_err(|e| tracing::warn!(error = %e, "Failed to process platform webhook events"));
+                .inspect_err(|e| crate::background_error!(NOTIFICATIONS, "platform_event_process", Warning, error = %e, "Failed to process platform webhook events"));
         }
 
         // === Step 2: Poll fusillade for completed batches ===
@@ -277,7 +278,7 @@ pub async fn run_notification_poller(
                     if dispatcher.is_some() {
                         let _ = create_batch_deliveries(&mut conn, &infos)
                             .await
-                            .inspect_err(|e| tracing::warn!(error = %e, "Failed to create webhook delivery records"));
+                            .inspect_err(|e| crate::background_error!(NOTIFICATIONS, "batch_delivery_create", Warning, error = %e, "Failed to create webhook delivery records"));
                     }
 
                     // === Step 4: Send email notifications ===
@@ -287,7 +288,7 @@ pub async fn run_notification_poller(
                 }
             }
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to poll for completed batches");
+                crate::background_error!(NOTIFICATIONS, "poll_completed_batches", Warning, error = %e, "Failed to poll for completed batches");
             }
         }
 
@@ -295,7 +296,7 @@ pub async fn run_notification_poller(
         if dispatcher.is_some() {
             let _ = process_new_batches(&mut conn)
                 .await
-                .inspect_err(|e| tracing::warn!(error = %e, "Failed to process new batch webhooks"));
+                .inspect_err(|e| crate::background_error!(NOTIFICATIONS, "new_batch_process", Warning, error = %e, "Failed to process new batch webhooks"));
         }
 
         // === Step 6: Low-balance notifications ===
@@ -304,7 +305,7 @@ pub async fn run_notification_poller(
             let candidates = {
                 let mut users = Users::new(&mut conn);
                 users.users_with_low_balance_threshold().await.unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "Failed to fetch low-balance threshold users");
+                    crate::background_error!(NOTIFICATIONS, "low_balance_fetch", Warning, error = %e, "Failed to fetch low-balance threshold users");
                     vec![]
                 })
             };
@@ -326,7 +327,7 @@ pub async fn run_notification_poller(
                 let refreshed = if !needs_refresh.is_empty() {
                     let mut credits = Credits::new(&mut conn);
                     credits.get_users_balances_bulk(&needs_refresh, Some(1)).await.unwrap_or_else(|e| {
-                        tracing::warn!(error = %e, "Failed to refresh balances for low-balance users");
+                        crate::background_error!(NOTIFICATIONS, "balance_refresh", Warning, error = %e, "Failed to refresh balances for low-balance users");
                         Default::default()
                     })
                 } else {
@@ -360,7 +361,7 @@ pub async fn run_notification_poller(
                     let _ = users
                         .clear_low_balance_notification_sent(&recovered)
                         .await
-                        .inspect_err(|e| tracing::warn!(error = %e, "Failed to clear recovered low-balance flags"));
+                        .inspect_err(|e| crate::background_error!(NOTIFICATIONS, "low_balance_flag_clear", Warning, error = %e, "Failed to clear recovered low-balance flags"));
                 }
             }
         }
@@ -512,7 +513,8 @@ async fn process_platform_events(conn: &mut sqlx::pool::PoolConnection<sqlx::Pos
             };
 
             let _ = repo.try_create_delivery(&delivery_request).await.inspect_err(|e| {
-                tracing::warn!(
+                crate::background_error!(
+                    NOTIFICATIONS, "delivery_create", Warning,
                     error = %e,
                     webhook_id = %webhook.id,
                     event_type = %event_type,
@@ -623,7 +625,8 @@ async fn process_new_batches(conn: &mut sqlx::pool::PoolConnection<sqlx::Postgre
             };
 
             let _ = repo.try_create_delivery(&delivery_request).await.inspect_err(|e| {
-                tracing::warn!(
+                crate::background_error!(
+                    NOTIFICATIONS, "delivery_create", Warning,
                     error = %e,
                     webhook_id = %webhook.id,
                     batch_id = %batch.id,
@@ -649,7 +652,7 @@ async fn send_email_notifications(
         match users.get_bulk(user_ids).await {
             Ok(u) => u,
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to fetch users for email notifications");
+                crate::background_error!(NOTIFICATIONS, "user_fetch", Warning, error = %e, "Failed to fetch users for email notifications");
                 return;
             }
         }
@@ -672,7 +675,8 @@ async fn send_email_notifications(
             .send_batch_completion_email(&user.email, Some(name), info, is_first_batch)
             .await
         {
-            tracing::warn!(
+            crate::background_error!(
+                NOTIFICATIONS, "email_send", Warning,
                 batch_id = %info.batch_id,
                 email = %user.email,
                 error = %e,
@@ -693,7 +697,8 @@ async fn send_email_notifications(
         if is_first_batch {
             let mut users = Users::new(&mut *conn);
             if let Err(e) = users.mark_first_batch_email_sent(info.user_id).await {
-                tracing::warn!(
+                crate::background_error!(
+                    NOTIFICATIONS, "mark_email_sent", Warning,
                     user_id = %info.user_id,
                     error = %e,
                     "Failed to mark first batch email as sent"
@@ -724,7 +729,7 @@ async fn process_auto_topups(
     let candidates = {
         let mut users = Users::new(&mut *conn);
         users.users_with_auto_topup_enabled().await.unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "Failed to fetch auto-topup eligible users");
+            crate::background_error!(AUTO_TOPUP, "eligible_fetch", Warning, error = %e, "Failed to fetch auto-topup eligible users");
             vec![]
         })
     };
@@ -742,7 +747,7 @@ async fn process_auto_topups(
     let refreshed = {
         let mut credits = Credits::new(&mut *conn);
         credits.get_users_balances_bulk(&all_ids, Some(1)).await.unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "Failed to refresh balances for auto-topup users");
+            crate::background_error!(AUTO_TOPUP, "balance_refresh", Warning, error = %e, "Failed to refresh balances for auto-topup users");
             Default::default()
         })
     };
@@ -773,8 +778,7 @@ async fn process_auto_topups(
         match credits.get_monthly_auto_topup_spend_bulk(&limit_user_ids).await {
             Ok(spends) => spends,
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to batch-fetch monthly auto-topup spend, aborting auto-topup run");
-                counter!("dwctl_auto_topup_errors_total", "stage" => "monthly_limit_check").increment(1);
+                crate::background_error!(AUTO_TOPUP, "monthly_spend_fetch", Error, error = %e, "Failed to batch-fetch monthly auto-topup spend, aborting auto-topup run");
                 return;
             }
         }
@@ -807,11 +811,11 @@ async fn process_auto_topups(
                         .send_auto_topup_limit_reached_email(&user.email, Some(name), &monthly_limit, &balance)
                         .await
                     {
-                        tracing::warn!(user_id = %user.id, error = %e, "Failed to send auto top-up limit reached email");
+                        crate::background_error!(AUTO_TOPUP, "email_send", Warning, user_id = %user.id, error = %e, "Failed to send auto top-up limit reached email");
                     } else {
                         let mut users = Users::new(&mut *conn);
                         let _ = users.mark_auto_topup_limit_notification_sent(&[user.id]).await.inspect_err(
-                            |e| tracing::warn!(user_id = %user.id, error = %e, "Failed to mark auto-topup limit notification as sent"),
+                            |e| crate::background_error!(AUTO_TOPUP, "mark_limit_notified", Warning, user_id = %user.id, error = %e, "Failed to mark auto-topup limit notification as sent"),
                         );
                     }
                 }
@@ -833,7 +837,7 @@ async fn process_auto_topups(
                     // Spend is back under the limit (new month or limit raised) — clear the flag
                     let mut users = Users::new(&mut *conn);
                     let _ = users.clear_auto_topup_limit_notification_sent(&[user.id]).await.inspect_err(
-                        |e| tracing::warn!(user_id = %user.id, error = %e, "Failed to clear auto-topup limit notification flag"),
+                        |e| crate::background_error!(AUTO_TOPUP, "clear_limit_flag", Warning, user_id = %user.id, error = %e, "Failed to clear auto-topup limit notification flag"),
                     );
                 }
                 (user.auto_topup_amount, "Automatic top-up")
@@ -869,8 +873,7 @@ async fn process_auto_topups(
                 }
                 Ok(false) => {}
                 Err(e) => {
-                    tracing::warn!(user_id = %user.id, error = %e, "Failed to check auto-topup idempotency");
-                    counter!("dwctl_auto_topup_errors_total", "stage" => "idempotency_check").increment(1);
+                    crate::background_error!(AUTO_TOPUP, "idempotency_check", Error, user_id = %user.id, error = %e, "Failed to check auto-topup idempotency");
                     continue;
                 }
             }
@@ -881,21 +884,19 @@ async fn process_auto_topups(
             Ok(Some(pm_id)) => pm_id,
             Ok(None) => {
                 tracing::warn!(user_id = %user.id, "No default payment method found, skipping auto top-up");
-                counter!("dwctl_auto_topup_charge_failures_total").increment(1);
                 if let Some(email_svc) = email_service {
                     let name = user.display_name.as_deref().unwrap_or(&user.username);
                     if let Err(e) = email_svc
                         .send_auto_topup_failed_email(&user.email, Some(name), &user.auto_topup_amount, &user.auto_topup_threshold)
                         .await
                     {
-                        tracing::warn!(user_id = %user.id, error = %e, "Failed to send auto top-up failure email");
+                        crate::background_error!(AUTO_TOPUP, "email_send", Warning, user_id = %user.id, error = %e, "Failed to send auto top-up failure email");
                     }
                 }
                 continue;
             }
             Err(e) => {
-                tracing::warn!(user_id = %user.id, error = %e, "Failed to fetch default payment method");
-                counter!("dwctl_auto_topup_errors_total", "stage" => "payment_method_lookup").increment(1);
+                crate::background_error!(AUTO_TOPUP, "payment_method_lookup", Error, user_id = %user.id, error = %e, "Failed to fetch default payment method");
                 continue;
             }
         };
@@ -907,19 +908,19 @@ async fn process_auto_topups(
         {
             Ok(id) => id,
             Err(e) => {
-                tracing::warn!(
+                crate::background_error!(
+                    AUTO_TOPUP, "charge", Warning,
                     user_id = %user.id,
                     error = %e,
                     "Failed to charge auto top-up"
                 );
-                counter!("dwctl_auto_topup_charge_failures_total").increment(1);
                 if let Some(email_svc) = email_service {
                     let name = user.display_name.as_deref().unwrap_or(&user.username);
                     if let Err(e) = email_svc
                         .send_auto_topup_failed_email(&user.email, Some(name), &user.auto_topup_amount, &user.auto_topup_threshold)
                         .await
                     {
-                        tracing::warn!(user_id = %user.id, error = %e, "Failed to send auto top-up failure email");
+                        crate::background_error!(AUTO_TOPUP, "email_send", Warning, user_id = %user.id, error = %e, "Failed to send auto top-up failure email");
                     }
                 }
                 continue;
@@ -941,7 +942,7 @@ async fn process_auto_topups(
         // been charged regardless of what happens with the credit-transaction insert
         // below. Mark verified now for the onwards rate-limit tier.
         if let Err(e) = Users::new(&mut *conn).set_verified(user.id).await {
-            tracing::warn!(user_id = %user.id, error = %e, "Failed to mark user verified after auto top-up");
+            crate::background_error!(AUTO_TOPUP, "mark_verified", Warning, user_id = %user.id, error = %e, "Failed to mark user verified after auto top-up");
         }
 
         let mut credits = Credits::new(&mut *conn);
@@ -960,7 +961,7 @@ async fn process_auto_topups(
                         .send_auto_topup_success_email(&user.email, Some(name), &charge_amount, &user.auto_topup_threshold, &new_balance)
                         .await
                     {
-                        tracing::warn!(user_id = %user.id, error = %e, "Failed to send auto top-up success email");
+                        crate::background_error!(AUTO_TOPUP, "email_send", Warning, user_id = %user.id, error = %e, "Failed to send auto top-up success email");
                     }
                 }
                 // First-payment match (no-op unless enabled and this is the user's
@@ -970,7 +971,7 @@ async fn process_auto_topups(
                     .grant_first_payment_match(credits_config.first_payment_match_up_to, user.id, charge_amount, &request.source_id)
                     .await
                 {
-                    tracing::error!(user_id = %user.id, error = %e, "First-payment match failed after auto top-up; purchase unaffected, grant manually if needed");
+                    crate::background_error!(AUTO_TOPUP, "first_payment_match", Critical, user_id = %user.id, error = %e, "First-payment match failed after auto top-up; purchase unaffected, grant manually if needed");
                 }
             }
             Err(crate::db::errors::DbError::UniqueViolation { constraint, .. })
@@ -980,15 +981,15 @@ async fn process_auto_topups(
                 tracing::info!(user_id = %user.id, "Auto top-up credit transaction already exists (race), treating as success");
             }
             Err(e) => {
-                tracing::error!(
+                crate::background_error!(
+                    AUTO_TOPUP, "credit_record", Critical,
                     user_id = %user.id,
                     payment_intent_id = %payment_intent_id,
                     amount = %user.auto_topup_amount,
                     error = %e,
-                    "CRITICAL: Auto top-up payment succeeded but credit transaction failed. \
+                    "Auto top-up payment succeeded but credit transaction failed. \
                      User was charged but did not receive credits. Manual reconciliation required."
                 );
-                counter!("dwctl_auto_topup_credit_failures_total").increment(1);
                 // Do NOT send "payment failed" email here — the payment actually succeeded.
                 // The user was charged but credits weren't recorded due to a DB error.
                 // The CRITICAL log + metric above should trigger an alert for manual reconciliation.
@@ -1011,7 +1012,8 @@ async fn send_low_balance_notifications(
         let name = user.display_name.as_deref().unwrap_or(&user.username);
 
         if let Err(e) = email_service.send_low_balance_email(&user.email, Some(name), &balance).await {
-            tracing::warn!(
+            crate::background_error!(
+                NOTIFICATIONS, "email_send", Warning,
                 user_id = %user.id,
                 email = %user.email,
                 error = %e,
@@ -1028,7 +1030,7 @@ async fn send_low_balance_notifications(
     if !sent_ids.is_empty() {
         let mut users_repo = Users::new(&mut *conn);
         if let Err(e) = users_repo.mark_low_balance_notification_sent(&sent_ids).await {
-            tracing::warn!(error = %e, "Failed to mark low-balance notifications as sent");
+            crate::background_error!(NOTIFICATIONS, "mark_low_balance_sent", Warning, error = %e, "Failed to mark low-balance notifications as sent");
         }
     }
 }

--- a/dwctl/src/probes/scheduler.rs
+++ b/dwctl/src/probes/scheduler.rs
@@ -4,6 +4,7 @@
 //! on the leader replica. It periodically polls the database for active probes
 //! and manages background tasks that execute each probe at its configured interval.
 
+use crate::metrics::errors::component::PROBE_SCHEDULER;
 use crate::probes::db::ProbeManager;
 use sqlx::PgPool;
 use std::collections::HashMap;
@@ -82,7 +83,7 @@ impl ProbeScheduler {
                         let probe = match ProbeManager::get_probe(&pool, probe_id).await {
                             Ok(p) => p,
                             Err(e) => {
-                                tracing::error!("Error fetching probe {}: {}", probe_id, e);
+                                crate::background_error!(PROBE_SCHEDULER, "probe_fetch", Warning, "Error fetching probe {}: {}", probe_id, e);
                                 return;
                             }
                         };
@@ -139,7 +140,7 @@ impl ProbeScheduler {
                 let probe = match ProbeManager::get_probe(&pool, probe_id).await {
                     Ok(p) => p,
                     Err(e) => {
-                        tracing::error!("Error fetching probe {}: {}", probe_id, e);
+                        crate::background_error!(PROBE_SCHEDULER, "probe_fetch", Warning, "Error fetching probe {}: {}", probe_id, e);
                         break;
                     }
                 };
@@ -164,7 +165,7 @@ impl ProbeScheduler {
                         }
                     }
                     Err(e) => {
-                        tracing::error!("Error executing probe {}: {}", probe.name, e);
+                        crate::background_error!(PROBE_SCHEDULER, "probe_execute", Warning, "Error executing probe {}: {}", probe.name, e);
                     }
                 }
 
@@ -236,7 +237,7 @@ impl ProbeScheduler {
         for probe_id in active_probe_ids.difference(&running_probe_ids) {
             tracing::info!("Starting scheduler for newly activated probe {}", probe_id);
             if let Err(e) = self.start_scheduler(*probe_id, shutdown_token.clone()).await {
-                tracing::error!("Failed to start scheduler for probe {}: {}", probe_id, e);
+                crate::background_error!(PROBE_SCHEDULER, "scheduler_start", Warning, "Failed to start scheduler for probe {}: {}", probe_id, e);
             }
         }
 
@@ -244,7 +245,7 @@ impl ProbeScheduler {
         for probe_id in running_probe_ids.difference(&active_probe_ids) {
             tracing::info!("Stopping scheduler for deactivated probe {}", probe_id);
             if let Err(e) = self.stop_scheduler(*probe_id).await {
-                tracing::error!("Failed to stop scheduler for probe {}: {}", probe_id, e);
+                crate::background_error!(PROBE_SCHEDULER, "scheduler_stop", Warning, "Failed to stop scheduler for probe {}: {}", probe_id, e);
             }
         }
 
@@ -292,7 +293,7 @@ impl ProbeScheduler {
             tokio::select! {
                 _ = interval.tick() => {
                     if let Err(e) = self.sync_with_database(shutdown_token.clone()).await {
-                        tracing::error!("Error syncing probe schedulers with database: {}", e);
+                        crate::background_error!(PROBE_SCHEDULER, "db_sync", Warning, "Error syncing probe schedulers with database: {}", e);
                     }
                 }
                 _ = shutdown_token.cancelled() => {
@@ -381,12 +382,12 @@ impl ProbeScheduler {
                                         ) {
                                             tracing::debug!("Received probe change notification: probe_id={}, active={}", probe_id, active);
                                             if let Err(e) = self.handle_probe_change(probe_id, active, shutdown_token.clone()).await {
-                                                tracing::error!("Failed to handle probe change for {}: {}", probe_id, e);
+                                                crate::background_error!(PROBE_SCHEDULER, "probe_change", Warning, "Failed to handle probe change for {}: {}", probe_id, e);
                                             }
                                         }
                                     }
                                     Err(e) => {
-                                        tracing::warn!("Failed to parse notification payload: {}", e);
+                                        crate::background_error!(PROBE_SCHEDULER, "payload_parse", Warning, "Failed to parse notification payload: {}", e);
                                     }
                                 }
                             }
@@ -401,7 +402,7 @@ impl ProbeScheduler {
                     _ = fallback_interval.tick() => {
                         tracing::debug!("Running fallback sync");
                         if let Err(e) = self.sync_with_database(shutdown_token.clone()).await {
-                            tracing::error!("Error during fallback sync: {}", e);
+                            crate::background_error!(PROBE_SCHEDULER, "db_sync", Warning, "Error during fallback sync: {}", e);
                         }
                     }
                 }

--- a/dwctl/src/probes/scheduler.rs
+++ b/dwctl/src/probes/scheduler.rs
@@ -83,7 +83,14 @@ impl ProbeScheduler {
                         let probe = match ProbeManager::get_probe(&pool, probe_id).await {
                             Ok(p) => p,
                             Err(e) => {
-                                crate::background_error!(PROBE_SCHEDULER, "probe_fetch", Warning, "Error fetching probe {}: {}", probe_id, e);
+                                crate::background_error!(
+                                    PROBE_SCHEDULER,
+                                    "probe_fetch",
+                                    Warning,
+                                    "Error fetching probe {}: {}",
+                                    probe_id,
+                                    e
+                                );
                                 return;
                             }
                         };
@@ -165,7 +172,14 @@ impl ProbeScheduler {
                         }
                     }
                     Err(e) => {
-                        crate::background_error!(PROBE_SCHEDULER, "probe_execute", Warning, "Error executing probe {}: {}", probe.name, e);
+                        crate::background_error!(
+                            PROBE_SCHEDULER,
+                            "probe_execute",
+                            Warning,
+                            "Error executing probe {}: {}",
+                            probe.name,
+                            e
+                        );
                     }
                 }
 
@@ -237,7 +251,14 @@ impl ProbeScheduler {
         for probe_id in active_probe_ids.difference(&running_probe_ids) {
             tracing::info!("Starting scheduler for newly activated probe {}", probe_id);
             if let Err(e) = self.start_scheduler(*probe_id, shutdown_token.clone()).await {
-                crate::background_error!(PROBE_SCHEDULER, "scheduler_start", Warning, "Failed to start scheduler for probe {}: {}", probe_id, e);
+                crate::background_error!(
+                    PROBE_SCHEDULER,
+                    "scheduler_start",
+                    Warning,
+                    "Failed to start scheduler for probe {}: {}",
+                    probe_id,
+                    e
+                );
             }
         }
 
@@ -245,7 +266,14 @@ impl ProbeScheduler {
         for probe_id in running_probe_ids.difference(&active_probe_ids) {
             tracing::info!("Stopping scheduler for deactivated probe {}", probe_id);
             if let Err(e) = self.stop_scheduler(*probe_id).await {
-                crate::background_error!(PROBE_SCHEDULER, "scheduler_stop", Warning, "Failed to stop scheduler for probe {}: {}", probe_id, e);
+                crate::background_error!(
+                    PROBE_SCHEDULER,
+                    "scheduler_stop",
+                    Warning,
+                    "Failed to stop scheduler for probe {}: {}",
+                    probe_id,
+                    e
+                );
             }
         }
 

--- a/dwctl/src/request_logging/analytics_handler.rs
+++ b/dwctl/src/request_logging/analytics_handler.rs
@@ -44,8 +44,8 @@
 //! let layer = RequestLoggerLayer::new(outlet_config, handler);
 //! ```
 
-use crate::metrics::errors::component::ANALYTICS;
 use crate::config::Config;
+use crate::metrics::errors::component::ANALYTICS;
 use crate::request_logging::AiResponse;
 use crate::request_logging::batcher::{AnalyticsSender, RawAnalyticsRecord};
 use crate::request_logging::serializers::{Auth, UsageMetrics, parse_ai_response};

--- a/dwctl/src/request_logging/analytics_handler.rs
+++ b/dwctl/src/request_logging/analytics_handler.rs
@@ -44,16 +44,16 @@
 //! let layer = RequestLoggerLayer::new(outlet_config, handler);
 //! ```
 
+use crate::metrics::errors::component::ANALYTICS;
 use crate::config::Config;
 use crate::request_logging::AiResponse;
 use crate::request_logging::batcher::{AnalyticsSender, RawAnalyticsRecord};
 use crate::request_logging::serializers::{Auth, UsageMetrics, parse_ai_response};
 use crate::request_logging::utils::{extract_header_as_string, extract_header_as_uuid};
 use axum::http::Uri;
-use metrics::counter;
 use outlet::{RequestData, RequestHandler, ResponseData};
 use serde_json::Value;
-use tracing::{Instrument, error, info_span, warn};
+use tracing::{Instrument, info_span};
 use uuid::Uuid;
 
 /// A request handler that sends analytics data to a background batcher.
@@ -149,19 +149,14 @@ impl RequestHandler for AnalyticsHandler {
                             "Failed to parse successful AI response — tokens will be zero"
                         );
                         if let Some(endpoint) = usage_required_endpoint {
-                            counter!(
-                                "dwctl_usage_extraction_failures_total",
-                                "endpoint" => endpoint,
-                                "reason" => "parse_error"
-                            )
-                            .increment(1);
-                            error!(
+                            crate::background_error!(
+                                ANALYTICS, "parse_error", Error,
                                 correlation_id = correlation_id,
                                 uri = %request_data.uri,
                                 endpoint,
                                 fusillade_stream,
                                 error = %e.error,
-                                "CRITICAL: failed to serialize usage for successful generative response"
+                                "Failed to serialize usage for successful generative response"
                             );
                         }
                     }
@@ -179,13 +174,8 @@ impl RequestHandler for AnalyticsHandler {
                 && metrics.total_tokens == 0
                 && let Some(endpoint) = usage_required_endpoint
             {
-                counter!(
-                    "dwctl_usage_extraction_failures_total",
-                    "endpoint" => endpoint,
-                    "reason" => "missing_usage"
-                )
-                .increment(1);
-                error!(
+                crate::background_error!(
+                    ANALYTICS, "missing_usage", Error,
                     correlation_id = correlation_id,
                     uri = %request_data.uri,
                     endpoint,
@@ -193,7 +183,7 @@ impl RequestHandler for AnalyticsHandler {
                     fusillade_stream,
                     request_model = ?metrics.request_model,
                     response_model = ?metrics.response_model,
-                    "CRITICAL: successful generative response recorded zero tokens"
+                    "Successful generative response recorded zero tokens"
                 );
             }
 
@@ -250,8 +240,8 @@ impl RequestHandler for AnalyticsHandler {
 
             // Send to batcher (non-blocking, just puts in channel)
             if let Err(e) = self.sender.send(record).await {
-                counter!("dwctl_analytics_send_errors_total").increment(1);
-                warn!(
+                crate::background_error!(
+                    ANALYTICS, "send_failed", Error,
                     correlation_id = correlation_id,
                     error = %e,
                     "Failed to send analytics record to batcher - channel may be full or closed"

--- a/dwctl/src/request_logging/batcher.rs
+++ b/dwctl/src/request_logging/batcher.rs
@@ -33,11 +33,11 @@
 //! - **Batch enrichment**: User and pricing lookups are batched using `IN` clauses,
 //!   reducing from O(N) queries to O(1) per batch.
 
-use crate::metrics::errors::component::ANALYTICS_BATCHER;
 use crate::config::{Config, ONWARDS_CONFIG_CHANGED_CHANNEL};
 use crate::db::handlers::Credits;
 use crate::db::models::api_keys::ApiKeyPurpose;
 use crate::metrics::MetricsRecorder;
+use crate::metrics::errors::component::ANALYTICS_BATCHER;
 use crate::request_logging::serializers::HttpAnalyticsRow;
 use chrono::{DateTime, Utc};
 use metrics::{counter, histogram};

--- a/dwctl/src/request_logging/batcher.rs
+++ b/dwctl/src/request_logging/batcher.rs
@@ -33,6 +33,7 @@
 //! - **Batch enrichment**: User and pricing lookups are batched using `IN` clauses,
 //!   reducing from O(N) queries to O(1) per batch.
 
+use crate::metrics::errors::component::ANALYTICS_BATCHER;
 use crate::config::{Config, ONWARDS_CONFIG_CHANGED_CHANNEL};
 use crate::db::handlers::Credits;
 use crate::db::models::api_keys::ApiKeyPurpose;
@@ -276,8 +277,7 @@ where
             let enriched = match self.enrich_batch(buffer).await {
                 Ok(enriched) => enriched,
                 Err(e) => {
-                    error!(error = %e, batch_size = batch_size, ?correlation_ids, "Failed to enrich analytics batch");
-                    counter!("dwctl_analytics_batch_errors_total", "phase" => "enrich").increment(1);
+                    crate::background_error!(ANALYTICS_BATCHER, "enrich", Error, error = %e, batch_size = batch_size, ?correlation_ids, "Failed to enrich analytics batch");
                     buffer.clear();
                     return;
                 }
@@ -321,14 +321,14 @@ where
             }
 
             if let Some(e) = last_error {
-                error!(
+                crate::background_error!(
+                    ANALYTICS_BATCHER, "write_drop", Critical,
                     error = %e,
                     batch_size = batch_size,
                     attempts = self.max_retries + 1,
                     ?correlation_ids,
                     "Failed to write analytics batch after all retries, dropping batch"
                 );
-                counter!("dwctl_analytics_batch_errors_total", "phase" => "write").increment(1);
                 buffer.clear();
                 return;
             }
@@ -841,7 +841,8 @@ where
 
             // Get analytics_id
             let Some(&analytics_id) = analytics_ids.get(&(record.raw.instance_id, record.raw.correlation_id)) else {
-                warn!(
+                crate::background_error!(
+                    ANALYTICS_BATCHER, "analytics_id_missing", Warning,
                     instance_id = %record.raw.instance_id,
                     correlation_id = record.raw.correlation_id,
                     "Analytics ID not found for credit transaction"

--- a/dwctl/src/responses/writer.rs
+++ b/dwctl/src/responses/writer.rs
@@ -56,6 +56,7 @@
 //! one fusillade transaction per flush, no dwctl_pool access on the bulk path
 //! ```
 
+use crate::metrics::errors::component::RESPONSES_WRITER;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -64,7 +65,7 @@ use metrics::{counter, gauge, histogram};
 use sqlx_pool_router::PoolProvider;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, error, info, info_span, warn};
+use tracing::{Instrument, debug, info, info_span, warn};
 use uuid::Uuid;
 
 /// Channel capacity. Records sit here when the writer can't keep up; once
@@ -289,13 +290,13 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> RequestsWriter<P> {
             }
 
             if let Some(e) = last_error {
-                error!(
+                crate::background_error!(
+                    RESPONSES_WRITER, "flush_drop", Error,
                     error = %e,
                     batch_size,
                     attempts = self.max_retries + 1,
                     "Failed to flush responses batch after all retries, dropping batch"
                 );
-                counter!("dwctl_requests_writer_flush_errors_total").increment(1);
                 buffer.clear();
                 return;
             }

--- a/dwctl/src/responses/writer.rs
+++ b/dwctl/src/responses/writer.rs
@@ -26,8 +26,8 @@
 //!   * **Sustained fusillade outage**: `flush_batch` retries with
 //!     exponential backoff up to `max_retries` (default 3). If every
 //!     attempt fails the batch is dropped, logged at `error`, and
-//!     `dwctl_requests_writer_flush_errors_total` increments. There is
-//!     no requeue or dead-letter table.
+//!     `dwctl_background_errors_total{component="responses_writer", reason="flush_drop"}`
+//!     increments. There is no requeue or dead-letter table.
 //!
 //! Both losses are acceptable here because billing and usage accounting
 //! read from `http_analytics` and `credit_transactions`, not `requests`.

--- a/dwctl/src/sync/onwards_config/mod.rs
+++ b/dwctl/src/sync/onwards_config/mod.rs
@@ -392,7 +392,7 @@ impl OnwardsConfigSync {
                                 debug!("Fallback sync: updated onwards configuration successfully");
                             }
                             Err(e) => {
-                                crate::background_error!(ONWARDS_SYNC, "load_targets", Error, "Fallback sync: failed to load targets from database: {}", e);
+                                crate::background_error!(ONWARDS_SYNC, "load_targets_fallback", Error, "Fallback sync: failed to load targets from database: {}", e);
                                 // Continue - fallback sync errors shouldn't crash the service
                             }
                         }

--- a/dwctl/src/sync/onwards_config/mod.rs
+++ b/dwctl/src/sync/onwards_config/mod.rs
@@ -174,7 +174,13 @@ impl OnwardsConfigSync {
         // Populate cache info metrics on startup
         let mut cache_info_state = crate::metrics::CacheInfoState::new();
         if let Err(e) = crate::metrics::update_cache_info_metrics(&db, &initial_targets, &mut cache_info_state).await {
-            crate::background_error!(ONWARDS_SYNC, "cache_info_metrics", Error, "Failed to update cache info metrics: {}", e);
+            crate::background_error!(
+                ONWARDS_SYNC,
+                "cache_info_metrics",
+                Error,
+                "Failed to update cache info metrics: {}",
+                e
+            );
         }
 
         // Create watch channel with initial state
@@ -1152,7 +1158,9 @@ fn convert_to_config_file(
     for composite in composites {
         if composite.components.is_empty() {
             crate::background_error!(
-                ONWARDS_SYNC, "composite_no_components", Warning,
+                ONWARDS_SYNC,
+                "composite_no_components",
+                Warning,
                 "Composite model '{}' has no enabled components - requests will return 503",
                 composite.alias
             );

--- a/dwctl/src/sync/onwards_config/mod.rs
+++ b/dwctl/src/sync/onwards_config/mod.rs
@@ -1,5 +1,6 @@
 //! Configuration synchronization to onwards routing layer.
 
+use crate::metrics::errors::component::ONWARDS_SYNC;
 use std::{collections::HashMap, num::NonZeroU32, sync::Arc};
 
 use metrics::histogram;
@@ -173,7 +174,7 @@ impl OnwardsConfigSync {
         // Populate cache info metrics on startup
         let mut cache_info_state = crate::metrics::CacheInfoState::new();
         if let Err(e) = crate::metrics::update_cache_info_metrics(&db, &initial_targets, &mut cache_info_state).await {
-            error!("Failed to update cache info metrics: {}", e);
+            crate::background_error!(ONWARDS_SYNC, "cache_info_metrics", Error, "Failed to update cache info metrics: {}", e);
         }
 
         // Create watch channel with initial state
@@ -288,12 +289,12 @@ impl OnwardsConfigSync {
                                         // Update daemon capacity limits if configured
                                         if let Some(ref limits) = self.daemon_capacity_limits
                                             && let Err(e) = update_daemon_capacity_limits(&self.db, limits, self.default_batch_capacity).await {
-                                                error!("Failed to update daemon capacity limits: {}", e);
+                                                crate::background_error!(ONWARDS_SYNC, "capacity_limits", Error, "Failed to update daemon capacity limits: {}", e);
                                             }
 
                                         // Update cache info metrics
                                         if let Err(e) = crate::metrics::update_cache_info_metrics(&self.db, &new_targets, &mut self.cache_info_state).await {
-                                            error!("Failed to update cache info metrics: {}", e);
+                                            crate::background_error!(ONWARDS_SYNC, "cache_info_metrics", Error, "Failed to update cache info metrics: {}", e);
                                         }
 
                                         // Send update through watch channel
@@ -318,7 +319,7 @@ impl OnwardsConfigSync {
                                         }
                                     }
                                     Err(e) => {
-                                        error!("Failed to load targets from database: {}", e);
+                                        crate::background_error!(ONWARDS_SYNC, "load_targets", Error, "Failed to load targets from database: {}", e);
                                         // Return error if database operations fail consistently
                                         if e.to_string().contains("closed pool") || e.to_string().contains("connection closed") {
                                             error!("Database pool closed, exiting sync task");
@@ -371,12 +372,12 @@ impl OnwardsConfigSync {
                                 // Update daemon capacity limits if configured
                                 if let Some(ref limits) = self.daemon_capacity_limits
                                     && let Err(e) = update_daemon_capacity_limits(&self.db, limits, self.default_batch_capacity).await {
-                                        error!("Failed to update daemon capacity limits: {}", e);
+                                        crate::background_error!(ONWARDS_SYNC, "capacity_limits", Error, "Failed to update daemon capacity limits: {}", e);
                                     }
 
                                 // Update cache info metrics
                                 if let Err(e) = crate::metrics::update_cache_info_metrics(&self.db, &new_targets, &mut self.cache_info_state).await {
-                                    error!("Failed to update cache info metrics: {}", e);
+                                    crate::background_error!(ONWARDS_SYNC, "cache_info_metrics", Error, "Failed to update cache info metrics: {}", e);
                                 }
 
                                 // Send update through watch channel
@@ -391,8 +392,7 @@ impl OnwardsConfigSync {
                                 debug!("Fallback sync: updated onwards configuration successfully");
                             }
                             Err(e) => {
-                                error!("Fallback sync: failed to load targets from database: {}", e);
-                                metrics::counter!("dwctl_cache_sync_errors_total", "source" => "fallback").increment(1);
+                                crate::background_error!(ONWARDS_SYNC, "load_targets", Error, "Fallback sync: failed to load targets from database: {}", e);
                                 // Continue - fallback sync errors shouldn't crash the service
                             }
                         }
@@ -1151,7 +1151,8 @@ fn convert_to_config_file(
     // Convert composite models (including those with no components - they'll return 503)
     for composite in composites {
         if composite.components.is_empty() {
-            warn!(
+            crate::background_error!(
+                ONWARDS_SYNC, "composite_no_components", Warning,
                 "Composite model '{}' has no enabled components - requests will return 503",
                 composite.alias
             );

--- a/dwctl/src/tasks.rs
+++ b/dwctl/src/tasks.rs
@@ -4,6 +4,7 @@
 //! work. Job definitions live alongside their handlers (e.g. batch population
 //! is defined in `api::handlers::batches`); this module wires them together.
 
+use crate::metrics::errors::component::TASK_WORKER;
 use std::sync::{Arc, OnceLock, Weak};
 
 use anyhow::Result;
@@ -170,7 +171,7 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> TaskRunner<P> {
                 "create-batch-worker",
                 tokio::spawn(async move {
                     if let Err(e) = worker.run().await {
-                        tracing::error!(error = %e, worker = i, "Create-batch worker error");
+                        crate::background_error!(TASK_WORKER, "create_batch", Error, error = %e, worker = i, "Create-batch worker error");
                     }
                 }),
             ));
@@ -186,7 +187,7 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> TaskRunner<P> {
                     "cascade-batch-state-worker",
                     tokio::spawn(async move {
                         if let Err(e) = worker.run().await {
-                            tracing::error!(error = %e, worker = i, "Cascade-batch-state worker error");
+                            crate::background_error!(TASK_WORKER, "cascade_batch_state", Error, error = %e, worker = i, "Cascade-batch-state worker error");
                         }
                     }),
                 ));
@@ -212,7 +213,7 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> TaskRunner<P> {
                 "sync-discovery-worker",
                 tokio::spawn(async move {
                     if let Err(e) = worker.run().await {
-                        tracing::error!(error = %e, worker = i, "Sync-connection worker error");
+                        crate::background_error!(TASK_WORKER, "sync_connection", Error, error = %e, worker = i, "Sync-connection worker error");
                     }
                 }),
             ));
@@ -226,7 +227,7 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> TaskRunner<P> {
                 "ingest-file-worker",
                 tokio::spawn(async move {
                     if let Err(e) = worker.run().await {
-                        tracing::error!(error = %e, worker = i, "Ingest-file worker error");
+                        crate::background_error!(TASK_WORKER, "ingest_file", Error, error = %e, worker = i, "Ingest-file worker error");
                     }
                 }),
             ));
@@ -240,7 +241,7 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> TaskRunner<P> {
                 "activate-batch-worker",
                 tokio::spawn(async move {
                     if let Err(e) = worker.run().await {
-                        tracing::error!(error = %e, worker = i, "Activate-batch worker error");
+                        crate::background_error!(TASK_WORKER, "activate_batch", Error, error = %e, worker = i, "Activate-batch worker error");
                     }
                 }),
             ));

--- a/dwctl/src/webhooks/dispatcher.rs
+++ b/dwctl/src/webhooks/dispatcher.rs
@@ -29,6 +29,7 @@
 //! On shutdown, unprocessed deliveries become re-claimable after the 5-minute
 //! crash safety window.
 
+use crate::metrics::errors::component::WEBHOOK_DISPATCH;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -118,7 +119,7 @@ impl WebhookDispatcher {
         let mut conn = match self.pool.acquire().await {
             Ok(c) => c,
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to acquire connection for retry claims");
+                crate::background_error!(WEBHOOK_DISPATCH, "db_acquire", Warning, error = %e, "Failed to acquire connection for retry claims");
                 return;
             }
         };
@@ -128,7 +129,7 @@ impl WebhookDispatcher {
             match repo.claim_retriable_deliveries(self.claim_batch_size).await {
                 Ok(d) => d,
                 Err(e) => {
-                    tracing::warn!(error = %e, "Failed to claim retriable deliveries");
+                    crate::background_error!(WEBHOOK_DISPATCH, "claim", Warning, error = %e, "Failed to claim retriable deliveries");
                     return;
                 }
             }
@@ -173,7 +174,7 @@ impl WebhookDispatcher {
             let payload_str = match serde_json::to_string(&delivery.payload) {
                 Ok(s) => s,
                 Err(e) => {
-                    tracing::warn!(error = %e, delivery_id = %delivery.id, "Failed to serialize delivery payload, marking exhausted");
+                    crate::background_error!(WEBHOOK_DISPATCH, "payload_serialize", Warning, error = %e, delivery_id = %delivery.id, "Failed to serialize delivery payload, marking exhausted");
                     let mut repo = Webhooks::new(&mut conn);
                     let _ = repo.mark_exhausted(delivery.id).await;
                     continue;
@@ -185,7 +186,7 @@ impl WebhookDispatcher {
             let signature = match signing::sign_payload(&msg_id, timestamp, &payload_str, secret) {
                 Some(s) => s,
                 None => {
-                    tracing::warn!(delivery_id = %delivery.id, "Failed to sign webhook payload");
+                    crate::background_error!(WEBHOOK_DISPATCH, "sign", Warning, delivery_id = %delivery.id, "Failed to sign webhook payload");
                     continue;
                 }
             };
@@ -222,7 +223,7 @@ impl WebhookDispatcher {
         let mut conn = match self.pool.acquire().await {
             Ok(c) => c,
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to acquire connection for result drain");
+                crate::background_error!(WEBHOOK_DISPATCH, "db_acquire", Warning, error = %e, "Failed to acquire connection for result drain");
                 return;
             }
         };
@@ -239,10 +240,10 @@ impl WebhookDispatcher {
                 SendOutcome::Success { status_code } => {
                     counter!("dwctl_webhook_deliveries_total", "outcome" => "success").increment(1);
                     if let Err(e) = repo.mark_delivered(result.delivery_id, status_code as i32).await {
-                        tracing::warn!(error = %e, delivery_id = %result.delivery_id, "Failed to mark delivery as delivered");
+                        crate::background_error!(WEBHOOK_DISPATCH, "mark_delivered", Warning, error = %e, delivery_id = %result.delivery_id, "Failed to mark delivery as delivered");
                     }
                     if let Err(e) = repo.reset_failures(result.webhook_id).await {
-                        tracing::warn!(error = %e, webhook_id = %result.webhook_id, "Failed to reset webhook failures");
+                        crate::background_error!(WEBHOOK_DISPATCH, "reset_failures", Warning, error = %e, webhook_id = %result.webhook_id, "Failed to reset webhook failures");
                     }
                     tracing::debug!(
                         webhook_id = %result.webhook_id,
@@ -263,7 +264,7 @@ impl WebhookDispatcher {
                         )
                         .await
                     {
-                        tracing::warn!(error = %e, delivery_id = %result.delivery_id, "Failed to mark delivery as failed");
+                        crate::background_error!(WEBHOOK_DISPATCH, "mark_failed", Warning, error = %e, delivery_id = %result.delivery_id, "Failed to mark delivery as failed");
                     }
                     // increment_failures returns None if the webhook was deleted
                     // while this delivery was in-flight — not an error.
@@ -276,7 +277,7 @@ impl WebhookDispatcher {
                             );
                         }
                         Err(e) => {
-                            tracing::warn!(error = %e, webhook_id = %result.webhook_id, "Failed to increment webhook failures");
+                            crate::background_error!(WEBHOOK_DISPATCH, "increment_failures", Warning, error = %e, webhook_id = %result.webhook_id, "Failed to increment webhook failures");
                         }
                         Ok(Some(_)) => {}
                     }
@@ -382,7 +383,7 @@ async fn run_sender(
             };
 
             if let Err(e) = tx.send(result).await {
-                tracing::warn!(delivery_id = %request.delivery_id, "Failed to send webhook result back: {}", e);
+                crate::background_error!(WEBHOOK_DISPATCH, "result_send", Warning, delivery_id = %request.delivery_id, "Failed to send webhook result back: {}", e);
             }
         });
     }


### PR DESCRIPTION
# standardise error logs into having metric emissions

  For failures off the request path (background tasks, pollers, daemon loops, sync
  jobs), use `background_error!` instead of a bare `tracing::error!`. It emits the
  log and the `dwctl_background_errors_total` metric together, so failures show up
  on dashboards and alerts instead of being invisible.

## What

Standardises dwctl's background failure logging onto one unified metric,
`dwctl_background_errors_total{component, reason, severity}`, emitted together
with the log by a new `background_error!` macro (`metrics/errors.rs`). One call
site, both signals, no drift. The background subsystems now use it across roughly
90 sites, and the bespoke per-failure counters are removed (no dual-emit).

## The macro and tiers

`background_error!(component, reason, Severity, ...fields, "message")`.
`component`, `reason`, and `severity` are `&'static str` so label cardinality
stays bounded. Severity tiers:

- `Critical`: logs at `error!`, pages (the alert keys on `severity="critical"`).
- `Error`: logs at `error!`, does not page (dashboard / rate input).
- `Warning`: logs at `warn!`, does not page.

Foreground (request-path) failures are intentionally NOT migrated: a route that
returns a 5xx is already counted by `dwctl_http_requests_total{status}`. The
macro is for background / off-request-path failures, plus a few request-path
sites where the failure is swallowed and would otherwise be invisible.

## Removed counters (no dual-emit)

Each becomes a labelled slice of the unified metric:

- `dwctl_auto_topup_charge_failures_total` becomes `...{component="auto_topup", reason="charge"}`
- `dwctl_auto_topup_errors_total` becomes `...{component="auto_topup"}` reasons `idempotency_check` / `payment_method_lookup` / `monthly_spend_fetch` (severity `error`)
- `dwctl_auto_topup_credit_failures_total` becomes `...{component="auto_topup", reason="credit_record"}` (critical)
- `dwctl_usage_extraction_failures_total` becomes `...{component="analytics"}`
- `dwctl_analytics_batch_errors_total` becomes `...{component="analytics_batcher"}`
- `dwctl_analytics_send_errors_total` becomes `...{component="analytics", reason="send_failed"}`
- `dwctl_requests_writer_flush_errors_total` becomes `...{component="responses_writer", reason="flush_drop"}`
- `dwctl_cache_sync_errors_total` becomes `...{component="onwards_sync", reason=~"load_targets.*"}`


## Severity highlights

- Critical (pages): auto_topup `credit_record` / `first_payment_match`,
  `leader_election` invariant_violation, `config_watcher` setup_failed,
  notifications `email_service_init` / `listener_setup`, analytics_batcher
  `write_drop`, batch_populate `populate_failed`.
- auto_topup infra reasons are `Error` so "we needed a top-up but our side could
  not apply it" is alertable separately from routine card declines (`Warning`).
- Probes are observability-only (they do not gate routing), so all
  probe_scheduler failures are `Warning`.

## Foreground hygiene fixes

- `payments` `process_payment`: the server-error branch now emits the unified
  metric (the handler is reachable off the request path too, so a 5xx there is
  not always captured by `dwctl_http_requests_total`). Client-error branch stays
  a plain `warn!`.
- `onwards_sync` fallback sweep uses a distinct `reason="load_targets_fallback"`
  so it stays separable from the LISTEN/NOTIFY path (restores the old `source`
  breakdown).
- Error-classification tidy-ups: `inference_endpoints` alias-conflict split,
  `batches` list `ValidationError` mapping, `organizations` accept-invite logs at
  `warn`, `payments` passes the provider status through instead of hardcoding 500.
