### PR TITLE
feat: expose response request endpoint

### DIFF
--- a/dwctl/src/api/handlers/batch_requests.rs
+++ b/dwctl/src/api/handlers/batch_requests.rs
@@ -282,6 +282,19 @@ pub async fn get_batch_request<P: PoolProvider>(
     .await
     .map_err(|e| Error::Database(e.into()))?;
 
+    let endpoint = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT t.path
+        FROM fusillade.requests r
+        JOIN fusillade.request_templates t ON r.template_id = t.id
+        WHERE r.id = $1 AND r.created_by IS NOT NULL
+        "#,
+    )
+    .bind(request_id)
+    .fetch_optional(state.db.read())
+    .await
+    .map_err(|e| Error::Database(e.into()))?;
+
     // Look up the creator's email via UUID primary-key lookup (org IDs and unparseable
     // values return None without a query). Uses the primary pool to avoid replica lag
     // right after response creation.
@@ -315,6 +328,7 @@ pub async fn get_batch_request<P: PoolProvider>(
         reasoning_tokens: analytics.as_ref().and_then(|a| a.reasoning_tokens),
         total_tokens: analytics.as_ref().and_then(|a| a.total_tokens),
         total_cost: analytics.as_ref().and_then(|a| a.total_cost),
+        endpoint,
         body: detail.body.unwrap_or_default(),
         response_body: detail.response_body,
         error: detail.error,
@@ -627,6 +641,7 @@ mod tests {
         response.assert_status_ok();
         let body: serde_json::Value = response.json();
         assert_eq!(body["id"], request_id.to_string());
+        assert_eq!(body["endpoint"], "/v1/chat/completions");
         assert_eq!(body["created_by_email"], user.email);
     }
 

--- a/dwctl/src/api/models/batch_requests.rs
+++ b/dwctl/src/api/models/batch_requests.rs
@@ -75,6 +75,8 @@ pub struct ResponseDetail {
     pub reasoning_tokens: Option<i64>,
     pub total_tokens: Option<i64>,
     pub total_cost: Option<f64>,
+    /// OpenAI-compatible API path the request was sent to, e.g. `/v1/responses`.
+    pub endpoint: Option<String>,
     pub body: String,
     pub response_body: Option<String>,
     pub error: Option<String>,


### PR DESCRIPTION
## Summary

- Adds `endpoint` to the admin response-detail payload returned by `GET /admin/api/v1/batches/requests/{request_id}`.
- Populates the value from the persisted fusillade request template path, e.g. `/v1/responses` or `/v1/chat/completions`.
- Adds a regression assertion covering the serialized detail response.

## Why

The app-doubleword-private Responses detail page needs to show the endpoint under Summary. The frontend is blocked on this backend field going live so it can render the real request path instead of inferring it from the body shape.

## Verification

- `cargo test -p dwctl test_get_batch_request_populates_created_by_email -- --nocapture`
