### PR TITLE
fix: stop logging tool response bodies and serde body fragments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,9 +2335,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "19.1.0"
+version = "19.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0571a0aca8e62e5282c3660b9a2a9a2cd510de08989379991952eecd19f030fc"
+checksum = "e741222960a22b4830df69c3d83e1c1e30f28c9a53504953e79e18efa3978985"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4197,9 +4197,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onwards"
-version = "0.34.0"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccdd0f051e35e50eea9bff69178a4e2fd77caf628b13185aacfcb544d160235"
+checksum = "000f5b251360369b7ba7bb46d114764cced46148924c4413892f69b5a2ce9d63"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "19.1.0" }
+fusillade = { version = "19.2.0" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
@@ -80,7 +80,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 argon2 = "0.5"
 base64 = "0.22"
 bytes = "1.5"
-onwards = { version = "0.34.0", features = ["multi-step"] }
+onwards = { version = "0.34.2", features = ["multi-step"] }
 thiserror = "2.0.14"
 axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)

--- a/dwctl/src/inference/tools/executor.rs
+++ b/dwctl/src/inference/tools/executor.rs
@@ -224,8 +224,11 @@ impl ToolExecutor for HttpToolExecutor {
                             },
                         }
                     } else {
-                        let body = resp.text().await.unwrap_or_default();
-                        let msg = format!("HTTP {}: {}", status_u16, body);
+                        // ZDR: never put the tool response body into the error — it
+                        // becomes the ToolError Display, which `#[instrument(err)]`
+                        // logs, and tool outputs are disallowed payload content.
+                        let body_len = resp.text().await.map(|b| b.len()).unwrap_or(0);
+                        let msg = format!("HTTP {} ({}-byte body omitted)", status_u16, body_len);
                         (Err(ToolError::ExecutionError(msg)), Some(status_u16), Some("http_error"))
                     }
                 }
@@ -354,16 +357,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_returns_error_on_4xx() {
+        // ZDR (COR-499): the tool response body must never appear in the error,
+        // which `#[instrument(err)]` logs. Use a sentinel body and assert it is
+        // absent while the status is still reported.
+        const SENTINEL: &str = "ZDR-SENTINEL-TOOL-BODY-4a1f";
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/tool"))
-            .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(SENTINEL))
             .mount(&server)
             .await;
 
         let (executor, ctx) = make_executor_and_ctx("test_tool", &server.uri(), None);
         let result = executor.execute("test_tool", "id1", &serde_json::json!({}), &ctx).await;
-        assert!(matches!(result, Err(ToolError::ExecutionError(_))));
+        let Err(ToolError::ExecutionError(msg)) = result else {
+            panic!("expected ExecutionError, got {result:?}");
+        };
+        assert!(!msg.contains(SENTINEL), "tool response body leaked into error: {msg}");
+        assert!(msg.contains("400"), "expected status in error message: {msg}");
     }
 
     #[tokio::test]

--- a/dwctl/src/inference/tools/executor.rs
+++ b/dwctl/src/inference/tools/executor.rs
@@ -226,9 +226,13 @@ impl ToolExecutor for HttpToolExecutor {
                     } else {
                         // ZDR: never put the tool response body into the error — it
                         // becomes the ToolError Display, which `#[instrument(err)]`
-                        // logs, and tool outputs are disallowed payload content.
-                        let body_len = resp.text().await.map(|b| b.len()).unwrap_or(0);
-                        let msg = format!("HTTP {} ({}-byte body omitted)", status_u16, body_len);
+                        // logs, and tool outputs are disallowed payload content. Use
+                        // the advertised Content-Length where present and drop the
+                        // body unread, rather than buffering it just to size it.
+                        let msg = match resp.content_length() {
+                            Some(len) => format!("HTTP {status_u16} ({len}-byte body omitted)"),
+                            None => format!("HTTP {status_u16} (body omitted)"),
+                        };
                         (Err(ToolError::ExecutionError(msg)), Some(status_u16), Some("http_error"))
                     }
                 }

--- a/dwctl/src/request_logging/analytics_handler.rs
+++ b/dwctl/src/request_logging/analytics_handler.rs
@@ -169,7 +169,7 @@ impl RequestHandler for AnalyticsHandler {
                                 endpoint,
                                 fusillade_stream,
                                 error = %zdr_safe_parse_error(e.error.as_ref()),
-                                "Failed to serialize usage for successful generative response"
+                                "Failed to parse usage from a successful generative response"
                             );
                         }
                     }

--- a/dwctl/src/request_logging/analytics_handler.rs
+++ b/dwctl/src/request_logging/analytics_handler.rs
@@ -56,6 +56,19 @@ use serde_json::Value;
 use tracing::{Instrument, info_span};
 use uuid::Uuid;
 
+/// ZDR-safe descriptor for a payload (de)serialization error.
+///
+/// Logs only the underlying JSON error's location and category, never its
+/// `Display` message — serde messages can echo a fragment of the request or
+/// response body (e.g. `invalid type: string "<content>"`), which must never
+/// reach logs.
+fn zdr_safe_parse_error(err: &(dyn std::error::Error + Send + Sync + 'static)) -> String {
+    match err.downcast_ref::<serde_json::Error>() {
+        Some(e) => format!("json parse error ({:?}) at line {} column {}", e.classify(), e.line(), e.column()),
+        None => "parse error".to_string(),
+    }
+}
+
 /// A request handler that sends analytics data to a background batcher.
 ///
 /// This handler implements [`outlet::RequestHandler`] and can be used standalone or composed
@@ -145,7 +158,7 @@ impl RequestHandler for AnalyticsHandler {
                         tracing::warn!(
                             correlation_id = correlation_id,
                             uri = %request_data.uri,
-                            error = %e.error,
+                            error = %zdr_safe_parse_error(e.error.as_ref()),
                             "Failed to parse successful AI response — tokens will be zero"
                         );
                         if let Some(endpoint) = usage_required_endpoint {
@@ -155,7 +168,7 @@ impl RequestHandler for AnalyticsHandler {
                                 uri = %request_data.uri,
                                 endpoint,
                                 fusillade_stream,
-                                error = %e.error,
+                                error = %zdr_safe_parse_error(e.error.as_ref()),
                                 "Failed to serialize usage for successful generative response"
                             );
                         }
@@ -264,6 +277,25 @@ mod tests {
     use std::collections::HashMap;
     use std::time::{Duration, SystemTime};
     use tokio::sync::mpsc;
+
+    /// ZDR (COR-499): the serialization-error descriptor used in the parse-failure
+    /// logs must report only the JSON error's location/category, never a fragment
+    /// of the offending body that serde's `Display` can echo.
+    #[test]
+    fn zdr_safe_parse_error_omits_body_fragment() {
+        const SENTINEL: &str = "ZDR-SENTINEL-BODY-FRAGMENT-8d2c";
+        // A type mismatch makes serde's Display echo the offending value
+        // (`invalid type: string "<content>"`), which is exactly what we must drop.
+        let err: serde_json::Error =
+            serde_json::from_str::<std::collections::HashMap<String, u32>>(&format!("{{\"k\": \"{SENTINEL}\"}}")).unwrap_err();
+        // Sanity: the raw serde message really does contain the sentinel.
+        assert!(err.to_string().contains(SENTINEL));
+
+        let boxed: Box<dyn std::error::Error + Send + Sync> = Box::new(err);
+        let safe = zdr_safe_parse_error(boxed.as_ref());
+        assert!(!safe.contains(SENTINEL), "body fragment leaked: {safe}");
+        assert!(safe.contains("line") && safe.contains("column"), "expected location: {safe}");
+    }
 
     fn create_test_request_data() -> RequestData {
         RequestData {


### PR DESCRIPTION
## What & why

Part of the ZDR no-payload-logging work (**COR-499**, under COR-479). Production runs at `RUST_LOG=debug` with OTLP export on, so `debug!`/`warn!`/`error!` events reach Loki/Tempo. Two error/parse-path log sites could emit payload content:

1. **`inference/tools/executor.rs`** — on a tool HTTP error the upstream tool's response body was formatted into `ToolError::ExecutionError`, and `execute()` carries `#[instrument(..., err)]`, which logs the returned error's `Display`. Tool outputs are disallowed payload content. Now reports `HTTP <status> (<n>-byte body omitted)`. The success-path body (the actual tool result passed downstream) is unchanged — that's legitimate, not a log.
2. **`request_logging/analytics_handler.rs`** — the analytics parse-failure logs recorded `error = %e.error`, i.e. the serde error's `Display`, which can echo a fragment of the request/response body (`invalid type: string "<content>"`). Added `zdr_safe_parse_error()` which downcasts to `serde_json::Error` and logs only its `classify()` + line/column.

No behavioural change beyond what's written to logs.

## Scope note

The audit also flagged `prompt_cache/classifier.rs` and `inference/translation/middleware.rs`, but those modules are **not on `main`** (they live on unmerged feature branches). They'll need the same `zdr_safe_parse_error`-style fix wherever they land — tracked as a follow-up on COR-499.

## Tests

- `cargo check -p dwctl` ✅ (offline) · `cargo clippy -p dwctl --lib` ✅ (no new warnings) · `cargo fmt --check` ✅
- `inference::tools::executor` (12 tests) and `request_logging::analytics_handler` pass against a local PG18. New regression tests: tool 4xx error omits a sentinel body; the serde descriptor drops a sentinel value fragment. No SQL changed (`.sqlx` untouched).

Related: COR-497 (onwards #235), COR-498 (fusillade #304), COR-500 (CI lint guard), COR-501 (sentinel harness).