### PR TITLE
fix(image-normalizer): don't re-sign URLs already in our own store

### DIFF
--- a/dwctl/src/image_normalizer/mod.rs
+++ b/dwctl/src/image_normalizer/mod.rs
@@ -136,6 +136,15 @@ pub trait ImageNormalizer: Send + Sync {
     /// Read bytes for `token` directly. Used by the dashboard image
     /// endpoint (after authorisation).
     async fn read(&self, token: ImageToken) -> Result<(String, Bytes), NormalizeError>;
+
+    /// True if `url` already points at an object in our own store (a URL we
+    /// previously signed). Callers use this to avoid re-ingesting/re-signing
+    /// an already-normalised URL — which would waste a re-fetch and clobber a
+    /// longer upstream TTL (e.g. the batch dispatch TTL) with a shorter one.
+    /// Default `false` preserves prior always-ingest behaviour.
+    fn owns_url(&self, _url: &str) -> bool {
+        false
+    }
 }
 
 /// No-op normaliser used when `config.enabled = false`. Surfaces an error
@@ -221,6 +230,10 @@ impl<S: ImageStore + 'static> ImageNormalizer for DefaultImageNormalizer<S> {
 
     async fn read(&self, token: ImageToken) -> Result<(String, Bytes), NormalizeError> {
         Ok(self.store.read(token).await?)
+    }
+
+    fn owns_url(&self, url: &str) -> bool {
+        self.store.owns_url(url)
     }
 }
 

--- a/dwctl/src/image_normalizer/store.rs
+++ b/dwctl/src/image_normalizer/store.rs
@@ -24,6 +24,7 @@ use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Duration;
+use url::Url;
 
 use super::token::ImageToken;
 
@@ -147,8 +148,22 @@ impl ImageStore for MemoryStore {
     }
 
     fn owns_url(&self, url: &str) -> bool {
-        // We hand out `{base_url}/{hex}?expires=...` URLs.
-        url.starts_with(self.base_url.trim_end_matches('/'))
+        // We hand out `{base_url}/{hex}?expires=...` URLs. Match the parsed
+        // origin (scheme + host + port) exactly and require the candidate path
+        // to extend our base path at a `/` boundary — so neither a different
+        // host nor a sibling prefix (`/dw-img2`, `/dw-img.evil`) can be
+        // mistaken for one of ours.
+        let (Ok(base), Ok(u)) = (Url::parse(&self.base_url), Url::parse(url)) else {
+            return false;
+        };
+        if base.scheme() != u.scheme() || base.host_str() != u.host_str() || base.port_or_known_default() != u.port_or_known_default() {
+            return false;
+        }
+        let prefix = base.path().trim_end_matches('/');
+        match u.path().strip_prefix(prefix) {
+            Some(rest) => rest.is_empty() || rest.starts_with('/'),
+            None => false,
+        }
     }
 }
 
@@ -284,10 +299,18 @@ impl ImageStore for GcsStore {
     }
 
     fn owns_url(&self, url: &str) -> bool {
-        // V4 signed URLs are `https://storage.googleapis.com/{bucket}/images/...`.
-        // Bind to our bucket + the content-addressed `images/` key prefix so an
-        // arbitrary external URL can't be mistaken for one of ours.
-        url.contains("storage.googleapis.com") && url.contains(&format!("/{}/images/", self.bucket))
+        // V4 signed URLs are path-style:
+        // `https://storage.googleapis.com/{bucket}/images/...`. Parse and match
+        // the host *exactly* (so a suffix-spoof like
+        // `storage.googleapis.com.evil.com` is rejected) and look for our
+        // bucket + content-addressed `images/` prefix on the path only (so it
+        // can't be smuggled in via the query string).
+        let Ok(u) = Url::parse(url) else {
+            return false;
+        };
+        u.scheme() == "https"
+            && u.host_str() == Some("storage.googleapis.com")
+            && u.path().starts_with(&format!("/{}/images/", self.bucket))
     }
 }
 
@@ -312,8 +335,9 @@ const S3_MAX_PRESIGN: Duration = Duration::from_secs(7 * 24 * 60 * 60 - 60);
 pub struct S3CompatStore {
     bucket: String,
     /// The configured endpoint (e.g. `https://<acct>.r2.cloudflarestorage.com`),
-    /// trailing slash trimmed. Presigned URLs from this store start with it,
-    /// so it lets us recognise our own signed URLs in [`owns_url`].
+    /// trailing slash trimmed. Parsed in [`owns_url`] to match the host of our
+    /// own presigned URLs — exactly for path-style, or as `{bucket}.{host}` for
+    /// virtual-hosted addressing.
     endpoint: String,
     client: aws_sdk_s3::Client,
 }
@@ -431,11 +455,31 @@ impl ImageStore for S3CompatStore {
     }
 
     fn owns_url(&self, url: &str) -> bool {
-        // Path-style presigned URLs from this store look like
-        // `{endpoint}/{bucket}/images/{hex}/{hex}/{sha}?X-Amz-...`. Bind to
-        // both our endpoint (host) and our bucket + content-addressed key
-        // prefix so an arbitrary external URL can't be mistaken for ours.
-        url.starts_with(&self.endpoint) && url.contains(&format!("/{}/images/", self.bucket))
+        // Presigned URLs from this store are either path-style
+        // (`{endpoint}/{bucket}/images/{hex}/{hex}/{sha}?X-Amz-...`) or, when
+        // `force_path_style` is off, virtual-hosted
+        // (`https://{bucket}.{endpoint-host}/images/...`). Parse both endpoint
+        // and candidate and match the host *exactly* — rejecting suffix-spoofs
+        // like `…r2.cloudflarestorage.com.evil.com` — then look for the
+        // content-addressed `images/` prefix on the path only (never the query).
+        let (Ok(ep), Ok(u)) = (Url::parse(&self.endpoint), Url::parse(url)) else {
+            return false;
+        };
+        if u.scheme() != ep.scheme() {
+            return false;
+        }
+        let (Some(ep_host), Some(u_host)) = (ep.host_str(), u.host_str()) else {
+            return false;
+        };
+        // Path-style: same host[:port], `/{bucket}/images/...`.
+        if u_host == ep_host && u.port_or_known_default() == ep.port_or_known_default() {
+            return u.path().starts_with(&format!("/{}/images/", self.bucket));
+        }
+        // Virtual-hosted: `{bucket}.{endpoint-host}`, `/images/...`.
+        if u_host == format!("{}.{}", self.bucket, ep_host) {
+            return u.path().starts_with("/images/");
+        }
+        false
     }
 }
 
@@ -548,10 +592,35 @@ mod tests {
         // so it still gets normalised rather than forwarded raw.
         let spoofed = format!("https://evil.example.com/images-bucket/images/{}/{}/{}", &hex[..2], &hex[2..4], hex);
         assert!(!s.owns_url(&spoofed));
+        // Host suffix-spoof: our endpoint host as a *prefix* of an
+        // attacker-controlled host must not match (exact-host parsing).
+        assert!(!s.owns_url("https://acct.r2.cloudflarestorage.com.evil.com/images-bucket/images/ab/cd/abcd"));
+        // The owned key prefix smuggled into the query string, on a foreign
+        // host → not ours (we only inspect the parsed path).
+        assert!(!s.owns_url("https://evil.example.com/x?next=/images-bucket/images/ab/cd/abcd"));
         // Arbitrary external image URL → not ours.
         assert!(!s.owns_url("https://example.com/cat.png"));
         // A data: URI is never ours.
         assert!(!s.owns_url("data:image/png;base64,AAAA"));
+    }
+
+    #[test]
+    fn s3_owns_url_matches_virtual_hosted_urls() {
+        // With `force_path_style = false`, presigned URLs are virtual-hosted:
+        // `https://{bucket}.{endpoint-host}/images/...`.
+        let s = S3CompatStore::new(
+            "images-bucket",
+            "https://acct.r2.cloudflarestorage.com",
+            "auto",
+            false,
+            "AKIDEXAMPLE",
+            "secret",
+        );
+        assert!(s.owns_url("https://images-bucket.acct.r2.cloudflarestorage.com/images/ab/cd/abcd?X-Amz-Signature=deadbeef"));
+        // A different bucket label on the host → not ours.
+        assert!(!s.owns_url("https://other.acct.r2.cloudflarestorage.com/images/ab/cd/abcd"));
+        // Bucket as a suffix-spoof of an external host → not ours.
+        assert!(!s.owns_url("https://images-bucket.acct.r2.cloudflarestorage.com.evil.com/images/ab/cd/abcd"));
     }
 
     #[test]
@@ -573,6 +642,14 @@ mod tests {
         let s = MemoryStore::new().with_base_url("http://test.local/img");
         assert!(s.owns_url("http://test.local/img/abcd?expires=123"));
         assert!(!s.owns_url("https://example.com/cat.png"));
+        // Sibling prefixes sharing the leading characters must NOT match —
+        // the path has to extend `/img` at a `/` boundary.
+        assert!(!s.owns_url("http://test.local/img2/abcd"));
+        assert!(!s.owns_url("http://test.local/img.evil/abcd"));
+        // Same host + path but a different scheme → not ours.
+        assert!(!s.owns_url("https://test.local/img/abcd"));
+        // Same path on a different host → not ours.
+        assert!(!s.owns_url("http://evil.test/img/abcd"));
     }
 
     #[test]
@@ -581,6 +658,13 @@ mod tests {
         assert!(s.owns_url("https://storage.googleapis.com/images-bucket/images/ab/cd/abcd?X-Goog-Signature=x"));
         assert!(!s.owns_url("https://storage.googleapis.com/other-bucket/images/ab/cd/abcd"));
         assert!(!s.owns_url("https://example.com/cat.png"));
+        // Host suffix-spoof: `storage.googleapis.com` as a prefix of an
+        // attacker host must not match (exact-host parsing).
+        assert!(!s.owns_url("https://storage.googleapis.com.evil.com/images-bucket/images/ab/cd/abcd"));
+        // Our key prefix smuggled into the query on a foreign host → not ours.
+        assert!(!s.owns_url("https://evil.example.com/x?u=/images-bucket/images/ab/cd/abcd"));
+        // Plain http (signed URLs are always https) → not ours.
+        assert!(!s.owns_url("http://storage.googleapis.com/images-bucket/images/ab/cd/abcd"));
     }
 
     #[tokio::test]

--- a/dwctl/src/image_normalizer/store.rs
+++ b/dwctl/src/image_normalizer/store.rs
@@ -64,6 +64,18 @@ pub trait ImageStore: Send + Sync {
     /// True if an object with this token already exists. Cheap check used
     /// by the ingest path to skip uploads on dedup hits.
     async fn exists(&self, token: ImageToken) -> Result<bool, StoreError>;
+
+    /// True if `url` already points at an object in THIS store — i.e. a URL
+    /// we previously signed. Used to avoid re-ingesting and re-signing our
+    /// own signed URLs: doing so would (a) waste a round-trip re-fetching an
+    /// image we already host and (b) clobber a longer upstream TTL (e.g. the
+    /// batch dispatch TTL) with whatever TTL the re-signing path uses.
+    ///
+    /// Default `false` (treat nothing as ours, always ingest) preserves the
+    /// prior behaviour for backends that don't override it.
+    fn owns_url(&self, _url: &str) -> bool {
+        false
+    }
 }
 
 // ============================ MemoryStore =================================
@@ -132,6 +144,11 @@ impl ImageStore for MemoryStore {
     async fn exists(&self, token: ImageToken) -> Result<bool, StoreError> {
         let map = self.inner.lock().expect("MemoryStore mutex poisoned");
         Ok(map.contains_key(&token))
+    }
+
+    fn owns_url(&self, url: &str) -> bool {
+        // We hand out `{base_url}/{hex}?expires=...` URLs.
+        url.starts_with(self.base_url.trim_end_matches('/'))
     }
 }
 
@@ -265,6 +282,13 @@ impl ImageStore for GcsStore {
             },
         }
     }
+
+    fn owns_url(&self, url: &str) -> bool {
+        // V4 signed URLs are `https://storage.googleapis.com/{bucket}/images/...`.
+        // Bind to our bucket + the content-addressed `images/` key prefix so an
+        // arbitrary external URL can't be mistaken for one of ours.
+        url.contains("storage.googleapis.com") && url.contains(&format!("/{}/images/", self.bucket))
+    }
 }
 
 // ========================== S3CompatStore =================================
@@ -287,6 +311,10 @@ const S3_MAX_PRESIGN: Duration = Duration::from_secs(7 * 24 * 60 * 60 - 60);
 /// so it is created eagerly in [`S3CompatStore::new`].
 pub struct S3CompatStore {
     bucket: String,
+    /// The configured endpoint (e.g. `https://<acct>.r2.cloudflarestorage.com`),
+    /// trailing slash trimmed. Presigned URLs from this store start with it,
+    /// so it lets us recognise our own signed URLs in [`owns_url`].
+    endpoint: String,
     client: aws_sdk_s3::Client,
 }
 
@@ -301,15 +329,17 @@ impl S3CompatStore {
     ) -> Self {
         let creds =
             aws_credential_types::Credentials::new(access_key_id.into(), secret_access_key.into(), None, None, "dwctl-image-normalizer");
+        let endpoint = endpoint_url.into();
         let s3_config = aws_sdk_s3::config::Builder::new()
             .region(aws_sdk_s3::config::Region::new(region.into()))
             .credentials_provider(creds)
-            .endpoint_url(endpoint_url.into())
+            .endpoint_url(endpoint.clone())
             .force_path_style(force_path_style)
             .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
             .build();
         Self {
             bucket: bucket.into(),
+            endpoint: endpoint.trim_end_matches('/').to_string(),
             client: aws_sdk_s3::Client::from_conf(s3_config),
         }
     }
@@ -399,6 +429,14 @@ impl ImageStore for S3CompatStore {
             }
         }
     }
+
+    fn owns_url(&self, url: &str) -> bool {
+        // Path-style presigned URLs from this store look like
+        // `{endpoint}/{bucket}/images/{hex}/{hex}/{sha}?X-Amz-...`. Bind to
+        // both our endpoint (host) and our bucket + content-addressed key
+        // prefix so an arbitrary external URL can't be mistaken for ours.
+        url.starts_with(&self.endpoint) && url.contains(&format!("/{}/images/", self.bucket))
+    }
 }
 
 #[cfg(test)]
@@ -485,6 +523,64 @@ mod tests {
             "secret",
         );
         assert_eq!(s.bucket, "imgs");
+    }
+
+    #[test]
+    fn s3_owns_url_matches_own_presigned_urls_only() {
+        let s = S3CompatStore::new(
+            "images-bucket",
+            "https://acct.r2.cloudflarestorage.com",
+            "auto",
+            true,
+            "AKIDEXAMPLE",
+            "secret",
+        );
+        let hex = tok(0xab).to_hex();
+        // Our own path-style presigned URL → owned.
+        let ours = format!(
+            "https://acct.r2.cloudflarestorage.com/images-bucket/images/{}/{}/{}?x-id=GetObject&X-Amz-Signature=deadbeef",
+            &hex[..2],
+            &hex[2..4],
+            hex
+        );
+        assert!(s.owns_url(&ours));
+        // Same bucket+key path but a DIFFERENT (external) host → not ours,
+        // so it still gets normalised rather than forwarded raw.
+        let spoofed = format!("https://evil.example.com/images-bucket/images/{}/{}/{}", &hex[..2], &hex[2..4], hex);
+        assert!(!s.owns_url(&spoofed));
+        // Arbitrary external image URL → not ours.
+        assert!(!s.owns_url("https://example.com/cat.png"));
+        // A data: URI is never ours.
+        assert!(!s.owns_url("data:image/png;base64,AAAA"));
+    }
+
+    #[test]
+    fn s3_owns_url_endpoint_trailing_slash_trimmed() {
+        let s = S3CompatStore::new(
+            "imgs",
+            "https://acct.r2.cloudflarestorage.com/",
+            "auto",
+            true,
+            "AKIDEXAMPLE",
+            "secret",
+        );
+        assert_eq!(s.endpoint, "https://acct.r2.cloudflarestorage.com");
+        assert!(s.owns_url("https://acct.r2.cloudflarestorage.com/imgs/images/ab/cd/abcd"));
+    }
+
+    #[test]
+    fn memory_store_owns_url() {
+        let s = MemoryStore::new().with_base_url("http://test.local/img");
+        assert!(s.owns_url("http://test.local/img/abcd?expires=123"));
+        assert!(!s.owns_url("https://example.com/cat.png"));
+    }
+
+    #[test]
+    fn gcs_owns_url_matches_bucket_and_key_prefix() {
+        let s = GcsStore::new("images-bucket", "europe-west4");
+        assert!(s.owns_url("https://storage.googleapis.com/images-bucket/images/ab/cd/abcd?X-Goog-Signature=x"));
+        assert!(!s.owns_url("https://storage.googleapis.com/other-bucket/images/ab/cd/abcd"));
+        assert!(!s.owns_url("https://example.com/cat.png"));
     }
 
     #[tokio::test]

--- a/dwctl/src/responses/image_normalizer_middleware.rs
+++ b/dwctl/src/responses/image_normalizer_middleware.rs
@@ -155,6 +155,16 @@ pub async fn image_normalizer_middleware(
         let pool_for_access = pool_for_access.clone();
         let is_data_uri = url.starts_with("data:");
         async move {
+            // Pass through URLs that already point at our own normalised
+            // store. These were signed upstream (e.g. by the batch dispatch
+            // JIT-signing path, which uses the long dispatch TTL). Re-ingesting
+            // and re-signing here would (a) waste a round-trip re-fetching an
+            // image we already host and (b) clobber that longer TTL with the
+            // shorter realtime TTL — which is what caused batch image fetches
+            // to 403 on expired URLs when the worker was backlogged.
+            if !is_data_uri && normalizer.owns_url(&url) {
+                return Ok::<String, NormalizeError>(url);
+            }
             let input = if is_data_uri {
                 ImageInput::DataUri(url)
             } else {
@@ -389,6 +399,38 @@ mod tests {
         assert!(
             substituted.starts_with("http://test.local/dw-img/"),
             "expected MemoryStore-backed signed URL, got: {substituted}",
+        );
+    }
+
+    #[tokio::test]
+    async fn passes_through_url_already_in_our_store_unchanged() {
+        // Regression: a request whose image_url already points at our own
+        // normalised store (e.g. signed upstream by the batch dispatch path
+        // with the long dispatch TTL) must be forwarded UNCHANGED. Re-ingesting
+        // + re-signing here would clobber the upstream TTL with the shorter
+        // realtime TTL — the root cause of batch image fetches 403-ing on
+        // expired URLs. With MemoryStore, our own URLs start with the base_url.
+        let already_ours = "http://test.local/dw-img/abcdef0123456789?expires=9999999999";
+        let router = build_router(state_for_tests());
+        let (status, echoed) = post_json(
+            router,
+            "/chat/completions",
+            json!({
+                "model": "vision",
+                "messages": [{
+                    "role": "user",
+                    "content": [{ "type": "image_url", "image_url": { "url": already_ours } }]
+                }]
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let forwarded = echoed["messages"][0]["content"][0]["image_url"]["url"]
+            .as_str()
+            .expect("image_url.url should still be a string");
+        assert_eq!(
+            forwarded, already_ours,
+            "a URL already in our store must pass through unchanged (no re-sign / TTL clobber)"
         );
     }
 


### PR DESCRIPTION
## Problem

When image-input normalization is enabled, the realtime `image_normalizer_middleware` runs in `Mode::All`, which matches `http(s)` image URLs.

Requests dispatched through the batch path have already had their `dw-img://` tokens resolved to signed object-store URLs by the dispatch-time JIT signer, which uses the **dispatch TTL** (derived from the processing timeout plus headroom, so a signed URL always outlives a dispatch attempt).

Because those already-signed URLs are plain `https://…` URLs, the realtime middleware treated them as fresh external inputs: it **re-ingested and re-signed them with the much shorter realtime TTL**. The net effect was that batch-dispatched image URLs reached the upstream model carrying the realtime TTL instead of the intended dispatch TTL.

If the upstream worker doesn't fetch the image promptly — for example when it is backlogged — the short-lived URL can expire before the fetch, and the object store responds `403 Forbidden`. This surfaces as an image-loading failure in the worker and a failed request.

## Fix

Teach the store to recognise **its own** signed URLs and have the realtime middleware pass them through unchanged instead of re-ingesting and re-signing:

- `ImageStore::owns_url(&str) -> bool` (default `false`), implemented for the S3-compatible, GCS, and in-memory backends.
- Exposed via `ImageNormalizer::owns_url`, delegating to the store.
- The middleware's substitute closure now skips (forwards unchanged) any non-`data:` URL for which `owns_url` is true.

This preserves the upstream (dispatch) TTL and avoids a redundant re-fetch of an image we already host. Genuine external / `data:` image inputs are unaffected and still normalized as before.

`owns_url` is **host- and bucket-bound** (S3/GCS: endpoint or host plus the `/{bucket}/images/` key prefix; in-memory: the configured base URL), so an external URL that merely mimics the content-addressed key path is **not** mistaken for one of ours.

## Tests

- `store.rs`: `owns_url` for the S3-compatible backend (including a spoofed-external-host negative and trailing-slash endpoint handling), GCS, and in-memory.
- `image_normalizer_middleware.rs`: regression test asserting a URL already in the store is forwarded **unchanged** (no re-sign / TTL change).

> The wider `dwctl` crate requires a database for its `sqlx` query macros to compile; the change here is confined to the database-free `image_normalizer` module and middleware, so the added tests are exercised by CI.

## Possible follow-ups
- Consider deriving the batch dispatch URL TTL from the batch completion window rather than the per-attempt processing timeout, so very long-queued batches cannot expire their URLs even when correctly signed once.
- A worker that holds a request far longer than the per-attempt timeout (e.g. while recovering from a restart) can still outlive even a correctly-sized URL; capping per-request image count/size and ensuring adequate worker memory reduces that risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)