### PR TITLE
chore: bump fusillade to 18.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,9 +2333,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a159b6aaa3c49930fe3688c87821bd49900c88d7981506e0785d484e8d42b38"
+checksum = "960cf97f8e3fc88cc93d6ad918bbb19f90c09fbad4bd09469bce81382870df0d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "18.0.0" }
+fusillade = { version = "18.0.1" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"


### PR DESCRIPTION
Bumps `fusillade` 18.0.0 → 18.0.1 in dwctl.

## What's in 18.0.1
Migration-files-only release (fusillade PR #288): both new claim-path indexes now use `CREATE INDEX IF NOT EXISTS`:
- `idx_requests_pending_claim_pull` (rank-then-pull, batched arms)
- `idx_requests_pending_batchless` (batchless flex/async arms)

This makes the startup migrations idempotent so the indexes can be pre-created **CONCURRENTLY** before a deploy on large tables, without the migration runner crash-looping on `relation "…" already exists` (the staging failure we hit). On a fresh DB it's a plain index create.

## Risk
- **Zero `src/` change** vs 18.0.0 — migration files only — so dwctl compiles identically (verified offline against both crates' `.sqlx` caches: `Finished`, exit 0).
- Lock resolves a **single** `fusillade v18.0.1` (no duplicate 17/18); `onwards 0.31.1` already permits `<19`, so no onwards change needed.

## Deploy note
On prod (large `requests` table), pre-create both indexes CONCURRENTLY and `ANALYZE requests` **before** rolling this image, so the startup migrations are no-ops. See the migration file headers for the exact `CREATE INDEX CONCURRENTLY IF NOT EXISTS` statements.