### PR TITLE
fix: disable batch capacity pending counts by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,9 +2335,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "19.2.1"
+version = "19.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123cd9cf5b5c7bc0e35275bf03010f1b1ac60e1ec4bbfbb8f3fd1131fdfcc7e4"
+checksum = "0284b0fcdb499cf0ed7a34eafd252edcba3f74b624e1ca1a0076544165540f6c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ batches:
   # Enable batches API endpoints (/ai/v1/files, /ai/v1/batches)
   # When disabled, these endpoints will not be available (default: false).
   enabled: false
-  pending_request_counts_enabled: false # Enable /monitoring/pending-request-counts queries (default: false)
+  pending_capacity_counts_enabled: false # Include committed pending requests in batch submission capacity checks (default: false)
 
   # Daemon configuration for processing batch requests
   daemon:

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ batches:
     body_timeout_ms: 86400000 # Max total time for entire response body (24 hours)
     claim_timeout_ms: 60000 # Max time in "claimed" state before auto-unclaim (1 minute)
     processing_timeout_ms: 600000 # Max time in "processing" state before auto-unclaim (10 minutes)
+    pending_request_counts_timeout_ms: 60000 # Statement timeout for pending request count queries (1 minute)
 
     # Observability
     status_log_interval_ms: 2000 # Interval for logging daemon status (set to null to disable)

--- a/README.md
+++ b/README.md
@@ -265,17 +265,24 @@ enable_request_logging: true # Enable request/response logging to database
 # hours.
 batches:
   # Enable batches API endpoints (/ai/v1/files, /ai/v1/batches)
-  # When disabled, these endpoints will not be available (default: false).
-  enabled: false
+  # When disabled, these endpoints will not be available (default: true).
+  enabled: true
   pending_capacity_counts_enabled: false # Include committed pending requests in batch submission capacity checks (default: false)
 
+  # Files configuration for batch file uploads/downloads
+  files:
+    max_file_size: 2147483648 # 2 GB - maximum size for file uploads
+    upload_buffer_size: 100 # Buffer size for file upload streams
+    download_buffer_size: 100 # Buffer size for file download streams
+
+background_services:
   # Daemon configuration for processing batch requests
-  daemon:
+  batch_daemon:
     # Controls when the batch processing daemon runs
-    # - "leader": Only run on the elected leader instance (default)
-    # - "always": Run on all instances (use for single-instance deployments)
-    # - "never": Never run the daemon (useful for testing or when using external processors)
-    enabled: leader
+    # - "always": Run on all instances (default)
+    # - "leader": Only run on the elected leader instance
+    # - "never": Never run the daemon
+    enabled: always
 
     # Performance & Concurrency Settings
     claim_batch_size: 100 # Maximum number of requests to claim in each iteration
@@ -283,10 +290,11 @@ batches:
     claim_interval_ms: 1000 # Milliseconds to sleep between claim iterations
 
     # Retry & Backoff Settings
-    # All retry parameters are optional - default behaviour is to retry indefinitely until deadline
-    # max_retries: 100 # stop retrying a request after 100 failed attempts
-    # stop_before_deadline_ms: 900000 # Stop 15 minutes before batch deadline
-    
+    # All retry parameters are optional and default to fusillade's built-in defaults
+    # min_retries: 3 - Minimum retries guaranteed regardless of other limits
+    # max_retries: None - No cap on retries (only limited by deadline if set)
+    stop_before_deadline_ms: 0 # When to stop retrying/escalating relative to the batch completion window
+
     backoff_ms: 1000 # Initial backoff duration in milliseconds
     backoff_factor: 2 # Exponential backoff multiplier
     max_backoff_ms: 10000 # Maximum backoff duration in milliseconds
@@ -302,12 +310,6 @@ batches:
 
     # Observability
     status_log_interval_ms: 2000 # Interval for logging daemon status (set to null to disable)
-
-  # Files configuration for batch file uploads/downloads
-  files:
-    max_file_size: 2147483648 # 2 GB - maximum size for file uploads
-    upload_buffer_size: 100 # Buffer size for file upload streams
-    download_buffer_size: 100 # Buffer size for file download streams
 ```
 
 ### Initial Credit Grant

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ batches:
   # Enable batches API endpoints (/ai/v1/files, /ai/v1/batches)
   # When disabled, these endpoints will not be available (default: false).
   enabled: false
+  pending_request_counts_enabled: false # Enable /monitoring/pending-request-counts queries (default: false)
 
   # Daemon configuration for processing batch requests
   daemon:

--- a/config.yaml
+++ b/config.yaml
@@ -280,6 +280,7 @@ batches:
   # When set, completed FLEX requests within this lookback are included in
   # the 1h pending-request-counts bucket. Omit or set null to disable.
   priority_decay_window_secs: 600
+  pending_request_counts_enabled: false # Enable /monitoring/pending-request-counts queries (default: false)
 
   # Allowed completion windows for batch processing
   # These define the maximum time from batch creation to completion

--- a/config.yaml
+++ b/config.yaml
@@ -280,7 +280,7 @@ batches:
   # When set, completed FLEX requests within this lookback are included in
   # the 1h pending-request-counts bucket. Omit or set null to disable.
   priority_decay_window_secs: 600
-  pending_request_counts_enabled: false # Enable /monitoring/pending-request-counts queries (default: false)
+  pending_capacity_counts_enabled: false # Include committed pending requests in batch submission capacity checks (default: false)
 
   # Allowed completion windows for batch processing
   # These define the maximum time from batch creation to completion

--- a/config.yaml
+++ b/config.yaml
@@ -475,6 +475,7 @@ background_services:
     body_timeout_ms: 86400000 # Max total time for entire response body (24 hours)
     claim_timeout_ms: 60000 # Max time in "claimed" state before auto-unclaim (1 minute)
     processing_timeout_ms: 600000 # Max time in "processing" state before auto-unclaim (10 minutes)
+    pending_request_counts_timeout_ms: 60000 # Statement timeout for pending request count queries (1 minute)
 
     # Observability
     status_log_interval_ms: 2000 # Interval for logging daemon status (set to null to disable)

--- a/dashboard/src/api/control-layer/mocks/handlers.ts
+++ b/dashboard/src/api/control-layer/mocks/handlers.ts
@@ -2943,6 +2943,7 @@ export const handlers = [
             heartbeat_interval_ms: 5000,
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60000,
           },
         },
         {
@@ -2977,6 +2978,7 @@ export const handlers = [
             heartbeat_interval_ms: 5000,
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60000,
           },
         },
         {
@@ -3011,6 +3013,7 @@ export const handlers = [
             heartbeat_interval_ms: 5000,
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60000,
           },
         },
       ],

--- a/dashboard/src/api/control-layer/types.ts
+++ b/dashboard/src/api/control-layer/types.ts
@@ -1461,6 +1461,7 @@ export interface DaemonConfig {
   heartbeat_interval_ms: number;
   claim_timeout_ms: number;
   processing_timeout_ms: number;
+  pending_request_counts_timeout_ms: number;
 }
 
 export interface Daemon {

--- a/dwctl/Cargo.lock
+++ b/dwctl/Cargo.lock
@@ -1050,7 +1050,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1872,6 +1872,7 @@ dependencies = [
  "arc-swap",
  "argon2",
  "async-openai",
+ "async-stream",
  "async-stripe",
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -1903,6 +1904,7 @@ dependencies = [
  "hex",
  "hickory-resolver",
  "hmac 0.13.0",
+ "http-body-util",
  "humantime",
  "humantime-serde",
  "jsonwebtoken",
@@ -2333,9 +2335,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "18.0.2"
+version = "19.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3868ec40891b50efee32ac38298dae5c2012600c6e08e837ddc294c78ee75c"
+checksum = "0284b0fcdb499cf0ed7a34eafd252edcba3f74b624e1ca1a0076544165540f6c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4195,9 +4197,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onwards"
-version = "0.33.4"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245f7822a57b6e90cc272cc7ccae9a6235c9e379b4588aa7bc60559cae9561e3"
+checksum = "000f5b251360369b7ba7bb46d114764cced46148924c4413892f69b5a2ce9d63"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,7 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "19.2.1" }
+fusillade = { version = "19.4.1" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"

--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -830,6 +830,7 @@ async fn reserve_capacity_for_batch<P: PoolProvider>(
         default_throughput: config.batches.default_throughput,
         relaxation_factor,
         reservation_ttl_secs: config.batches.reservation_ttl_secs,
+        include_pending_counts: config.batches.pending_capacity_counts_enabled,
     };
 
     // Use the write pool for the reservation transaction

--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -1889,6 +1889,7 @@ mod tests {
     use fusillade::Storage;
     use rust_decimal::Decimal;
     use sqlx::PgPool;
+    use sqlx_pool_router::TestDbPools;
     use std::collections::HashMap;
     use uuid::Uuid;
 
@@ -2951,6 +2952,102 @@ mod tests {
         .unwrap();
 
         assert_eq!(count.unwrap_or(0), 0);
+    }
+
+    async fn seed_pending_capacity_batch(state: &crate::AppState<TestDbPools>, alias: &str) {
+        let pending_templates = (0..3)
+            .map(|idx| fusillade::RequestTemplateInput {
+                custom_id: Some(format!("pending-{idx}")),
+                endpoint: "https://api.example.com".to_string(),
+                method: "POST".to_string(),
+                path: "/v1/chat/completions".to_string(),
+                body: format!(r#"{{"model":"{alias}","messages":[{{"role":"user","content":"hello"}}]}}"#),
+                model: alias.to_string(),
+                api_key: "key".to_string(),
+            })
+            .collect();
+
+        let file_id = state
+            .request_manager
+            .create_file("pending-capacity-test".to_string(), None, pending_templates)
+            .await
+            .expect("create pending file");
+        let pending_batch = state
+            .request_manager
+            .create_batch(fusillade::BatchInput {
+                file_id,
+                endpoint: "/v1/chat/completions".to_string(),
+                completion_window: "1h".to_string(),
+                metadata: None,
+                created_by: None,
+                api_key_id: None,
+                api_key: None,
+                total_requests: None,
+            })
+            .await
+            .expect("create pending batch");
+
+        sqlx::query("UPDATE batches SET expires_at = NOW() + interval '30 minutes' WHERE id = $1")
+            .bind(pending_batch.id.0)
+            .execute(state.request_manager.pool())
+            .await
+            .expect("pin pending batch deadline");
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_reserve_capacity_for_batch_ignores_pending_counts_when_disabled(pool: PgPool) {
+        let mut config = create_test_config();
+        config.batches.pending_capacity_counts_enabled = false;
+        let state = create_test_app_state_with_fusillade(pool.clone(), config).await;
+
+        let user = create_test_user(&pool, Role::StandardUser).await;
+        let endpoint_id = create_test_endpoint(&pool, &format!("test-{}", Uuid::new_v4()), user.id).await;
+
+        let alias = format!("alias-{}", Uuid::new_v4());
+        let model_id = create_test_model(&pool, "model-a", &alias, endpoint_id, user.id).await;
+
+        seed_pending_capacity_batch(&state, &alias).await;
+
+        // Capacity is 3 requests for 1h; the 3 pending requests would reject this
+        // extra request if pending counts were included. With the flag disabled,
+        // reserve_capacity uses an empty pending map and only considers reservations.
+        let file_model_counts = HashMap::from([(alias.clone(), 1_i64)]);
+        let model_throughputs = HashMap::from([(alias.clone(), 0.001_f32)]);
+        let model_ids_by_alias = HashMap::from([(alias.clone(), model_id)]);
+
+        let reservation_ids =
+            super::reserve_capacity_for_batch(&state, "1h", &file_model_counts, &model_throughputs, &model_ids_by_alias, 1.0)
+                .await
+                .expect("pending counts should be ignored when disabled");
+
+        assert_eq!(reservation_ids.len(), 1);
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_reserve_capacity_for_batch_rejects_pending_counts_when_enabled(pool: PgPool) {
+        let mut config = create_test_config();
+        config.batches.pending_capacity_counts_enabled = true;
+        let state = create_test_app_state_with_fusillade(pool.clone(), config).await;
+
+        let user = create_test_user(&pool, Role::StandardUser).await;
+        let endpoint_id = create_test_endpoint(&pool, &format!("test-{}", Uuid::new_v4()), user.id).await;
+
+        let alias = format!("alias-{}", Uuid::new_v4());
+        let model_id = create_test_model(&pool, "model-a", &alias, endpoint_id, user.id).await;
+
+        seed_pending_capacity_batch(&state, &alias).await;
+
+        let file_model_counts = HashMap::from([(alias.clone(), 1_i64)]);
+        let model_throughputs = HashMap::from([(alias.clone(), 0.001_f32)]);
+        let model_ids_by_alias = HashMap::from([(alias.clone(), model_id)]);
+
+        let err = super::reserve_capacity_for_batch(&state, "1h", &file_model_counts, &model_throughputs, &model_ids_by_alias, 1.0)
+            .await
+            .expect_err("pending counts should reject when enabled");
+
+        assert!(matches!(err, Error::TooManyRequests { .. }));
     }
 
     /// Test that create_batch API accepts "high" priority name

--- a/dwctl/src/api/handlers/queue.rs
+++ b/dwctl/src/api/handlers/queue.rs
@@ -51,6 +51,10 @@ pub async fn get_pending_request_counts<P: PoolProvider>(
 ) -> Result<Json<PendingCountsByModelAndWindow>, Error> {
     let config = state.current_config();
 
+    if !config.batches.pending_request_counts_enabled {
+        return Ok(Json(HashMap::new()));
+    }
+
     // Call fusillade storage API to get pending request counts
     let windows = config
         .batches
@@ -136,7 +140,9 @@ mod tests {
         use sqlx::postgres::PgConnectOptions;
         use sqlx_pool_router::TestDbPools;
 
-        let (server, _bg): (TestServer, _) = create_test_app(pool.clone(), false).await;
+        let mut config = create_test_config();
+        config.batches.pending_request_counts_enabled = true;
+        let (server, _bg): (TestServer, _) = create_test_app_with_config(pool.clone(), config, false).await;
         let admin = create_test_admin_user(&pool, Role::PlatformManager).await;
 
         // Connect a request_manager to the same `fusillade` schema the app
@@ -248,6 +254,7 @@ mod tests {
         let mut config = create_test_config();
         config.batches.allowed_completion_windows = vec!["1h".to_string(), "24h".to_string()];
         config.batches.priority_decay_window_secs = Some(600);
+        config.batches.pending_request_counts_enabled = true;
         let (server, _bg): (TestServer, _) = create_test_app_with_config(pool.clone(), config, false).await;
         let admin = create_test_admin_user(&pool, Role::PlatformManager).await;
 

--- a/dwctl/src/api/handlers/queue.rs
+++ b/dwctl/src/api/handlers/queue.rs
@@ -51,10 +51,6 @@ pub async fn get_pending_request_counts<P: PoolProvider>(
 ) -> Result<Json<PendingCountsByModelAndWindow>, Error> {
     let config = state.current_config();
 
-    if !config.batches.pending_request_counts_enabled {
-        return Ok(Json(HashMap::new()));
-    }
-
     // Call fusillade storage API to get pending request counts
     let windows = config
         .batches
@@ -140,9 +136,7 @@ mod tests {
         use sqlx::postgres::PgConnectOptions;
         use sqlx_pool_router::TestDbPools;
 
-        let mut config = create_test_config();
-        config.batches.pending_request_counts_enabled = true;
-        let (server, _bg): (TestServer, _) = create_test_app_with_config(pool.clone(), config, false).await;
+        let (server, _bg): (TestServer, _) = create_test_app(pool.clone(), false).await;
         let admin = create_test_admin_user(&pool, Role::PlatformManager).await;
 
         // Connect a request_manager to the same `fusillade` schema the app
@@ -254,7 +248,6 @@ mod tests {
         let mut config = create_test_config();
         config.batches.allowed_completion_windows = vec!["1h".to_string(), "24h".to_string()];
         config.batches.priority_decay_window_secs = Some(600);
-        config.batches.pending_request_counts_enabled = true;
         let (server, _bg): (TestServer, _) = create_test_app_with_config(pool.clone(), config, false).await;
         let admin = create_test_admin_user(&pool, Role::PlatformManager).await;
 

--- a/dwctl/src/api/handlers/sla_capacity.rs
+++ b/dwctl/src/api/handlers/sla_capacity.rs
@@ -252,7 +252,7 @@ pub(crate) async fn reserve_capacity<P: sqlx_pool_router::PoolProvider>(
     };
 
     // Active reservations are always counted; the pending-count query above is optional.
-    let mut pending_with_reservations = pending_counts.clone();
+    let mut pending_with_reservations = pending_counts;
     for (model_id, reserved) in reserved_rows {
         if let Some(alias) = id_to_alias.get(&model_id) {
             let windows = pending_with_reservations.entry(alias.clone()).or_default();

--- a/dwctl/src/api/handlers/sla_capacity.rs
+++ b/dwctl/src/api/handlers/sla_capacity.rs
@@ -168,6 +168,7 @@ pub(crate) struct CapacityReservationInput<'a> {
     pub default_throughput: f32,
     pub relaxation_factor: f32,
     pub reservation_ttl_secs: i64,
+    pub include_pending_counts: bool,
 }
 
 /// Error type for capacity reservation operations.
@@ -222,31 +223,35 @@ pub(crate) async fn reserve_capacity<P: sqlx_pool_router::PoolProvider>(
         .await
         .map_err(|e| CapacityError::Internal(format!("sum active reservations: {e}")))?;
 
-    // Fetch pending counts AFTER locks to avoid stale snapshots
-    let windows = vec![(
-        input.completion_window.to_string(),
-        None,
-        parse_window_to_seconds(input.completion_window),
-    )];
-    let states = vec!["pending".to_string(), "claimed".to_string(), "processing".to_string()];
-    let model_filter: Vec<String> = input.file_model_counts.keys().cloned().collect();
-
-    // Exclude realtime (`priority`) requests: they're processed externally
-    // (not via the fusillade daemon) and should not consume batch capacity
-    // when admitting new batches.
-    let pending_counts: HashMap<String, HashMap<String, i64>> = request_manager
-        .get_pending_request_counts_by_model_and_window(
-            &windows,
-            &states,
-            &model_filter,
-            &ServiceTierFilter::Exclude(vec![Some("priority".to_string())]),
+    let pending_counts: HashMap<String, HashMap<String, i64>> = if input.include_pending_counts {
+        // Fetch pending counts AFTER locks to avoid stale snapshots.
+        let windows = vec![(
+            input.completion_window.to_string(),
             None,
-            true,
-        )
-        .await
-        .map_err(|e| CapacityError::Internal(format!("get pending counts: {e}")))?;
+            parse_window_to_seconds(input.completion_window),
+        )];
+        let states = vec!["pending".to_string(), "claimed".to_string(), "processing".to_string()];
+        let model_filter: Vec<String> = input.file_model_counts.keys().cloned().collect();
 
-    // Merge reservations into pending
+        // Exclude realtime (`priority`) requests: they're processed externally
+        // (not via the fusillade daemon) and should not consume batch capacity
+        // when admitting new batches.
+        request_manager
+            .get_pending_request_counts_by_model_and_window(
+                &windows,
+                &states,
+                &model_filter,
+                &ServiceTierFilter::Exclude(vec![Some("priority".to_string())]),
+                None,
+                true,
+            )
+            .await
+            .map_err(|e| CapacityError::Internal(format!("get pending counts: {e}")))?
+    } else {
+        HashMap::new()
+    };
+
+    // Active reservations are always counted; the pending-count query above is optional.
     let mut pending_with_reservations = pending_counts.clone();
     for (model_id, reserved) in reserved_rows {
         if let Some(alias) = id_to_alias.get(&model_id) {

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1206,6 +1206,11 @@ pub struct BatchConfig {
     /// count is applied.
     #[serde(default, deserialize_with = "deserialize_non_negative_optional_i64")]
     pub priority_decay_window_secs: Option<i64>,
+    /// Enable the internal pending request counts monitoring endpoint.
+    /// When false, the endpoint returns an empty result without querying fusillade.
+    /// Default: false.
+    #[serde(default)]
+    pub pending_request_counts_enabled: bool,
 }
 
 /// Configuration for the async requests feature.
@@ -1343,6 +1348,7 @@ impl Default for BatchConfig {
             default_throughput: default_batch_throughput(),
             reservation_ttl_secs: default_reservation_ttl_secs(),
             priority_decay_window_secs: None,
+            pending_request_counts_enabled: false,
         }
     }
 }
@@ -3258,6 +3264,12 @@ batches:
     fn test_priority_decay_window_default_disabled() {
         let config = Config::default();
         assert_eq!(config.batches.priority_decay_window_secs, None);
+    }
+
+    #[test]
+    fn test_pending_request_counts_default_disabled() {
+        let config = Config::default();
+        assert!(!config.batches.pending_request_counts_enabled);
     }
 
     #[test]

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1206,11 +1206,11 @@ pub struct BatchConfig {
     /// count is applied.
     #[serde(default, deserialize_with = "deserialize_non_negative_optional_i64")]
     pub priority_decay_window_secs: Option<i64>,
-    /// Enable the internal pending request counts monitoring endpoint.
-    /// When false, the endpoint returns an empty result without querying fusillade.
+    /// Include committed pending/claimed/processing requests in batch admission capacity checks.
+    /// When false, admission capacity checks only include active in-flight reservations.
     /// Default: false.
     #[serde(default)]
-    pub pending_request_counts_enabled: bool,
+    pub pending_capacity_counts_enabled: bool,
 }
 
 /// Configuration for the async requests feature.
@@ -1348,7 +1348,7 @@ impl Default for BatchConfig {
             default_throughput: default_batch_throughput(),
             reservation_ttl_secs: default_reservation_ttl_secs(),
             priority_decay_window_secs: None,
-            pending_request_counts_enabled: false,
+            pending_capacity_counts_enabled: false,
         }
     }
 }
@@ -3267,9 +3267,9 @@ batches:
     }
 
     #[test]
-    fn test_pending_request_counts_default_disabled() {
+    fn test_pending_capacity_counts_default_disabled() {
         let config = Config::default();
-        assert!(!config.batches.pending_request_counts_enabled);
+        assert!(!config.batches.pending_capacity_counts_enabled);
     }
 
     #[test]

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1432,6 +1432,11 @@ pub struct DaemonConfig {
     /// and returned to pending (milliseconds). This handles daemon crashes during execution. (default: 600000 = 10 minutes)
     pub processing_timeout_ms: u64,
 
+    /// PostgreSQL statement timeout for pending request count queries (milliseconds).
+    /// This bounds internal queue-depth monitoring work so a slow count query
+    /// fails without accumulating behind callers' poll cadence. (default: 60000 = 1 minute)
+    pub pending_request_counts_timeout_ms: u64,
+
     /// Per-model configurations for completion window escalation via route-at-claim-time.
     /// When a request is claimed with less than `escalation_threshold_seconds` remaining
     /// before batch expiry, it's routed to the `escalation_model` instead.
@@ -1544,6 +1549,7 @@ impl Default for DaemonConfig {
             status_log_interval_ms: Some(2000),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
+            pending_request_counts_timeout_ms: 60000,
             batch_metadata_fields: default_batch_metadata_fields_dwctl(),
             model_escalations: HashMap::new(),
             purge_interval_ms: 600_000,
@@ -1600,6 +1606,7 @@ impl DaemonConfig {
             status_log_interval_ms: self.status_log_interval_ms,
             claim_timeout_ms: self.claim_timeout_ms,
             processing_timeout_ms: self.processing_timeout_ms,
+            pending_request_counts_timeout_ms: self.pending_request_counts_timeout_ms,
             batch_metadata_fields: self.batch_metadata_fields.clone(),
             purge_interval_ms: self.purge_interval_ms,
             purge_batch_size: self.purge_batch_size,

--- a/dwctl/src/connections/sync.rs
+++ b/dwctl/src/connections/sync.rs
@@ -987,6 +987,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
                 default_throughput: config.batches.default_throughput,
                 relaxation_factor: config.batches.relaxation_factor(&completion_window),
                 reservation_ttl_secs: config.batches.reservation_ttl_secs,
+                include_pending_counts: config.batches.pending_capacity_counts_enabled,
             };
 
             match reserve_capacity(dwctl, &*state.request_manager, &cap_input).await {

--- a/dwctl/src/test/sla.rs
+++ b/dwctl/src/test/sla.rs
@@ -133,6 +133,7 @@ async fn test_route_at_claim_time_escalation(pool: PgPool) {
         body_timeout_ms: 86_400_000,
         claim_timeout_ms: 5000,
         processing_timeout_ms: 10000,
+        pending_request_counts_timeout_ms: 60_000,
         status_log_interval_ms: Some(500),
         // Configure route-at-claim-time escalation
         // When batch is within 60 seconds of expiry, route to escalation model
@@ -397,6 +398,7 @@ async fn test_no_escalation_when_not_near_expiry(pool: PgPool) {
         body_timeout_ms: 86_400_000,
         claim_timeout_ms: 5000,
         processing_timeout_ms: 10000,
+        pending_request_counts_timeout_ms: 60_000,
         status_log_interval_ms: None,
         model_escalations: {
             let mut map = HashMap::new();


### PR DESCRIPTION
## Summary
- Bump fusillade to 19.4.1 and keep the root and nested dwctl lockfiles aligned.
- Make the pending request counts timeout configurable for the batch daemon.
- Disable committed pending-count checks during batch admission by default, while still counting active reservations.
- Keep the pending request counts monitoring endpoint exposed.
- Add regression coverage for disabled vs enabled batch-admission pending count behavior.
- Update sample config, README, and dashboard API types/mocks for the new config fields.

## Testing
- cargo check
- DATABASE_URL=postgres://postgres:password@localhost:5432/dwctl?options=-c%20search_path%3Dpublic cargo test pending_counts_when --lib
- DATABASE_URL=postgres://postgres:password@localhost:5432/dwctl?options=-c%20search_path%3Dpublic cargo test config:: --lib
- DATABASE_URL=postgres://postgres:password@localhost:5432/dwctl?options=-c%20search_path%3Dpublic cargo test api::handlers::queue::tests:: --lib
- pnpm --dir dashboard exec eslint . --max-warnings=0