### PR TITLE
fix: list accessible models without credit filtering

### DIFF
--- a/dwctl/src/api/handlers/ai_models.rs
+++ b/dwctl/src/api/handlers/ai_models.rs
@@ -4,7 +4,6 @@ use axum::{
     Json,
     extract::State,
     http::{HeaderMap, StatusCode, header},
-    middleware::Next,
     response::{IntoResponse, Response},
 };
 use serde::Serialize;
@@ -153,22 +152,4 @@ pub async fn list_ai_models<P: PoolProvider>(
             })
             .collect(),
     }))
-}
-
-pub async fn list_ai_models_middleware<P: PoolProvider>(
-    State(state): State<AppState<P>>,
-    request: axum::extract::Request,
-    next: Next,
-) -> Response {
-    let is_models_request = request.method() == axum::http::Method::GET && request.uri().path().ends_with("/models");
-
-    if is_models_request && request.headers().contains_key(header::AUTHORIZATION) {
-        let headers = request.headers().clone();
-        return match list_ai_models(State(state), headers).await {
-            Ok(response) => response.into_response(),
-            Err(response) => response,
-        };
-    }
-
-    next.run(request).await
 }

--- a/dwctl/src/api/handlers/ai_models.rs
+++ b/dwctl/src/api/handlers/ai_models.rs
@@ -3,7 +3,7 @@
 use axum::{
     Json,
     extract::State,
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, StatusCode, header},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -46,10 +46,22 @@ fn openai_error(status: StatusCode, message: &str, error_type: &str, code: &str)
 }
 
 fn bearer_token(headers: &HeaderMap) -> Option<&str> {
-    headers
-        .get("authorization")
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.strip_prefix("Bearer "))
+    let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?.trim();
+    let (scheme, token) = value.split_once(char::is_whitespace)?;
+    scheme
+        .eq_ignore_ascii_case("bearer")
+        .then_some(token.trim())
+        .filter(|token| !token.is_empty())
+}
+
+fn database_error(operation: &str, error: impl std::fmt::Display) -> Response {
+    tracing::error!(%error, operation, "Failed to list AI models");
+    openai_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Internal server error",
+        "server_error",
+        "database_error",
+    )
 }
 
 /// List active models that the presented inference API key has group access to.
@@ -65,19 +77,17 @@ pub async fn list_ai_models<P: PoolProvider>(
         return Err(openai_error(
             StatusCode::UNAUTHORIZED,
             "Missing Authorization header",
-            "invalid_request_error",
+            "authentication_error",
             "missing_authorization",
         ));
     };
 
-    let mut conn = state.db.read().acquire().await.map_err(|e| {
-        openai_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("Database error: {e}"),
-            "server_error",
-            "database_error",
-        )
-    })?;
+    let mut conn = state
+        .db
+        .read()
+        .acquire()
+        .await
+        .map_err(|e| database_error("acquire_read_connection", e))?;
 
     let user_id = sqlx::query_scalar::<_, uuid::Uuid>(
         r#"
@@ -94,20 +104,13 @@ pub async fn list_ai_models<P: PoolProvider>(
     .bind(token)
     .fetch_optional(&mut *conn)
     .await
-    .map_err(|e| {
-        openai_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("Database error: {e}"),
-            "server_error",
-            "database_error",
-        )
-    })?;
+    .map_err(|e| database_error("lookup_api_key", e))?;
 
     let Some(user_id) = user_id else {
         return Err(openai_error(
-            StatusCode::FORBIDDEN,
+            StatusCode::UNAUTHORIZED,
             "Invalid API key",
-            "invalid_request_error",
+            "authentication_error",
             "invalid_api_key",
         ));
     };
@@ -136,14 +139,7 @@ pub async fn list_ai_models<P: PoolProvider>(
     .bind(EVERYONE_GROUP_ID)
     .fetch_all(&mut *conn)
     .await
-    .map_err(|e| {
-        openai_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("Database error: {e}"),
-            "server_error",
-            "database_error",
-        )
-    })?;
+    .map_err(|e| database_error("list_accessible_models", e))?;
 
     Ok(Json(ModelsListResponse {
         object: "list".to_string(),
@@ -164,7 +160,10 @@ pub async fn list_ai_models_middleware<P: PoolProvider>(
     request: axum::extract::Request,
     next: Next,
 ) -> Response {
-    if request.method() == axum::http::Method::GET && request.uri().path() == "/models" {
+    let is_models_request = request.method() == axum::http::Method::GET && request.uri().path().ends_with("/models");
+    let is_anthropic_models_request = request.headers().contains_key("anthropic-version");
+
+    if is_models_request && !is_anthropic_models_request && request.headers().contains_key(header::AUTHORIZATION) {
         let headers = request.headers().clone();
         return match list_ai_models(State(state), headers).await {
             Ok(response) => response.into_response(),

--- a/dwctl/src/api/handlers/ai_models.rs
+++ b/dwctl/src/api/handlers/ai_models.rs
@@ -1,0 +1,176 @@
+//! OpenAI-compatible model listing for inference API keys.
+
+use axum::{
+    Json,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+use serde_json::json;
+use sqlx::Row;
+use sqlx_pool_router::PoolProvider;
+
+use crate::AppState;
+
+const EVERYONE_GROUP_ID: uuid::Uuid = uuid::Uuid::nil();
+
+#[derive(Serialize)]
+pub struct ModelsListResponse {
+    object: String,
+    data: Vec<ModelObject>,
+}
+
+#[derive(Serialize)]
+struct ModelObject {
+    id: String,
+    object: String,
+    created: i64,
+    owned_by: String,
+}
+
+fn openai_error(status: StatusCode, message: &str, error_type: &str, code: &str) -> Response {
+    (
+        status,
+        Json(json!({
+            "error": {
+                "message": message,
+                "type": error_type,
+                "param": null,
+                "code": code
+            }
+        })),
+    )
+        .into_response()
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+}
+
+/// List active models that the presented inference API key has group access to.
+///
+/// This intentionally does not filter by credit balance. Credit balance controls
+/// dispatch eligibility in the onwards key sync; model discovery should reflect
+/// access grants so users can still see what would be available after top-up.
+pub async fn list_ai_models<P: PoolProvider>(
+    State(state): State<AppState<P>>,
+    headers: HeaderMap,
+) -> Result<Json<ModelsListResponse>, Response> {
+    let Some(token) = bearer_token(&headers) else {
+        return Err(openai_error(
+            StatusCode::UNAUTHORIZED,
+            "Missing Authorization header",
+            "invalid_request_error",
+            "missing_authorization",
+        ));
+    };
+
+    let mut conn = state.db.read().acquire().await.map_err(|e| {
+        openai_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("Database error: {e}"),
+            "server_error",
+            "database_error",
+        )
+    })?;
+
+    let user_id = sqlx::query_scalar::<_, uuid::Uuid>(
+        r#"
+        SELECT ak.user_id
+        FROM api_keys ak
+        INNER JOIN users u ON u.id = ak.user_id
+        WHERE ak.secret = $1
+          AND ak.is_deleted = FALSE
+          AND u.is_deleted = FALSE
+          AND ak.purpose IN ('realtime', 'batch', 'playground')
+        LIMIT 1
+        "#,
+    )
+    .bind(token)
+    .fetch_optional(&mut *conn)
+    .await
+    .map_err(|e| {
+        openai_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("Database error: {e}"),
+            "server_error",
+            "database_error",
+        )
+    })?;
+
+    let Some(user_id) = user_id else {
+        return Err(openai_error(
+            StatusCode::FORBIDDEN,
+            "Invalid API key",
+            "invalid_request_error",
+            "invalid_api_key",
+        ));
+    };
+
+    let rows = sqlx::query(
+        r#"
+        SELECT DISTINCT
+            dm.alias,
+            EXTRACT(EPOCH FROM dm.created_at)::BIGINT AS created
+        FROM deployed_models dm
+        INNER JOIN deployment_groups dg ON dg.deployment_id = dm.id
+        WHERE dm.deleted = FALSE
+          AND dm.status = 'active'
+          AND (
+              dg.group_id = $2
+              OR dg.group_id IN (
+                  SELECT ug.group_id
+                  FROM user_groups ug
+                  WHERE ug.user_id = $1
+              )
+        )
+        ORDER BY dm.alias
+        "#,
+    )
+    .bind(user_id)
+    .bind(EVERYONE_GROUP_ID)
+    .fetch_all(&mut *conn)
+    .await
+    .map_err(|e| {
+        openai_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("Database error: {e}"),
+            "server_error",
+            "database_error",
+        )
+    })?;
+
+    Ok(Json(ModelsListResponse {
+        object: "list".to_string(),
+        data: rows
+            .into_iter()
+            .map(|row| ModelObject {
+                id: row.get("alias"),
+                object: "model".to_string(),
+                created: row.get::<Option<i64>, _>("created").unwrap_or_default(),
+                owned_by: "None".to_string(),
+            })
+            .collect(),
+    }))
+}
+
+pub async fn list_ai_models_middleware<P: PoolProvider>(
+    State(state): State<AppState<P>>,
+    request: axum::extract::Request,
+    next: Next,
+) -> Response {
+    if request.method() == axum::http::Method::GET && request.uri().path() == "/models" {
+        let headers = request.headers().clone();
+        return match list_ai_models(State(state), headers).await {
+            Ok(response) => response.into_response(),
+            Err(response) => response,
+        };
+    }
+
+    next.run(request).await
+}

--- a/dwctl/src/api/handlers/ai_models.rs
+++ b/dwctl/src/api/handlers/ai_models.rs
@@ -161,9 +161,8 @@ pub async fn list_ai_models_middleware<P: PoolProvider>(
     next: Next,
 ) -> Response {
     let is_models_request = request.method() == axum::http::Method::GET && request.uri().path().ends_with("/models");
-    let is_anthropic_models_request = request.headers().contains_key("anthropic-version");
 
-    if is_models_request && !is_anthropic_models_request && request.headers().contains_key(header::AUTHORIZATION) {
+    if is_models_request && request.headers().contains_key(header::AUTHORIZATION) {
         let headers = request.headers().clone();
         return match list_ai_models(State(state), headers).await {
             Ok(response) => response.into_response(),

--- a/dwctl/src/api/handlers/mod.rs
+++ b/dwctl/src/api/handlers/mod.rs
@@ -31,6 +31,7 @@
 //! appropriate HTTP status codes and JSON error responses. See [`crate::errors`]
 //! for details on error types and HTTP status mappings.
 
+pub mod ai_models;
 pub mod api_keys;
 pub mod auth;
 pub mod batch_requests;

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1576,8 +1576,9 @@ pub async fn build_router(
     // wrapper: on a request it runs first; on the response it runs last. The stack below,
     // outermost → innermost (i.e. reverse of the code order), is:
     //
-    //   responses_mw  →  outlet (logging/billing)  →  cache  →  error_enrichment
-    //                 →  image_normalizer  →  tool_injection  →  onwards
+    //   translation  →  models_list  →  responses_mw  →  outlet (logging/billing)
+    //                →  cache  →  error_enrichment  →  image_normalizer
+    //                →  tool_injection  →  onwards
     //
     // Why this order:
     //   • outlet outermost (of the body editors): it logs the request **as the customer
@@ -1690,15 +1691,23 @@ pub async fn build_router(
         onwards_router
     };
 
+    // Serve authenticated OpenAI-shaped model discovery from the control-layer
+    // database before falling through to onwards. This sits inside protocol
+    // translation so Anthropic `/v1/models` first normalizes `x-api-key` to
+    // `Authorization`, then this handler returns the OpenAI list, then the
+    // translator reshapes it back to Anthropic's response format.
+    let onwards_router = onwards_router.layer(middleware::from_fn_with_state(
+        state.clone(),
+        api::handlers::ai_models::list_ai_models_middleware,
+    ));
+
     // Apply the generic edge protocol-translation middleware as the OUTERMOST
     // layer on the onwards router. On the request path it runs first, so any
-    // foreign-protocol request (today: Anthropic `/v1/messages`) is translated
-    // to Chat Completions and its URI rewritten BEFORE image_normalizer,
-    // tool_injection, and onwards see it. On the response path it runs last, so
-    // outlet logging, billing, and usage extraction all observe Chat
-    // Completions, and only the final client bytes are reframed back into the
-    // foreign protocol. Native `/chat/completions` requests match no translator
-    // and pass through untouched.
+    // foreign-protocol request (today: Anthropic `/v1/messages` and `/v1/models`)
+    // is translated before model discovery, image_normalizer, tool_injection,
+    // and onwards see it. On the response path it runs last, so only the final
+    // client bytes are reframed back into the foreign protocol. Native OpenAI
+    // requests match no translator and pass through untouched.
     let onwards_router = {
         // Bound the body the translation middleware buffers by the same cap as the
         // rest of the inference path (limits.requests.max_body_size, 0 = unlimited).
@@ -1732,11 +1741,6 @@ pub async fn build_router(
         .merge(auth_routes);
 
     // Add AI routes with appropriate nesting based on strict mode
-    let onwards_router = onwards_router.layer(middleware::from_fn_with_state(
-        state.clone(),
-        api::handlers::ai_models::list_ai_models_middleware,
-    ));
-
     if strict_mode {
         // Strict mode: nest onwards at /ai/v1, nest batches at /ai/v1
         router = router.nest("/ai/v1", onwards_router);

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1732,6 +1732,11 @@ pub async fn build_router(
         .merge(auth_routes);
 
     // Add AI routes with appropriate nesting based on strict mode
+    let onwards_router = onwards_router.layer(middleware::from_fn_with_state(
+        state.clone(),
+        api::handlers::ai_models::list_ai_models_middleware,
+    ));
+
     if strict_mode {
         // Strict mode: nest onwards at /ai/v1, nest batches at /ai/v1
         router = router.nest("/ai/v1", onwards_router);

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1576,9 +1576,9 @@ pub async fn build_router(
     // wrapper: on a request it runs first; on the response it runs last. The stack below,
     // outermost → innermost (i.e. reverse of the code order), is:
     //
-    //   translation  →  models_list  →  responses_mw  →  outlet (logging/billing)
+    //   translation  →  responses_mw  →  outlet (logging/billing)
     //                →  cache  →  error_enrichment  →  image_normalizer
-    //                →  tool_injection  →  onwards
+    //                →  tool_injection  →  models_route  →  onwards
     //
     // Why this order:
     //   • outlet outermost (of the body editors): it logs the request **as the customer
@@ -1595,6 +1595,15 @@ pub async fn build_router(
     //   • tool_injection innermost: the body onwards forwards upstream is fully resolved.
     //
     // Each block below adds one layer; the inline notes cover that layer's specifics.
+
+    // Serve authenticated OpenAI-shaped model discovery from the control-layer
+    // database using a real exact route. Other AI paths fall through to the
+    // existing onwards router. Because this route is inserted before the shared
+    // onwards middleware stack is layered on, request logging and protocol
+    // translation still apply to `/models` just like other AI routes.
+    let onwards_router = Router::new()
+        .route("/models", get(api::handlers::ai_models::list_ai_models))
+        .fallback_service(onwards_router);
 
     // Apply tool injection middleware to the onwards router so that per-request tool
     // schemas are resolved and injected into the request body before onwards processes it.
@@ -1691,16 +1700,6 @@ pub async fn build_router(
         onwards_router
     };
 
-    // Serve authenticated OpenAI-shaped model discovery from the control-layer
-    // database before falling through to onwards. This sits inside protocol
-    // translation so Anthropic `/v1/models` first normalizes `x-api-key` to
-    // `Authorization`, then this handler returns the OpenAI list, then the
-    // translator reshapes it back to Anthropic's response format.
-    let onwards_router = onwards_router.layer(middleware::from_fn_with_state(
-        state.clone(),
-        api::handlers::ai_models::list_ai_models_middleware,
-    ));
-
     // Apply the generic edge protocol-translation middleware as the OUTERMOST
     // layer on the onwards router. On the request path it runs first, so any
     // foreign-protocol request (today: Anthropic `/v1/messages` and `/v1/models`)
@@ -1742,26 +1741,15 @@ pub async fn build_router(
 
     // Add AI routes with appropriate nesting based on strict mode
     if strict_mode {
-        // Strict mode: nest onwards at /ai/v1, nest batches at /ai/v1
-        router = router.nest("/ai/v1", onwards_router);
-        if let Some(batches) = batches_routes {
-            // Add fallback to batches router to return 404 for unknown routes
-            // This prevents unknown /ai/v1/* requests from falling through to the
-            // global GET-only fallback which would return 405 for POST requests
-            let batches_with_fallback = batches.fallback(|| async {
-                (
-                    axum::http::StatusCode::NOT_FOUND,
-                    axum::Json(serde_json::json!({
-                        "error": {
-                            "message": "Unknown endpoint",
-                            "type": "invalid_request_error",
-                            "code": "not_found"
-                        }
-                    })),
-                )
-            });
-            router = router.nest("/ai/v1", batches_with_fallback);
-        }
+        // Strict mode: combine batches and onwards before nesting so the shared
+        // `/models` route wrapper can fall through to onwards without competing
+        // with a second `/ai/v1` fallback.
+        let ai_router = if let Some(batches) = batches_routes {
+            batches.merge(onwards_router)
+        } else {
+            onwards_router
+        };
+        router = router.nest("/ai/v1", ai_router);
     } else {
         // Non-strict mode: merge batches + onwards, nest at /ai/v1
         let ai_router = if let Some(batches) = batches_routes {
@@ -1817,7 +1805,8 @@ pub async fn build_router(
     let router = router
         .nest("/admin/api/v1", api_routes_with_state)
         .merge(openapi_router.with_state(state.clone()))
-        .fallback_service(fallback.with_state(state.clone()));
+        .fallback_service(fallback.with_state(state.clone()))
+        .with_state(state.clone());
 
     // Apply CORS to the main router (request logging already applied to
     // onwards_router above). When configured, this also opens uncredentialed

--- a/dwctl/src/test/anthropic.rs
+++ b/dwctl/src/test/anthropic.rs
@@ -96,6 +96,37 @@ async fn wait_for_model(server: &TestServer, api_key: &str) {
 }
 
 #[sqlx::test]
+async fn anthropic_models_uses_control_layer_model_discovery(pool: PgPool) {
+    let mock = wiremock::MockServer::start().await;
+
+    let mut config = create_test_config();
+    config.onwards.strict_mode = true;
+    config.background_services.onwards_sync.enabled = true;
+    let app = crate::Application::new_with_pool(config, Some(pool.clone()), None)
+        .await
+        .expect("app");
+    let (server, _bg) = app.into_test_server();
+
+    let api_key = seed_model_and_key(&server, &pool, &mock.uri()).await;
+
+    let resp = server
+        .get("/ai/v1/models")
+        .add_header("x-api-key", &api_key)
+        .add_header("anthropic-version", "2023-06-01")
+        .await;
+
+    let status = resp.status_code();
+    let text = resp.text();
+    assert_eq!(status, 200, "got {status}: {text}");
+
+    let body: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(body["has_more"], false);
+    assert_eq!(body["data"][0]["type"], "model");
+    assert_eq!(body["data"][0]["id"], "gpt-4");
+    assert_eq!(body["data"][0]["display_name"], "gpt-4");
+}
+
+#[sqlx::test]
 async fn anthropic_messages_blocking_end_to_end(pool: PgPool) {
     let mock = wiremock::MockServer::start().await;
     wiremock::Mock::given(wiremock::matchers::method("POST"))

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -248,7 +248,7 @@ async fn ai_models_lists_group_accessible_paid_models_without_credits(pool: PgPo
         .json(&serde_json::json!({
             "type": "standard",
             "model_name": "paid-model",
-            "alias": alias,
+            "alias": alias.clone(),
             "description": "Paid model visible with zero credits",
             "hosted_on": endpoint.id,
             "tariffs": [{
@@ -300,13 +300,14 @@ async fn ai_models_lists_group_accessible_paid_models_without_credits(pool: PgPo
         .post("/ai/v1/chat/completions")
         .add_header("authorization", format!("Bearer {}", api_key.key))
         .json(&serde_json::json!({
-            "model": alias,
+            "model": alias.clone(),
             "messages": [{"role": "user", "content": "hello"}]
         }))
         .await;
-    assert!(
-        !completion_response.status_code().is_success(),
-        "Zero-credit key should still be excluded from paid inference"
+    assert_eq!(
+        completion_response.status_code(),
+        404,
+        "Zero-credit key should remain absent from the dispatch target pool"
     );
 }
 

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -192,6 +192,124 @@ async fn wait_for_model(server: &TestServer, api_key: &str, alias: &str) {
     assert_eq!(status, 200, "Model should be available in onwards config after polling");
 }
 
+#[sqlx::test]
+async fn ai_models_lists_group_accessible_paid_models_without_credits(pool: PgPool) {
+    let mut config = crate::test::utils::create_test_config();
+    config.background_services.onwards_sync.enabled = true;
+
+    let app = crate::Application::new_with_pool(config, Some(pool.clone()), None)
+        .await
+        .expect("Failed to create application");
+    let (server, bg_services) = app.into_test_server();
+
+    let admin_user = create_test_admin_user(&pool, Role::PlatformManager).await;
+    let admin_headers = add_auth_headers(&admin_user);
+
+    let regular_user = create_test_user(&pool, Role::StandardUser).await;
+    let regular_headers = add_auth_headers(&regular_user);
+
+    let group_response = server
+        .post("/admin/api/v1/groups")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&serde_json::json!({
+            "name": format!("zero-balance-models-{}", Uuid::new_v4()),
+            "description": "Models list access for zero-balance users"
+        }))
+        .await;
+    assert_eq!(group_response.status_code(), 201, "Failed to create group");
+    let group: GroupResponse = group_response.json();
+
+    let add_user_response = server
+        .post(&format!("/admin/api/v1/groups/{}/users/{}", group.id, regular_user.id))
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .await;
+    assert_eq!(add_user_response.status_code(), 204, "Failed to add user to group");
+
+    let endpoint_response = server
+        .post("/admin/api/v1/endpoints")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&serde_json::json!({
+            "name": format!("Zero Balance Endpoint {}", Uuid::new_v4()),
+            "url": "https://example.invalid/v1/",
+            "description": "Endpoint for zero-balance model list test"
+        }))
+        .await;
+    assert_eq!(endpoint_response.status_code(), 201, "Failed to create endpoint");
+    let endpoint: crate::api::models::inference_endpoints::InferenceEndpointResponse = endpoint_response.json();
+
+    let alias = format!("paid-model-visible-{}", Uuid::new_v4());
+    let deployment_response = server
+        .post("/admin/api/v1/models")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&serde_json::json!({
+            "type": "standard",
+            "model_name": "paid-model",
+            "alias": alias,
+            "description": "Paid model visible with zero credits",
+            "hosted_on": endpoint.id,
+            "tariffs": [{
+                "name": "realtime",
+                "input_price_per_token": "0.001",
+                "output_price_per_token": "0.001",
+                "api_key_purpose": "realtime"
+            }]
+        }))
+        .await;
+    assert_eq!(deployment_response.status_code(), 200, "Failed to create deployment");
+    let deployment: crate::api::models::deployments::DeployedModelResponse = deployment_response.json();
+
+    let add_deployment_response = server
+        .post(&format!("/admin/api/v1/groups/{}/models/{}", group.id, deployment.id))
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .await;
+    assert_eq!(add_deployment_response.status_code(), 204, "Failed to add deployment to group");
+
+    let api_key_response = server
+        .post(&format!("/admin/api/v1/users/{}/api-keys", regular_user.id))
+        .add_header(&regular_headers[0].0, &regular_headers[0].1)
+        .add_header(&regular_headers[1].0, &regular_headers[1].1)
+        .json(&serde_json::json!({
+            "name": "Zero Balance Realtime Key",
+            "purpose": "realtime"
+        }))
+        .await;
+    assert_eq!(api_key_response.status_code(), 201, "Failed to create API key");
+    let api_key: crate::api::models::api_keys::ApiKeyResponse = api_key_response.json();
+
+    let models_response = server
+        .get("/ai/v1/models")
+        .add_header("authorization", format!("Bearer {}", api_key.key))
+        .await;
+    assert_eq!(models_response.status_code(), 200);
+    let models: serde_json::Value = models_response.json();
+    assert!(
+        models["data"]
+            .as_array()
+            .is_some_and(|data| data.iter().any(|model| model["id"].as_str() == Some(alias.as_str()))),
+        "Models list should include group-accessible paid models even without credits: {models}"
+    );
+
+    bg_services.sync_onwards_config(&pool).await.expect("Failed to sync onwards config");
+
+    let completion_response = server
+        .post("/ai/v1/chat/completions")
+        .add_header("authorization", format!("Bearer {}", api_key.key))
+        .json(&serde_json::json!({
+            "model": alias,
+            "messages": [{"role": "user", "content": "hello"}]
+        }))
+        .await;
+    assert!(
+        !completion_response.status_code().is_success(),
+        "Zero-credit key should still be excluded from paid inference"
+    );
+}
+
 async fn assert_usage_recorded(fixture: &StreamingFixture, expected_uri: &str, prompt_tokens: i64, completion_tokens: i64) {
     let mut tries = 0;
     let usage_tx = loop {


### PR DESCRIPTION
## Summary
- serve the OpenAI-compatible AI models list from control-layer access grants instead of the proxy dispatch key set
- keep inference dispatch governed by the existing runtime eligibility checks
- add regression coverage for a key that can discover an accessible paid model without being eligible to run it

## Test plan
- `DATABASE_URL=... cargo test -p dwctl ai_models_lists_group_accessible_paid_models_without_credits`
- `SQLX_OFFLINE=true cargo check -p dwctl --lib`