### PR TITLE
chore(deps): bump undici from 7.24.7 to 7.28.0 in /dashboard

### DIFF
--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -1319,8 +1319,8 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
-  '@rollup/wasm-node@4.62.0':
-    resolution: {integrity: sha512-TW5f2b5d8Y1DwilaxaXhPkYI1a+i1Am2+eDEf6Tu/QrPxt6kdh/4HT6y460MmzE1im71rudvEs5zLLFr7qBAtQ==}
+  '@rollup/wasm-node@4.62.2':
+    resolution: {integrity: sha512-LseVv64SSO6S7eyc+LFGUnH36NMMFbtKN28vTUHFinRVzFKH4cVQ/BB22JfXM9Ei5l7x46AIQp+n2QzzJ9kxHg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -3551,8 +3551,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.24.7:
-    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -4822,7 +4822,7 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rollup/wasm-node@4.62.0':
+  '@rollup/wasm-node@4.62.2':
     dependencies:
       '@types/estree': 1.0.9
     optionalDependencies:
@@ -6266,7 +6266,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.7
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -7480,7 +7480,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.24.7: {}
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -7579,7 +7579,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.14
-      rollup: '@rollup/wasm-node@4.62.0'
+      rollup: '@rollup/wasm-node@4.62.2'
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.12.2


### PR DESCRIPTION
## What

Bumps `undici` `7.24.7` → `7.28.0` in `dashboard/pnpm-lock.yaml`, clearing six Dependabot alerts:

| Severity | Advisory |
|---|---|
| High | GHSA-hm92-r4w5-c3mj |
| High | GHSA-vmh5-mc38-953g |
| Medium | GHSA-p88m-4jfj-68fv |
| Medium | GHSA-pr7r-676h-xcf6 |
| Low | GHSA-g8m3-5g58-fq7m |
| Low | GHSA-35p6-xmwp-9g52 |

## Impact

Lower than the severity labels suggest. `undici` is not a direct dependency and is not in the production bundle — it arrives transitively through `jsdom`, which is a `devDependency` used solely as the vitest test environment. The exposure is test-time only.

## Note on the `@rollup/wasm-node` hunk

The diff also moves `@rollup/wasm-node` `4.62.0` → `4.62.2`. This is not incidental noise I can drop: the `rollup` override in `package.json` is unpinned (`"rollup": "npm:@rollup/wasm-node"`), so pnpm re-resolves it to the latest patch on any lockfile update. Separating it would require pinning the override, which is a different change. It is a patch bump and the production build passes.

## Verification

- `pnpm install --frozen-lockfile` succeeds (this is what CI and both Dockerfiles run)
- `just test ts` — 617 tests across 51 files pass
- `just lint ts` clean
- `pnpm run build` succeeds
- `libc:` fields in the lockfile preserved (see below)

## Reviewer note

Regenerate this lockfile with **pnpm ≥ 10.34**, not an older 10.x. Older pnpm silently strips the `libc: [glibc]` / `libc: [musl]` fields from the `@tailwindcss/oxide-*` and `lightningcss-*` platform packages, which is what selects the correct native binary on musl vs glibc images. The Dockerfiles install floating `pnpm@10`, so a stale local pnpm would introduce that regression invisibly. This branch keeps all 9 `libc:` lines intact.

The remaining open Dependabot alerts (`cmov`, `opentelemetry_sdk`, both Rust) are untouched here and still have open Dependabot PRs.