### PR TITLE
Add organization role descriptions and tooltips to member management

### DIFF
--- a/dashboard/src/components/features/organizations/MemberManagement.test.tsx
+++ b/dashboard/src/components/features/organizations/MemberManagement.test.tsx
@@ -249,4 +249,47 @@ describe("MemberManagement", () => {
       expect(within(container).getByText("Members (2)")).toBeInTheDocument();
     });
   });
+
+  it("exposes an org roles info control with role descriptions", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <MemberManagement organizationId="org-550e8400-0001" />,
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(within(container).getByText("Members (2)")).toBeInTheDocument();
+    });
+
+    const infoButton = within(container).getByRole("button", {
+      name: /about organization roles/i,
+    });
+    expect(infoButton).toBeInTheDocument();
+
+    await user.hover(infoButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Organization roles")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/cannot promote others to Owner/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows org roles info even in readOnly mode", async () => {
+    const { container } = render(
+      <MemberManagement organizationId="org-550e8400-0001" readOnly />,
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(within(container).getByText("Sarah Chen")).toBeInTheDocument();
+    });
+
+    expect(
+      within(container).getByRole("button", {
+        name: /about organization roles/i,
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/dashboard/src/components/features/organizations/MemberManagement.tsx
+++ b/dashboard/src/components/features/organizations/MemberManagement.tsx
@@ -13,13 +13,14 @@ import { useOrganizationContext } from "@/contexts";
 import type { OrgMemberRole, OrganizationMember } from "@/api/control-layer/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import * as SelectPrimitive from "@radix-ui/react-select";
 import {
   Select,
   SelectContent,
-  SelectItem,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -29,8 +30,72 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { UserAvatar } from "@/components/ui";
-import { UserPlus, Trash2, Mail, X, LogOut } from "lucide-react";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { UserPlus, Trash2, Mail, X, LogOut, Info, CheckIcon } from "lucide-react";
 import { toast } from "sonner";
+import {
+  ORG_MEMBER_ROLES,
+  formatOrgRoleForDisplay,
+  getOrgRoleDescription,
+} from "@/utils/roles";
+
+// Custom select item so the dropdown can show a role description while the
+// trigger only mirrors the role name (Radix mirrors `ItemText` into the value).
+function OrgRoleSelectItem({ role }: { role: OrgMemberRole }) {
+  return (
+    <SelectPrimitive.Item
+      value={role}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default flex-col items-start rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      )}
+    >
+      <span className="absolute right-2 top-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>
+        {formatOrgRoleForDisplay(role)}
+      </SelectPrimitive.ItemText>
+      <span className="text-xs text-muted-foreground max-w-[18rem] whitespace-normal">
+        {getOrgRoleDescription(role)}
+      </span>
+    </SelectPrimitive.Item>
+  );
+}
+
+function OrgRolesInfo() {
+  return (
+    <HoverCard openDelay={150} closeDelay={200}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="About organization roles"
+        >
+          <Info className="h-4 w-4" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent side="bottom" align="start" className="w-80 space-y-3">
+        <p className="text-sm font-medium">Organization roles</p>
+        {ORG_MEMBER_ROLES.map((role) => (
+          <div key={role} className="space-y-0.5">
+            <p className="text-xs font-semibold">
+              {formatOrgRoleForDisplay(role)}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {getOrgRoleDescription(role)}
+            </p>
+          </div>
+        ))}
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
 
 interface MemberManagementProps {
   organizationId: string;
@@ -153,9 +218,12 @@ export function MemberManagement({ organizationId, readOnly = false }: MemberMan
     <div className="space-y-4">
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
         <div className="flex items-center justify-between mb-4">
-          <h4 className="text-lg font-medium text-gray-900">
-            Members ({activeMembers.length})
-          </h4>
+          <div className="flex items-center gap-2">
+            <h4 className="text-lg font-medium text-gray-900">
+              Members ({activeMembers.length})
+            </h4>
+            <OrgRolesInfo />
+          </div>
           {!readOnly && (
             <Button
               variant="outline"
@@ -187,9 +255,9 @@ export function MemberManagement({ organizationId, readOnly = false }: MemberMan
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="member">Member</SelectItem>
-                  <SelectItem value="admin">Admin</SelectItem>
-                  <SelectItem value="owner">Owner</SelectItem>
+                  {ORG_MEMBER_ROLES.map((role) => (
+                    <OrgRoleSelectItem key={role} role={role} />
+                  ))}
                 </SelectContent>
               </Select>
               <Button
@@ -264,9 +332,9 @@ export function MemberManagement({ organizationId, readOnly = false }: MemberMan
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="member">Member</SelectItem>
-                          <SelectItem value="admin">Admin</SelectItem>
-                          <SelectItem value="owner">Owner</SelectItem>
+                          {ORG_MEMBER_ROLES.map((role) => (
+                            <OrgRoleSelectItem key={role} role={role} />
+                          ))}
                         </SelectContent>
                       </Select>
                       <button

--- a/dashboard/src/utils/roles.test.ts
+++ b/dashboard/src/utils/roles.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import {
+  ORG_MEMBER_ROLES,
+  formatOrgRoleForDisplay,
+  getOrgRoleDescription,
+} from "./roles";
+
+describe("organization role helpers", () => {
+  it("orders roles from least to most privileged", () => {
+    expect(ORG_MEMBER_ROLES).toEqual(["member", "admin", "owner"]);
+  });
+
+  it("formats org roles for display", () => {
+    expect(formatOrgRoleForDisplay("member")).toBe("Member");
+    expect(formatOrgRoleForDisplay("admin")).toBe("Admin");
+    expect(formatOrgRoleForDisplay("owner")).toBe("Owner");
+  });
+
+  it("provides a non-empty description for every org role", () => {
+    for (const role of ORG_MEMBER_ROLES) {
+      expect(getOrgRoleDescription(role).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("describes the owner-only ability to promote owners", () => {
+    expect(getOrgRoleDescription("owner")).toMatch(/Owner role/i);
+    expect(getOrgRoleDescription("admin")).toMatch(/cannot promote/i);
+  });
+});

--- a/dashboard/src/utils/roles.ts
+++ b/dashboard/src/utils/roles.ts
@@ -1,4 +1,4 @@
-import type { Role } from "../api/control-layer/types";
+import type { OrgMemberRole, Role } from "../api/control-layer/types";
 
 // Available user roles - must match Role type
 export const AVAILABLE_ROLES: Role[] = [
@@ -55,4 +55,38 @@ export const isAdmin = (isAdminFlag: boolean): boolean => {
  */
 export const getRoleDisplayName = (role: Role): string => {
   return formatRoleForDisplay(role);
+};
+
+// Organization membership roles - must match OrgMemberRole type.
+// Ordered from least to most privileged.
+export const ORG_MEMBER_ROLES: OrgMemberRole[] = ["member", "admin", "owner"];
+
+/**
+ * Format an organization membership role for display
+ * (member -> Member, admin -> Admin, owner -> Owner).
+ */
+export const formatOrgRoleForDisplay = (role: OrgMemberRole): string => {
+  const displayNames: Record<OrgMemberRole, string> = {
+    owner: "Owner",
+    admin: "Admin",
+    member: "Member",
+  };
+  return displayNames[role] || role;
+};
+
+/**
+ * Human-readable description of what an organization membership role can do.
+ * Org roles are independent of platform (system) roles: they only govern
+ * access within the organization context.
+ */
+export const getOrgRoleDescription = (role: OrgMemberRole): string => {
+  const descriptions: Record<OrgMemberRole, string> = {
+    member:
+      "Members can use the organization: create organization API keys, view usage and credit transactions, and read members and webhooks. They cannot manage members, change organization settings, or add funds.",
+    admin:
+      "Admins can do everything Members can, plus manage the organization: invite and remove members, change member roles, edit organization settings and webhooks, and add funds. They cannot promote others to Owner.",
+    owner:
+      "Owners have full control of the organization. They can do everything Admins can, plus assign the Owner role to other members. An organization must always keep at least one Owner.",
+  };
+  return descriptions[role];
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

There were two separate role systems in the product, and the **organization membership roles** (`owner`, `admin`, `member`) had no in-UI explanation. The role `<select>` in member management just listed the three role names with no descriptions or tooltips, unlike the platform/system roles which already have hover-card descriptions in the user create/edit modals. This left users guessing what each org role can actually do.

## What changed

- Added org-role helpers in `dashboard/src/utils/roles.ts`:
  - `ORG_MEMBER_ROLES` (ordered least→most privileged)
  - `formatOrgRoleForDisplay`
  - `getOrgRoleDescription` — plain-language summary of each role's capabilities
- Updated `MemberManagement.tsx`:
  - Added an info hover-card next to the **Members** heading that lists all three org roles and what they can do. It is visible to everyone (including read-only members who just see their role badge).
  - Replaced the hard-coded role `<select>` items (in both the invite form and the per-member role editor) with items that show a short description under each role name. A custom Radix item is used so the description appears in the dropdown but the trigger still shows only the role name.

## Role behavior reflected in the descriptions (sourced from backend authorization logic)

- **Member** — can use the org (create org API keys, view usage/credit transactions, read members and webhooks); cannot manage members, change settings, or add funds.
- **Admin** — everything a member can do, plus manage the org (invite/remove members, change roles, edit settings and webhooks, add funds); cannot promote others to Owner.
- **Owner** — full control, including assigning the Owner role; the org must always keep at least one Owner.

These are organization-scoped roles and are independent of platform/system roles (`StandardUser`, `PlatformManager`, etc.).

## Tests

- New `dashboard/src/utils/roles.test.ts` covering the org-role helpers.
- New `MemberManagement` tests asserting the info control is present (including in read-only mode) and surfaces the descriptions.
- `pnpm run lint`, `tsc --noEmit`, and the affected vitest suites all pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39e54ba8-5081-4211-af38-fbf1913025ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39e54ba8-5081-4211-af38-fbf1913025ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

