### PR TITLE
feat: add pending request service tier controls

### DIFF
--- a/dashboard/src/components/features/requests/RequestsAnalytics/RequestsAnalytics.test.tsx
+++ b/dashboard/src/components/features/requests/RequestsAnalytics/RequestsAnalytics.test.tsx
@@ -1,0 +1,112 @@
+import { render, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+import { ReactNode } from "react";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { RequestsAnalytics } from "./RequestsAnalytics";
+
+const aggregateResponse = {
+  total_requests: 12,
+  status_codes: [{ status: "200", count: 12, percentage: 100 }],
+  models: [{ model: "claude-sonnet-3.5", count: 12 }],
+  time_series: [
+    {
+      timestamp: new Date("2026-07-09T12:00:00.000Z").toISOString(),
+      requests: 12,
+      input_tokens: 1200,
+      output_tokens: 600,
+      avg_latency_ms: 120,
+      p95_latency_ms: 200,
+      p99_latency_ms: 320,
+    },
+  ],
+};
+
+const pendingServiceTierQueries: Array<string | null> = [];
+
+const server = setupServer(
+  http.get("/admin/api/v1/requests/aggregate", () => {
+    return HttpResponse.json(aggregateResponse);
+  }),
+  http.get("/admin/api/v1/models", () => {
+    return HttpResponse.json({
+      data: [
+        {
+          id: "model-1",
+          alias: "claude-sonnet-3.5",
+          model_name: "claude-sonnet-3.5",
+        },
+      ],
+      total_count: 1,
+      skip: 0,
+      limit: 100,
+    });
+  }),
+  http.get(
+    "/admin/api/v1/monitoring/pending-request-counts",
+    ({ request }) => {
+      const url = new URL(request.url);
+      pendingServiceTierQueries.push(url.searchParams.get("service_tiers"));
+
+      return HttpResponse.json({
+        "claude-sonnet-3.5": { "1h": 2, "24h": 4 },
+      });
+    },
+  ),
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+  pendingServiceTierQueries.length = 0;
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("RequestsAnalytics", () => {
+  it("sends selected pending service tiers to the pending count query", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <RequestsAnalytics selectedModel="claude-sonnet-3.5" />,
+      { wrapper: createWrapper() },
+    );
+    const view = within(container);
+
+    await waitFor(() => {
+      expect(pendingServiceTierQueries).toContain("batch");
+    });
+
+    const batchToggle = await view.findByRole("button", { name: "Batch" });
+    const flexToggle = view.getByRole("button", { name: "Flex" });
+
+    expect(batchToggle).toHaveAttribute("aria-pressed", "true");
+    expect(flexToggle).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(flexToggle);
+
+    await waitFor(() => {
+      expect(pendingServiceTierQueries).toContain("batch,flex");
+    });
+
+    await user.click(batchToggle);
+
+    await waitFor(() => {
+      expect(pendingServiceTierQueries).toContain("flex");
+    });
+  });
+});

--- a/dashboard/src/components/features/requests/RequestsAnalytics/RequestsAnalytics.tsx
+++ b/dashboard/src/components/features/requests/RequestsAnalytics/RequestsAnalytics.tsx
@@ -23,12 +23,23 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "../../../ui/hover-card";
+import { ToggleGroup, ToggleGroupItem } from "../../../ui/toggle-group";
 import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from "../../../ui/chart";
 import type { ChartConfig } from "../../../ui/chart";
+
+const pendingServiceTierOptions = [
+  { value: "batch", label: "Batch" },
+  { value: "flex", label: "Flex" },
+  { value: "priority", label: "Priority" },
+] as const;
+
+type PendingServiceTier = (typeof pendingServiceTierOptions)[number]["value"];
+
+const defaultPendingServiceTiers: PendingServiceTier[] = ["batch"];
 
 interface RequestsAnalyticsProps {
   selectedModel?: string;
@@ -47,11 +58,37 @@ export function RequestsAnalytics({
   const { data: allModelsData } = useRequestsAggregate(undefined, dateRange);
   const { data: modelsData } = useModels();
 
+  const [pendingServiceTiers, setPendingServiceTiers] = React.useState<
+    PendingServiceTier[]
+  >(() => [...defaultPendingServiceTiers]);
+  const pendingServiceTierFilter = React.useMemo(
+    () => pendingServiceTiers.join(","),
+    [pendingServiceTiers],
+  );
+  const handlePendingServiceTiersChange = React.useCallback(
+    (serviceTiers: string[]) => {
+      const selectedTiers = serviceTiers.filter(
+        (tier): tier is PendingServiceTier =>
+          pendingServiceTierOptions.some((option) => option.value === tier),
+      );
+
+      setPendingServiceTiers(
+        selectedTiers.length > 0
+          ? selectedTiers
+          : [...defaultPendingServiceTiers],
+      );
+    },
+    [],
+  );
+
   const {
     data: pendingCounts,
     isLoading: pendingCountsLoading,
     error: pendingCountsError,
-  } = usePendingRequestCounts({ enabled: !!selectedModel });
+  } = usePendingRequestCounts({
+    enabled: !!selectedModel,
+    service_tiers: pendingServiceTierFilter,
+  });
 
   // Initialize all React hooks at the top
   const [activeModel, setActiveModel] = React.useState("");
@@ -233,21 +270,43 @@ export function RequestsAnalytics({
       {/* Pending Queue Card - only show when a model is selected */}
       {selectedModel && (
         <Card>
-          <CardHeader>
-            <CardTitle className="text-sm flex items-center gap-1">
-              Pending Queue (Priority)
-              <HoverCard openDelay={100} closeDelay={100}>
-                <HoverCardTrigger asChild>
-                  <Info className="h-3 w-3 text-muted-foreground " />
-                </HoverCardTrigger>
-                <HoverCardContent className="w-80">
-                  <p className="text-sm">
-                    Shows how many batch requests are currently waiting for the
-                    selected model, grouped by priority.
-                  </p>
-                </HoverCardContent>
-              </HoverCard>
-            </CardTitle>
+          <CardHeader className="gap-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <CardTitle className="text-sm flex items-center gap-1">
+                Pending Queue
+                <HoverCard openDelay={100} closeDelay={100}>
+                  <HoverCardTrigger asChild>
+                    <Info className="h-3 w-3 text-muted-foreground " />
+                  </HoverCardTrigger>
+                  <HoverCardContent className="w-80">
+                    <p className="text-sm">
+                      Shows pending, claimed, and processing requests for the
+                      selected model. Use the service tier filter to choose
+                      which tiers feed this count.
+                    </p>
+                  </HoverCardContent>
+                </HoverCard>
+              </CardTitle>
+              <ToggleGroup
+                type="multiple"
+                value={pendingServiceTiers}
+                onValueChange={handlePendingServiceTiersChange}
+                className="flex-wrap"
+                variant="outline"
+                size="sm"
+                aria-label="Pending count service tiers"
+              >
+                {pendingServiceTierOptions.map((option) => (
+                  <ToggleGroupItem
+                    key={option.value}
+                    value={option.value}
+                    className="h-7 px-2 text-xs"
+                  >
+                    {option.label}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+            </div>
           </CardHeader>
           <CardContent className="flex justify-center items-center min-h-32">
             {pendingCountsLoading ? (


### PR DESCRIPTION
## Summary
- add Batch/Flex/Priority service tier controls to the pending queue analytics card
- default pending count queries to `service_tiers=batch` from the UI
- refetch pending counts when the selected tier set changes
- cover the query-string behavior with a RequestsAnalytics component test

## Tests
- `pnpm -C dashboard test src/components/features/requests/RequestsAnalytics/RequestsAnalytics.test.tsx --run`
- `pnpm -C dashboard exec eslint src/components/features/requests/RequestsAnalytics/RequestsAnalytics.tsx src/components/features/requests/RequestsAnalytics/RequestsAnalytics.test.tsx`
- `pnpm -C dashboard exec tsc -b tsconfig.app.json --pretty false`
- `git diff --check`
- `pnpm -C dashboard exec eslint .`
- `pnpm -C dashboard test --run`