### PR TITLE
feat(responses): fetch and inline input_file file_url for document inputs

### DIFF
--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -200,6 +200,13 @@ pub struct Config {
     /// shape and defaults.
     #[serde(default)]
     pub image_normalizer: crate::image_normalizer::ImageNormalizerConfig,
+    /// `input_file` (PDF / document) handling for `/v1/responses`. When
+    /// enabled, an `input_file.file_url` is fetched through the hardened
+    /// fetcher and inlined as base64 `file_data` before forwarding, so it
+    /// survives the strict Responses-to-Chat-Completions conversion. See
+    /// `crate::file_input` for the full shape and defaults.
+    #[serde(default)]
+    pub file_input: crate::file_input::FileInputConfig,
     /// OpenAPI spec exposure controls. Defaults disable the Admin spec
     /// (which describes internal management endpoints) and enable the
     /// AI spec (which mirrors the publicly-documented OpenAI surface).
@@ -1968,6 +1975,7 @@ impl Default for Config {
             connections: ConnectionsConfig::default(),
             responses: ResponsesConfig::default(),
             image_normalizer: crate::image_normalizer::ImageNormalizerConfig::default(),
+            file_input: crate::file_input::FileInputConfig::default(),
             openapi: OpenApiConfig::default(),
         }
     }

--- a/dwctl/src/db/handlers/api_keys.rs
+++ b/dwctl/src/db/handlers/api_keys.rs
@@ -2068,6 +2068,7 @@ mod tests {
             connections: Default::default(),
             responses: Default::default(),
             image_normalizer: Default::default(),
+            file_input: Default::default(),
             openapi: Default::default(),
         };
         crate::seed_database(&config.model_sources, &pool).await.unwrap();

--- a/dwctl/src/file_input/mod.rs
+++ b/dwctl/src/file_input/mod.rs
@@ -1,0 +1,231 @@
+//! Normalisation of Responses `input_file` content (PDF / document inputs).
+//!
+//! The OpenAI-compatible Chat Completions `file` content part can only carry
+//! inline bytes (`file_data`) or a provider-owned `file_id` - it has no URL
+//! form (unlike `image_url`). So an `input_file` submitted to `/v1/responses`
+//! with a `file_url` cannot survive the Responses-to-Chat-Completions
+//! conversion as a URL: the bytes have to be fetched and inlined first.
+//!
+//! This module rewrites each `input_file` content part in a Responses request
+//! body before it reaches onwards:
+//!
+//! - `file_url` -> fetch through the hardened [`ImageFetcher`] (the same
+//!   SSRF-protected fetcher used for image URLs: DNS pinning, IP deny-list,
+//!   redirect re-validation, MIME / size caps) and inline the bytes as a
+//!   base64 `file_data` data URI, dropping `file_url`.
+//! - `file_data` -> left untouched; onwards already maps it to a Chat
+//!   Completions `file` part.
+//! - `file_id` (with no `file_data`) -> rejected. dwctl customers never upload
+//!   to the upstream provider, so a bare `file_id` always refers to dwctl's own
+//!   file store, which is not yet wired to resolve Responses inputs. Returning
+//!   a clear error beats forwarding an id the provider can never resolve.
+//!
+//! The fetch is injected as a callback (mirroring
+//! [`crate::image_normalizer::walker::substitute_with`]) so the rewrite logic
+//! can be tested without a live fetch and the middleware can supply the real
+//! hardened fetcher.
+use std::future::Future;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::image_normalizer::NormalizeError;
+use crate::image_normalizer::config::FetcherConfig;
+
+/// Configuration for `input_file` normalisation.
+///
+/// Default = disabled. Enabling it lets dwctl make outbound fetches to
+/// user-supplied `file_url`s (through the hardened fetcher), so it is opt-in,
+/// mirroring the image normaliser. When disabled, an `input_file.file_url`
+/// flows to onwards untouched and onwards returns a clear error in strict mode
+/// rather than silently dropping it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileInputConfig {
+    /// Master switch for `file_url` fetch-and-inline.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Hardened-fetcher policy. Defaults to a document MIME allow-list.
+    #[serde(default = "default_file_fetcher")]
+    pub fetcher: FetcherConfig,
+}
+
+impl Default for FileInputConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            fetcher: default_file_fetcher(),
+        }
+    }
+}
+
+/// The image fetcher's defaults are sound for documents too (size cap,
+/// timeouts, redirect re-validation, IP deny-list); only the accepted MIME
+/// types differ.
+fn default_file_fetcher() -> FetcherConfig {
+    FetcherConfig {
+        allowed_mime: vec!["application/pdf".to_string()],
+        ..FetcherConfig::default()
+    }
+}
+
+/// Rewrite every `input_file` content part in a Responses request `body`,
+/// fetching+inlining `file_url`s and rejecting unresolvable references.
+///
+/// `fetch` is handed each `file_url` and must return the resolved
+/// `(mime, bytes)`; it carries the SSRF-hardened fetch in production.
+/// Returns the number of parts rewritten. Substitutions run sequentially in
+/// document order; the first error stops the walk.
+pub async fn normalize_input_files<F, Fut>(body: &mut Value, mut fetch: F) -> Result<usize, NormalizeError>
+where
+    F: FnMut(String) -> Fut,
+    Fut: Future<Output = Result<(String, Bytes), NormalizeError>>,
+{
+    // Responses shape: input[*].content[*] with `type == "input_file"`.
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+        return Ok(0);
+    };
+    let mut count = 0usize;
+    for item in input {
+        let Some(content) = item.get_mut("content").and_then(Value::as_array_mut) else {
+            continue;
+        };
+        for part in content {
+            if part.get("type").and_then(Value::as_str) != Some("input_file") {
+                continue;
+            }
+            // Already-inline bytes: onwards maps these straight to a file part.
+            if part.get("file_data").and_then(Value::as_str).is_some() {
+                continue;
+            }
+            // A URL we can fetch and inline.
+            if let Some(url) = part.get("file_url").and_then(Value::as_str).map(str::to_string) {
+                let (mime, bytes) = fetch(url).await?;
+                let data_uri = format!("data:{};base64,{}", mime, B64.encode(&bytes));
+                let obj = part.as_object_mut().expect("input_file content part is an object");
+                obj.remove("file_url");
+                obj.insert("file_data".to_string(), Value::String(data_uri));
+                count += 1;
+                continue;
+            }
+            // A bare dwctl-owned file_id we cannot resolve yet.
+            if part.get("file_id").and_then(Value::as_str).is_some() {
+                return Err(NormalizeError::BadInput(
+                    "input_file.file_id is not supported yet; send the document inline via \
+                     file_data or as a fetchable file_url"
+                        .to_string(),
+                ));
+            }
+            // Nothing usable on the part at all.
+            return Err(NormalizeError::BadInput(
+                "input_file must include one of file_data, file_url, or file_id".to_string(),
+            ));
+        }
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image_normalizer::fetcher::ImageFetcher;
+    use serde_json::json;
+
+    /// A stub fetch returning fixed bytes; asserts the walker never reaches the
+    /// network for the cases that shouldn't fetch.
+    fn fake_pdf(_url: String) -> impl Future<Output = Result<(String, Bytes), NormalizeError>> {
+        async { Ok(("application/pdf".to_string(), Bytes::from_static(b"%PDF-1.4 fake"))) }
+    }
+
+    fn responses_body_with(part: Value) -> Value {
+        json!({
+            "model": "doc-qa",
+            "input": [{
+                "role": "user",
+                "content": [
+                    { "type": "input_text", "text": "summarise" },
+                    part
+                ]
+            }]
+        })
+    }
+
+    #[tokio::test]
+    async fn fetches_file_url_and_inlines_as_base64_file_data() {
+        let mut body = responses_body_with(json!({
+            "type": "input_file",
+            "filename": "doc.pdf",
+            "file_url": "https://example.com/doc.pdf"
+        }));
+
+        let n = normalize_input_files(&mut body, fake_pdf).await.unwrap();
+        assert_eq!(n, 1);
+
+        let part = &body["input"][0]["content"][1];
+        assert!(part.get("file_url").is_none(), "file_url should be dropped");
+        let data = part["file_data"].as_str().expect("file_data should be set");
+        assert_eq!(data, format!("data:application/pdf;base64,{}", B64.encode(b"%PDF-1.4 fake")));
+        assert_eq!(part["filename"], "doc.pdf", "filename preserved");
+    }
+
+    #[tokio::test]
+    async fn file_data_passes_through_untouched_and_does_not_fetch() {
+        let mut body = responses_body_with(json!({
+            "type": "input_file",
+            "filename": "doc.pdf",
+            "file_data": "data:application/pdf;base64,QUJD"
+        }));
+        let n = normalize_input_files(&mut body, |_| async { panic!("must not fetch when file_data is already present") })
+            .await
+            .unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(body["input"][0]["content"][1]["file_data"], "data:application/pdf;base64,QUJD");
+    }
+
+    #[tokio::test]
+    async fn bare_file_id_is_rejected() {
+        let mut body = responses_body_with(json!({
+            "type": "input_file",
+            "file_id": "file-abc123"
+        }));
+        let err = normalize_input_files(&mut body, fake_pdf).await.unwrap_err();
+        assert!(
+            matches!(err, NormalizeError::BadInput(ref m) if m.contains("file_id")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_input_file_is_a_noop() {
+        let mut body = json!({
+            "model": "doc-qa",
+            "input": [{ "role": "user", "content": [{ "type": "input_text", "text": "hi" }] }]
+        });
+        let n = normalize_input_files(&mut body, fake_pdf).await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn link_local_file_url_is_rejected_by_real_ssrf_guard() {
+        // Drive the actual hardened fetcher: the IP deny-list must reject the
+        // cloud-metadata address before any bytes are inlined.
+        let fetcher = ImageFetcher::new(FetcherConfig {
+            allowed_mime: vec!["application/pdf".to_string()],
+            ..FetcherConfig::default()
+        });
+        let mut body = responses_body_with(json!({
+            "type": "input_file",
+            "file_url": "http://169.254.169.254/latest/meta-data/"
+        }));
+        let err = normalize_input_files(&mut body, |url| {
+            let fetcher = fetcher.clone();
+            async move { fetcher.fetch(&url).await.map(|f| (f.mime, f.bytes)).map_err(Into::into) }
+        })
+        .await
+        .unwrap_err();
+        assert!(matches!(err, NormalizeError::BadInput(_)), "unexpected error: {err}");
+    }
+}

--- a/dwctl/src/file_input/mod.rs
+++ b/dwctl/src/file_input/mod.rs
@@ -34,6 +34,7 @@ use serde_json::Value;
 
 use crate::image_normalizer::NormalizeError;
 use crate::image_normalizer::config::FetcherConfig;
+use crate::image_normalizer::fetcher::ImageFetcher;
 
 /// Configuration for `input_file` normalisation.
 ///
@@ -65,6 +66,13 @@ impl Default for FileInputConfig {
 /// The image fetcher's defaults are sound for documents too (size cap,
 /// timeouts, redirect re-validation, IP deny-list); only the accepted MIME
 /// types differ.
+///
+/// Only `application/pdf` is allowed by default: PDF is the dominant document
+/// input and the one with broad upstream model support, so we start narrow and
+/// let operators widen `allowed_mime` (e.g. for text/csv/docx) when their
+/// upstream actually accepts those types. Note the fetched bytes are inlined as
+/// base64, inflating the on-wire body by ~33%, so operators enabling this
+/// should keep `max_bytes` aligned with their upstream request-size limits.
 fn default_file_fetcher() -> FetcherConfig {
     FetcherConfig {
         allowed_mime: vec!["application/pdf".to_string()],
@@ -105,7 +113,9 @@ where
             if let Some(url) = part.get("file_url").and_then(Value::as_str).map(str::to_string) {
                 let (mime, bytes) = fetch(url).await?;
                 let data_uri = format!("data:{};base64,{}", mime, B64.encode(&bytes));
-                let obj = part.as_object_mut().expect("input_file content part is an object");
+                let obj = part
+                    .as_object_mut()
+                    .ok_or_else(|| NormalizeError::BadInput("input_file content part is not a JSON object".to_string()))?;
                 obj.remove("file_url");
                 obj.insert("file_data".to_string(), Value::String(data_uri));
                 count += 1;
@@ -126,6 +136,23 @@ where
         }
     }
     Ok(count)
+}
+
+/// Run [`normalize_input_files`] using the hardened [`ImageFetcher`] to fetch
+/// each `file_url`. Shared by the realtime `file_input` layer and the
+/// warm-path / flex normalisation in `responses_middleware`.
+pub async fn normalize_input_files_with_fetcher(body: &mut Value, fetcher: &ImageFetcher) -> Result<usize, NormalizeError> {
+    normalize_input_files(body, |url| {
+        let fetcher = fetcher.clone();
+        async move {
+            fetcher
+                .fetch(&url)
+                .await
+                .map(|fetched| (fetched.mime, fetched.bytes))
+                .map_err(NormalizeError::from)
+        }
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/dwctl/src/inference/engine/transition.rs
+++ b/dwctl/src/inference/engine/transition.rs
@@ -318,11 +318,12 @@ fn translate_message_content(content: &Value) -> Value {
 
 /// Map one Open Responses content part to its chat-completions equivalent.
 ///
-/// Returns `None` for parts with no chat-completions representation
-/// (`input_file`, unknown types); these are dropped with a trace rather than
-/// forwarded, since the upstream schema would reject them. Already
-/// chat-shaped parts (`text`, `image_url`) pass through unchanged so a client
-/// that sent chat-completions content directly still works.
+/// Returns `None` for parts with no chat-completions representation (unknown
+/// types, or an `input_file` carrying only a `file_url` that was never
+/// inlined); these are dropped with a trace rather than forwarded, since the
+/// upstream schema would reject them. Already chat-shaped parts (`text`,
+/// `image_url`) pass through unchanged so a client that sent chat-completions
+/// content directly still works.
 fn translate_content_part(part: &Value) -> Option<Value> {
     match part.get("type").and_then(|t| t.as_str()) {
         Some("input_text") | Some("output_text") => {
@@ -347,8 +348,28 @@ fn translate_content_part(part: &Value) -> Option<Value> {
         // Already chat-completions-shaped — forward unchanged.
         Some("text") | Some("image_url") => Some(part.clone()),
         Some("input_file") => {
-            tracing::debug!("dropping 'input_file' content part during /v1/responses translation");
-            None
+            // Map to the Chat Completions `file` content part, which carries
+            // `file_data` (base64) or `file_id`. `file_url` has no chat
+            // representation; by this point the file_input middleware should
+            // have inlined it, so an `input_file` left with only a url (e.g.
+            // the feature is disabled) is dropped with a trace.
+            let file_data = part.get("file_data").and_then(|v| v.as_str());
+            let file_id = part.get("file_id").and_then(|v| v.as_str());
+            if file_data.is_none() && file_id.is_none() {
+                tracing::debug!("dropping 'input_file' with no file_data/file_id during /v1/responses translation");
+                return None;
+            }
+            let mut file = serde_json::Map::new();
+            if let Some(data) = file_data {
+                file.insert("file_data".to_string(), json!(data));
+            }
+            if let Some(id) = file_id {
+                file.insert("file_id".to_string(), json!(id));
+            }
+            if let Some(filename) = part.get("filename").and_then(|v| v.as_str()) {
+                file.insert("filename".to_string(), json!(filename));
+            }
+            Some(json!({"type": "file", "file": Value::Object(file)}))
         }
         other => {
             tracing::warn!(part_type = ?other, "dropping unknown content part during /v1/responses translation");
@@ -878,22 +899,45 @@ mod tests {
 
     #[test]
     fn mixed_content_parts_keep_representable_drop_rest() {
-        // input_file has no chat-completions representation; it is dropped
-        // while the representable input_text part is kept.
+        // input_text is kept as text, input_file with a file_id maps to a chat
+        // `file` part, and a genuinely unrepresentable future type is dropped.
         let body = r#"{
             "model": "m",
             "input": [
                 {"type":"message","role":"user","content":[
                     {"type":"input_text","text":"keep me"},
-                    {"type":"input_file","file_id":"f1"}
+                    {"type":"input_file","file_id":"f1","filename":"doc.pdf"},
+                    {"type":"some_future_type","blob":"x"}
+                ]}
+            ]
+        }"#;
+        let p = parse_parent_request(body).unwrap();
+        let parts = p.initial_messages[0]["content"].as_array().unwrap();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[0]["text"], "keep me");
+        assert_eq!(parts[1]["type"], "file");
+        assert_eq!(parts[1]["file"]["file_id"], "f1");
+        assert_eq!(parts[1]["file"]["filename"], "doc.pdf");
+    }
+
+    #[test]
+    fn input_file_with_file_data_maps_to_chat_file_part() {
+        // The common case after file_input normalisation: file_url has been
+        // inlined as base64 file_data, which maps straight to a chat file part.
+        let body = r#"{
+            "model": "m",
+            "input": [
+                {"type":"message","role":"user","content":[
+                    {"type":"input_file","file_data":"data:application/pdf;base64,QUJD"}
                 ]}
             ]
         }"#;
         let p = parse_parent_request(body).unwrap();
         let parts = p.initial_messages[0]["content"].as_array().unwrap();
         assert_eq!(parts.len(), 1);
-        assert_eq!(parts[0]["type"], "text");
-        assert_eq!(parts[0]["text"], "keep me");
+        assert_eq!(parts[0]["type"], "file");
+        assert_eq!(parts[0]["file"]["file_data"], "data:application/pdf;base64,QUJD");
     }
 
     #[test]
@@ -905,11 +949,13 @@ mod tests {
             "model": "m",
             "input": [
                 {"type":"message","role":"user","content":[
-                    {"type":"input_file","file_id":"f1"},
+                    {"type":"input_file","file_url":"https://x/y.pdf"},
                     {"type":"some_future_type","blob":"x"}
                 ]}
             ]
         }"#;
+        // input_file with only a (non-inlined) file_url has no chat
+        // representation and is dropped, as is the unknown type.
         let p = parse_parent_request(body).unwrap();
         assert_eq!(p.initial_messages[0]["content"], "");
     }

--- a/dwctl/src/inference/file_input_middleware.rs
+++ b/dwctl/src/inference/file_input_middleware.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 use std::sync::Arc;
 use tracing::{debug, warn};
 
-use crate::file_input::normalize_input_files;
+use crate::file_input::normalize_input_files_with_fetcher;
 use crate::image_normalizer::NormalizeError;
 use crate::image_normalizer::fetcher::ImageFetcher;
 
@@ -84,20 +84,7 @@ pub async fn file_input_middleware(State(state): State<FileInputMiddlewareState>
         }
     };
 
-    let fetcher = state.fetcher.clone();
-    let result = normalize_input_files(&mut body_value, |url| {
-        let fetcher = fetcher.clone();
-        async move {
-            fetcher
-                .fetch(&url)
-                .await
-                .map(|fetched| (fetched.mime, fetched.bytes))
-                .map_err(NormalizeError::from)
-        }
-    })
-    .await;
-
-    let substituted = match result {
+    let substituted = match normalize_input_files_with_fetcher(&mut body_value, &state.fetcher).await {
         Ok(n) => n,
         Err(e) => {
             warn!(error = %e, "input_file normalisation failed");
@@ -140,7 +127,7 @@ pub async fn file_input_middleware(State(state): State<FileInputMiddlewareState>
 /// File-specific codes/messages so the document case is self-diagnosing (the
 /// shared `NormalizeError` Display text is image-oriented, so we build our own
 /// message from the inner detail).
-fn file_input_error_response(err: NormalizeError) -> Response {
+pub(crate) fn file_input_error_response(err: NormalizeError) -> Response {
     let (status, code, message) = match err {
         NormalizeError::BadInput(m) => (StatusCode::BAD_REQUEST, "input_file_rejected", m),
         NormalizeError::Unfetchable(m) => (
@@ -184,11 +171,17 @@ fn path_accepts_files(path: &str) -> bool {
     path.ends_with("/responses")
 }
 
-/// Cheap pre-check on the raw body so we only pay for a JSON parse when an
-/// `input_file` content part might be present. A false positive (the substring
-/// appears elsewhere, e.g. in user text) just falls through to the normal walk,
-/// which is a no-op; a false negative is impossible because every `input_file`
-/// part carries the literal `"input_file"` type discriminator.
+/// Cheap best-effort pre-check on the raw body so we only pay for a JSON parse
+/// when an `input_file` content part is likely present. A false positive (the
+/// substring appears elsewhere, e.g. in user text) just falls through to the
+/// normal walk, which is a no-op.
+///
+/// This is an optimisation, not a correctness boundary: a client could in
+/// principle encode the discriminator with JSON escapes (`"input_file"`),
+/// which this raw-byte scan would miss. In that case normalisation is skipped
+/// and the unresolved `file_url` flows to onwards, which returns a clear
+/// strict-mode error - never a silent drop. Real OpenAI SDK clients emit the
+/// literal `"input_file"`, so the fast path applies in practice.
 fn contains_input_file(body: &[u8]) -> bool {
     // `input_file` is 10 bytes; scan for the discriminator substring.
     body.windows(b"input_file".len()).any(|w| w == b"input_file")

--- a/dwctl/src/inference/file_input_middleware.rs
+++ b/dwctl/src/inference/file_input_middleware.rs
@@ -1,0 +1,313 @@
+//! Body-rewriting middleware that walks incoming `/responses` requests and
+//! normalises every `input_file` content part via [`crate::file_input`]:
+//! `file_url`s are fetched through the hardened fetcher and inlined as base64
+//! `file_data`, and unresolvable references (a bare dwctl `file_id`) are
+//! rejected with a clear 4xx instead of being silently dropped downstream.
+//!
+//! Modelled on [`super::image_normalizer_middleware`]: read the body once,
+//! mutate the JSON in place, restore the body via `Body::from(...)`.
+//!
+//! The middleware is a no-op for:
+//! - non-`/responses` paths (only the Responses API carries `input_file`),
+//! - the feature being disabled,
+//! - requests with no body or a non-JSON body,
+//! - bodies that contain no rewritable `input_file` parts.
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use serde_json::Value;
+use std::sync::Arc;
+use tracing::{debug, warn};
+
+use crate::file_input::normalize_input_files;
+use crate::image_normalizer::NormalizeError;
+use crate::image_normalizer::fetcher::ImageFetcher;
+
+/// Shared state threaded through the middleware.
+#[derive(Clone)]
+pub struct FileInputMiddlewareState {
+    /// Whether `input_file` `file_url` fetch-and-inline is enabled
+    /// (`config.file_input.enabled`). When false the middleware passes traffic
+    /// through untouched - onwards then returns a clear error for an
+    /// unconvertible `file_url` in strict mode rather than dropping it.
+    pub enabled: bool,
+    /// Hardened fetcher with the document MIME allow-list applied.
+    pub fetcher: Arc<ImageFetcher>,
+}
+
+/// Axum middleware function. Applies to the onwards router.
+pub async fn file_input_middleware(State(state): State<FileInputMiddlewareState>, mut request: Request<Body>, next: Next) -> Response {
+    if !state.enabled {
+        return next.run(request).await;
+    }
+
+    // `input_file` is a Responses-API concept; nothing else carries it.
+    if !path_accepts_files(request.uri().path()) {
+        return next.run(request).await;
+    }
+
+    // Read the body once.
+    let body_bytes = match axum::body::to_bytes(std::mem::take(request.body_mut()), usize::MAX).await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(error = %e, "Failed to read request body in file_input middleware");
+            let body = serde_json::json!({
+                "error": {
+                    "message": format!("failed to read request body: {e}"),
+                    "type": "invalid_request_error",
+                    "code": "body_read_failed",
+                }
+            });
+            return (StatusCode::BAD_REQUEST, axum::Json(body)).into_response();
+        }
+    };
+
+    // Fast path: if the raw body never mentions `input_file` there is nothing
+    // to rewrite or reject, so skip the JSON parse entirely and forward the
+    // bytes untouched. This keeps the common (no document input) case as cheap
+    // as the unavoidable body buffer.
+    if !contains_input_file(&body_bytes) {
+        *request.body_mut() = Body::from(body_bytes);
+        return next.run(request).await;
+    }
+
+    // Non-JSON bodies pass through (we only act on JSON request bodies).
+    let mut body_value: Value = match serde_json::from_slice(&body_bytes) {
+        Ok(v) => v,
+        Err(_) => {
+            *request.body_mut() = Body::from(body_bytes);
+            return next.run(request).await;
+        }
+    };
+
+    let fetcher = state.fetcher.clone();
+    let result = normalize_input_files(&mut body_value, |url| {
+        let fetcher = fetcher.clone();
+        async move {
+            fetcher
+                .fetch(&url)
+                .await
+                .map(|fetched| (fetched.mime, fetched.bytes))
+                .map_err(NormalizeError::from)
+        }
+    })
+    .await;
+
+    let substituted = match result {
+        Ok(n) => n,
+        Err(e) => {
+            warn!(error = %e, "input_file normalisation failed");
+            return file_input_error_response(e);
+        }
+    };
+
+    if substituted == 0 {
+        // No parts touched - restore the original bytes verbatim to avoid any
+        // whitespace / key-order drift from a JSON round-trip.
+        *request.body_mut() = Body::from(body_bytes);
+    } else {
+        debug!(substituted, "file_input normaliser inlined file_url bytes");
+        let new_bytes = match serde_json::to_vec(&body_value) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(error = %e, "Failed to re-serialise body after input_file normalisation");
+                let body = serde_json::json!({
+                    "error": {
+                        "message": format!("failed to re-serialise request body: {e}"),
+                        "type": "internal_error",
+                        "code": "body_reserialize_failed",
+                    }
+                });
+                return (StatusCode::INTERNAL_SERVER_ERROR, axum::Json(body)).into_response();
+            }
+        };
+        let len = new_bytes.len();
+        request.headers_mut().insert(
+            axum::http::header::CONTENT_LENGTH,
+            len.to_string().parse().expect("digit string is a valid header value"),
+        );
+        *request.body_mut() = Body::from(new_bytes);
+    }
+
+    next.run(request).await
+}
+
+/// Map a [`NormalizeError`] from `input_file` handling to an HTTP response.
+/// File-specific codes/messages so the document case is self-diagnosing (the
+/// shared `NormalizeError` Display text is image-oriented, so we build our own
+/// message from the inner detail).
+fn file_input_error_response(err: NormalizeError) -> Response {
+    let (status, code, message) = match err {
+        NormalizeError::BadInput(m) => (StatusCode::BAD_REQUEST, "input_file_rejected", m),
+        NormalizeError::Unfetchable(m) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "input_file_url_unfetchable",
+            format!(
+                "the file URL could not be retrieved: {m}; ensure it is publicly accessible and \
+                 does not require authentication"
+            ),
+        ),
+        NormalizeError::Transient(m) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "input_file_fetch_transient",
+            format!("transient failure fetching the file URL: {m}"),
+        ),
+        NormalizeError::FetchFailed(m) => (
+            StatusCode::BAD_GATEWAY,
+            "input_file_fetch_failed",
+            format!("failed to fetch the file URL: {m}"),
+        ),
+        NormalizeError::StoreFailed(m) => (StatusCode::SERVICE_UNAVAILABLE, "input_file_store_failed", m),
+        NormalizeError::NotFound => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "input_file_not_found",
+            "file reference could not be resolved".to_string(),
+        ),
+    };
+    let body = serde_json::json!({
+        "error": {
+            "message": message,
+            "type": "invalid_request_error",
+            "code": code,
+        }
+    });
+    (status, axum::Json(body)).into_response()
+}
+
+/// Only the Responses API carries `input_file`. Matches both `/ai/v1`-nested
+/// (production) and bare `/responses` (tests / strict mode) paths.
+fn path_accepts_files(path: &str) -> bool {
+    path.ends_with("/responses")
+}
+
+/// Cheap pre-check on the raw body so we only pay for a JSON parse when an
+/// `input_file` content part might be present. A false positive (the substring
+/// appears elsewhere, e.g. in user text) just falls through to the normal walk,
+/// which is a no-op; a false negative is impossible because every `input_file`
+/// part carries the literal `"input_file"` type discriminator.
+fn contains_input_file(body: &[u8]) -> bool {
+    // `input_file` is 10 bytes; scan for the discriminator substring.
+    body.windows(b"input_file".len()).any(|w| w == b"input_file")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image_normalizer::config::FetcherConfig;
+    use axum::{Router, body::to_bytes, http::Method, middleware, routing::post};
+    use serde_json::json;
+    use tower::ServiceExt;
+
+    fn build_router(enabled: bool) -> Router {
+        let state = FileInputMiddlewareState {
+            enabled,
+            fetcher: Arc::new(ImageFetcher::new(FetcherConfig {
+                allowed_mime: vec!["application/pdf".to_string()],
+                ..FetcherConfig::default()
+            })),
+        };
+        let inner = post(|body: axum::body::Bytes| async move { (StatusCode::OK, body) });
+        Router::new()
+            .route("/responses", inner.clone())
+            .route("/chat/completions", inner)
+            .layer(middleware::from_fn_with_state(state, file_input_middleware))
+    }
+
+    async fn post_json(router: Router, path: &str, body: Value) -> (StatusCode, Value) {
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(path)
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        (status, v)
+    }
+
+    fn input_file_body(part: Value) -> Value {
+        json!({
+            "model": "doc-qa",
+            "input": [{ "role": "user", "content": [{ "type": "input_text", "text": "hi" }, part] }]
+        })
+    }
+
+    #[tokio::test]
+    async fn responses_without_input_file_passes_through_verbatim() {
+        // No input_file present: the fast path forwards the body untouched.
+        let body = json!({
+            "model": "doc-qa",
+            "input": [{ "role": "user", "content": [{ "type": "input_text", "text": "hi" }] }]
+        });
+        let (status, echoed) = post_json(build_router(true), "/responses", body.clone()).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(echoed, body);
+    }
+
+    #[tokio::test]
+    async fn rejects_bare_file_id_with_400() {
+        let (status, body) = post_json(
+            build_router(true),
+            "/responses",
+            input_file_body(json!({ "type": "input_file", "file_id": "file-abc" })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "input_file_rejected");
+    }
+
+    #[tokio::test]
+    async fn rejects_link_local_file_url_with_400() {
+        let (status, body) = post_json(
+            build_router(true),
+            "/responses",
+            input_file_body(json!({
+                "type": "input_file",
+                "file_url": "http://169.254.169.254/latest/meta-data/"
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "input_file_rejected");
+    }
+
+    #[tokio::test]
+    async fn passes_inline_file_data_through_unchanged() {
+        let body = input_file_body(json!({
+            "type": "input_file",
+            "file_data": "data:application/pdf;base64,QUJD"
+        }));
+        let (status, echoed) = post_json(build_router(true), "/responses", body.clone()).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(echoed, body);
+    }
+
+    #[tokio::test]
+    async fn disabled_passes_file_url_through_unchanged() {
+        let body = input_file_body(json!({
+            "type": "input_file",
+            "file_url": "http://169.254.169.254/latest/meta-data/"
+        }));
+        let (status, echoed) = post_json(build_router(false), "/responses", body.clone()).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(echoed, body, "disabled middleware must not touch the body");
+    }
+
+    #[tokio::test]
+    async fn ignores_non_responses_paths() {
+        let body = input_file_body(json!({ "type": "input_file", "file_id": "file-abc" }));
+        // Same body on /chat/completions must not be inspected or rejected.
+        let (status, _echoed) = post_json(build_router(true), "/chat/completions", body).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+}

--- a/dwctl/src/inference/middleware.rs
+++ b/dwctl/src/inference/middleware.rs
@@ -58,6 +58,15 @@ pub struct ResponsesMiddlewareState<P: PoolProvider + Clone = sqlx_pool_router::
     pub image_normalizer: Arc<dyn ImageNormalizer>,
     /// Whether image normalisation is enabled (`config.image_normalizer.enabled`).
     pub image_normalizer_enabled: bool,
+    /// Hardened fetcher for `input_file.file_url` (document MIME allow-list).
+    /// The warm-path (multi-step) and flex paths short-circuit before the
+    /// downstream `file_input` layer, so they inline `file_url` here instead
+    /// (the realtime path is handled by that layer). When disabled, the
+    /// `input_file` part is left untouched.
+    pub file_input_fetcher: Arc<crate::image_normalizer::fetcher::ImageFetcher>,
+    /// Whether `input_file` `file_url` fetch-and-inline is enabled
+    /// (`config.file_input.enabled`).
+    pub file_input_enabled: bool,
 }
 
 /// Middleware that routes inference requests based on service_tier and background.
@@ -200,7 +209,23 @@ pub async fn responses_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
     //   no tools, !flex                              → falls through to handle_realtime below
     //   any flex                                     → falls through to handle_flex below
     let stream_requested = is_responses_api && !background && request_value["stream"].as_bool().unwrap_or(false);
-    match warm_path_branch(is_responses_api, is_flex, background, stream_requested, has_tools) {
+    let warm_branch = warm_path_branch(is_responses_api, is_flex, background, stream_requested, has_tools);
+
+    // The warm path (multi-step loop) and the flex path short-circuit before
+    // the downstream `file_input` layer, and the multi-step translator only
+    // keeps an `input_file` once its `file_url` has been inlined as
+    // `file_data`. So inline `input_file.file_url` here for the warm-path
+    // branches (flex is handled in its own branch below). The realtime
+    // fall-through is normalised by the `file_input` layer instead.
+    if state.file_input_enabled
+        && !matches!(warm_branch, WarmPathBranch::FallThrough)
+        && let Err(e) = crate::file_input::normalize_input_files_with_fetcher(&mut request_value, &state.file_input_fetcher).await
+    {
+        tracing::warn!(error = %e, "input_file normalisation failed on warm path");
+        return super::file_input_middleware::file_input_error_response(e);
+    }
+
+    match warm_branch {
         WarmPathBranch::Stream => {
             if let Some(resp) = try_warm_path_stream(&state, &request_value, api_key.as_deref(), model).await {
                 return resp;
@@ -312,6 +337,16 @@ pub async fn responses_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
                         return normalize_error_response(e);
                     }
                 }
+            }
+            // Flex bypasses the downstream `file_input` layer too, so inline
+            // `input_file.file_url` here before the request is persisted for
+            // the daemon. The daemon then dispatches the already-inlined
+            // `file_data` (mapped to a chat `file` part by the translator).
+            if state.file_input_enabled
+                && let Err(e) = crate::file_input::normalize_input_files_with_fetcher(&mut request_value, &state.file_input_fetcher).await
+            {
+                tracing::warn!(error = %e, "flex input_file normalisation failed");
+                return super::file_input_middleware::file_input_error_response(e);
             }
             let flex_input = fusillade::CreateFlexInput {
                 request_id,

--- a/dwctl/src/inference/mod.rs
+++ b/dwctl/src/inference/mod.rs
@@ -17,6 +17,7 @@
 //! - **engine**: the multi-step Open Responses orchestration loop and the
 //!   daemon-side request processor.
 
+pub mod file_input_middleware;
 pub mod handler;
 pub mod image_normalizer_middleware;
 pub mod middleware;

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -151,6 +151,7 @@ mod email;
 pub mod encryption;
 mod error_enrichment;
 pub mod errors;
+pub mod file_input;
 pub mod image_normalizer;
 pub mod inference;
 mod leader_election;
@@ -1557,6 +1558,25 @@ pub async fn build_router(
         onwards_router.layer(middleware::from_fn_with_state(
             image_normalizer_state,
             crate::inference::image_normalizer_middleware::image_normalizer_middleware,
+        ))
+    };
+
+    // Apply the input_file (PDF / document) normaliser middleware. For each
+    // `/responses` request it fetches any `input_file.file_url` through the
+    // hardened fetcher and inlines the bytes as base64 `file_data`, so the
+    // document survives the strict Responses-to-Chat-Completions conversion
+    // (which has no URL form for files). Unresolvable references are rejected
+    // with a clear 4xx instead of being silently dropped downstream.
+    let onwards_router = {
+        let cfg = state.current_config();
+        let fetcher = std::sync::Arc::new(crate::image_normalizer::fetcher::ImageFetcher::new(cfg.file_input.fetcher.clone()));
+        let file_input_state = crate::inference::file_input_middleware::FileInputMiddlewareState {
+            enabled: cfg.file_input.enabled,
+            fetcher,
+        };
+        onwards_router.layer(middleware::from_fn_with_state(
+            file_input_state,
+            crate::inference::file_input_middleware::file_input_middleware,
         ))
     };
 

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -3085,6 +3085,10 @@ impl Application {
             loop_config: multi_step_loop_config,
             image_normalizer: image_normalizer.clone(),
             image_normalizer_enabled: config.image_normalizer.enabled,
+            file_input_fetcher: std::sync::Arc::new(crate::image_normalizer::fetcher::ImageFetcher::new(
+                config.file_input.fetcher.clone(),
+            )),
+            file_input_enabled: config.file_input.enabled,
         };
 
         // Build onwards router from targets with body transform, response sanitization, and tool executor.

--- a/dwctl/src/test/utils.rs
+++ b/dwctl/src/test/utils.rs
@@ -332,6 +332,7 @@ pub fn create_test_config() -> crate::config::Config {
         connections: Default::default(),
         responses: Default::default(),
         image_normalizer: Default::default(),
+        file_input: Default::default(),
         openapi: Default::default(),
     }
 }


### PR DESCRIPTION
# feat(responses): fetch and inline input_file file_url for document inputs

## Summary

This is the dwctl half of COR-427 (PDF / `input_file` support on
`/ai/v1/responses`). The onwards half makes the gateway able to carry and map
`input_file` content; this half makes a `file_url` actually work end to end in
strict mode.

A Chat Completions `file` content part can only carry inline bytes
(`file_data`) or a provider-owned `file_id` - it has no URL form (unlike
`image_url`). So an `input_file.file_url` cannot survive the
Responses-to-Chat-Completions conversion as a URL: the bytes have to be fetched
and inlined first. dwctl is the only layer that can do that fetch (onwards is a
pure transform with no outbound I/O).

A new middleware rewrites each `input_file` content part in a `/responses`
request body before it reaches onwards:

- `file_url` -> fetch through the hardened fetcher (the same SSRF-protected
  fetcher used for image URLs: DNS pinning, IP deny-list, redirect
  re-validation, MIME / size caps) and inline the bytes as a base64 `file_data`
  data URI, dropping `file_url`.
- `file_data` -> left untouched; onwards maps it to a Chat Completions `file`
  part.
- `file_id` (with no `file_data`) -> rejected with a clear 400. dwctl customers
  never upload to the upstream provider, so a bare `file_id` always refers to
  dwctl's own file store, which is not yet wired to resolve Responses inputs.
  Returning a documented error beats forwarding an id the provider can never
  resolve.

## Changes

- New `crate::file_input` module: `FileInputConfig` (enabled flag + a
  document-MIME fetcher policy, default `application/pdf`) and
  `normalize_input_files`, which walks `input[*].content[*]` and rewrites
  `input_file` parts. The fetch is injected as a callback (mirroring
  `image_normalizer::walker::substitute_with`) so the rewrite logic is testable
  without a live fetch.
- New `inference::file_input_middleware`: reads the body once, runs
  `normalize_input_files` with the real hardened fetcher, restores / reserialises
  the body, and maps failures to file-specific 4xx/5xx codes
  (`input_file_rejected`, `input_file_url_unfetchable`, ...). A raw-body
  substring fast-path skips the JSON parse entirely unless the body actually
  mentions `input_file`, and a body with nothing to rewrite is restored
  byte-for-byte (no reserialise, no Content-Length change).
- Reuses `image_normalizer::fetcher::ImageFetcher` and `NormalizeError`
  verbatim - only the MIME allow-list differs (documents instead of images).
- `Config` gains a `file_input` section; the middleware is layered onto the
  onwards router next to the image normaliser.

## Behaviour by config

- `file_input.enabled = false` (default): the middleware is a pass-through. An
  `input_file.file_url` flows to onwards untouched and onwards returns a clear
  strict-mode error rather than silently dropping it. Outbound fetch of
  user-supplied URLs is opt-in, mirroring the image normaliser.
- `file_input.enabled = true`: `file_url` is fetched and inlined, so a PDF by
  URL works end to end through strict mode.

## Tests

`crate::file_input` (rewrite logic): fetch+inline `file_url` to base64
`file_data`, `file_data` passthrough (asserts no fetch), bare `file_id`
rejected, no-`input_file` no-op, and a real-fetcher SSRF rejection
(link-local). `inference::file_input_middleware` (HTTP layer): `file_id` 400,
link-local `file_url` 400, inline `file_data` passthrough, no-`input_file`
verbatim passthrough, disabled passthrough, and non-`/responses` paths ignored.
`cargo test -p dwctl --lib file_input` passes (11 tests).

Note on test strategy: the SSRF guard hard-denies loopback, so a local mock
server cannot be fetched. The success path is covered by injecting a stub fetch
(the production fetcher is exercised separately against a link-local address to
prove the guard fires).

## Dependency / deploy ordering

This change has no compile-time dependency on the onwards half: dwctl rewrites
the JSON body (producing `input_file.file_data`) and forwards it, so it builds
against the current released onwards. The runtime dependency is that onwards
must understand `input_file.file_data` for the inlined document to reach the
model - that is the onwards half of COR-427.

So this is safe to merge independently: the feature is off by default
(`file_input.enabled = false`), and it is dormant until both halves are
deployed and the flag is enabled. Do not enable `file_input` in an environment
until the onwards `input_file` change is live there.

(Locally this branch is tested end to end against the onwards branch via a
`[patch.crates-io]` override in the workspace `Cargo.toml`. That override is
intentionally NOT part of this PR.)

## Follow-up

dwctl-owned `file_id` resolution: intercept a dwctl-issued `file_id`, load the
bytes from dwctl's file store, and inline them as `file_data` (the same shape
this middleware already produces for `file_url`). That turns the `file_id` 400
into a working path and is the remaining piece of COR-427.