### PR TITLE
fix: bump onwards to 0.34.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4215,9 +4215,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onwards"
-version = "0.34.4"
+version = "0.34.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca2f7756026d17dcb35818b9c6c66628a145ebab62aef6de38c4ba20aff09fd"
+checksum = "3d98db4d5ffc90c989cb6cf94f17fc4ba4e6dc0b5ab116752e2d826ffca21b64"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/dwctl/Cargo.lock
+++ b/dwctl/Cargo.lock
@@ -4197,9 +4197,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onwards"
-version = "0.34.3"
+version = "0.34.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd70bc7adc54a1469061b38c9200f92f32d60d7e14d077144bff8c2dee032360"
+checksum = "3d98db4d5ffc90c989cb6cf94f17fc4ba4e6dc0b5ab116752e2d826ffca21b64"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -80,7 +80,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 argon2 = "0.5"
 base64 = "0.22"
 bytes = "1.5"
-onwards = { version = "0.34.4", features = ["multi-step"] }
+onwards = { version = "0.34.5", features = ["multi-step"] }
 thiserror = "2.0.14"
 axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)


### PR DESCRIPTION
## Summary
- Bump `onwards` from `0.34.4` to `0.34.5`.
- Refresh the tracked lockfiles for the updated crate checksum.
- Pick up the upstream fix for forwarding Responses text-format options when adapting requests.

## Testing
- `cargo fmt --check`
- `cargo metadata --locked --no-deps`
- `SQLX_OFFLINE=true cargo check -p dwctl --locked`

## Notes
- A filtered `cargo test --locked -p dwctl --lib inference::engine::assembly::tests` run was attempted with `SQLX_OFFLINE=true`, but the test profile currently has unrelated SQLx queries without cached metadata. No SQLx cache files were updated in this dependency-only PR.
