### PR TITLE
fix: bump fusillade to 18.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,9 +2333,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "18.0.1"
+version = "18.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960cf97f8e3fc88cc93d6ad918bbb19f90c09fbad4bd09469bce81382870df0d"
+checksum = "bd3868ec40891b50efee32ac38298dae5c2012600c6e08e837ddc294c78ee75c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "18.0.1" }
+fusillade = { version = "18.0.2" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"


### PR DESCRIPTION
## Summary

Bumps `fusillade` from **18.0.1 → 18.0.2** to pull in the `populate_batch` idempotency fix from [doublewordai/fusillade#280](https://github.com/doublewordai/fusillade/pull/280).

## Why

`underway` delivers the create-batch job **at-least-once**: on a heartbeat-expiry reclaim the populate step can run twice. Before 18.0.2 `populate_batch` was not idempotent — a re-delivery double-inserted request rows (`INSERT … SELECT FROM request_templates`) while `total_requests` kept the first run's value. That permanently wedges the batch in `finalizing`: `terminal_count = completed + failed + canceled` (e.g. 8368) can never equal `total_requests` (e.g. 4184), so the batch never flips to `completed` and the output file never finalizes. In prod this hit 2 of 43,645 batches.

18.0.2 adds two cheap guards in `populate_batch` (neither reads/locks the hot `requests` table):
- a transaction-scoped advisory lock keyed on the batch id, serializing concurrent populates of the same batch;
- an idempotency guard on `batches.requests_started_at` (set in the same transaction as the INSERT) so a committed prior population is a no-op while a rolled-back failed attempt still repopulates.

This is `fix:` (not `chore:`) intentionally — it carries a production bug fix and should ride the release pipeline to prod.

## Changes

- `dwctl/Cargo.toml`: `fusillade = "18.0.1"` → `"18.0.2"`
- `Cargo.lock`: regenerated

No control-layer code or migration changes (18.0.1 → 18.0.2 is a patch with an internal-only SQL change; fusillade's migrator is unchanged).

## Verification

- `cargo check --workspace` (offline) — compiles
- `cargo clippy --workspace` (lib) — clean
- `cargo test -p dwctl batch` — **118 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)