### PR TITLE
feat: upgrade fusillade split daemon runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,6 +1916,7 @@ dependencies = [
  "figment",
  "flate2",
  "fusillade",
+ "fusillade-arsenal",
  "futures",
  "google-cloud-auth",
  "google-cloud-storage",
@@ -2353,15 +2354,17 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "20.0.2"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c5aaac2eb541b427edf1f90735e35d118491974fc83a64858bdbfb972b7475"
+checksum = "d5d04f5b7ddafc991a80fd3e5d4988efaf6af791e3b8ea5557232f462eafdf35"
 dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
  "dashmap",
  "eventsource-stream",
+ "fusillade-arsenal",
+ "fusillade-core",
  "futures",
  "hostname",
  "humantime",
@@ -2374,14 +2377,59 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
- "sqlx",
- "sqlx-pool-router",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
  "tracing-opentelemetry",
+ "uuid",
+]
+
+[[package]]
+name = "fusillade-arsenal"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06df8fb12fcaa31fd34880a656abf9292dbb98ee8d9109164f9295e2f1ffcc6a"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "either",
+ "fusillade-core",
+ "futures",
+ "humantime",
+ "metrics",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "sqlx-pool-router",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "fusillade-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523273ae988756dd1260bba667af3f078df2e1171d798f3c06655d91052127b8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -4216,8 +4264,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "onwards"
 version = "0.34.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d98db4d5ffc90c989cb6cf94f17fc4ba4e6dc0b5ab116752e2d826ffca21b64"
+source = "git+https://github.com/doublewordai/onwards?branch=peter%2Ffusillade-21-compat#a7949320c7e58ef8d61dc668d3ccc8022273b085"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4263,8 +4263,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onwards"
-version = "0.34.5"
-source = "git+https://github.com/doublewordai/onwards?branch=peter%2Ffusillade-21-compat#a7949320c7e58ef8d61dc668d3ccc8022273b085"
+version = "0.34.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df68efd08162f124ab0d9891e05e8585d32f844b10a9baf6e121d49477d616b"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/config.yaml
+++ b/config.yaml
@@ -510,6 +510,11 @@ background_services:
     # - "leader": Only run on the elected leader instance
     # - "never": Never run the daemon
     enabled: always
+    # Which fusillade claim loops this daemon process runs:
+    # - "both": Run request and batch claim loops (default)
+    # - "request_only": Run only batchless request claims
+    # - "batch_only": Run only batch claims
+    mode: both
 
     # Performance & Concurrency Settings
     claim_batch_size: 100 # Maximum number of requests to claim in each iteration

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -81,7 +81,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 argon2 = "0.5"
 base64 = "0.22"
 bytes = "1.5"
-onwards = { git = "https://github.com/doublewordai/onwards", branch = "peter/fusillade-21-compat", features = ["multi-step"] }
+onwards = { version = "0.34.6", features = ["multi-step"] }
 thiserror = "2.0.14"
 axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,7 +19,8 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = { version = "20.0.2" }
+fusillade = "21.0.1"
+fusillade-arsenal = "1.0.1"
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
@@ -80,7 +81,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 argon2 = "0.5"
 base64 = "0.22"
 bytes = "1.5"
-onwards = { version = "0.34.5", features = ["multi-step"] }
+onwards = { git = "https://github.com/doublewordai/onwards", branch = "peter/fusillade-21-compat", features = ["multi-step"] }
 thiserror = "2.0.14"
 axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)

--- a/dwctl/src/api/handlers/queue.rs
+++ b/dwctl/src/api/handlers/queue.rs
@@ -193,7 +193,7 @@ mod tests {
             .await
             .expect("Failed to create fusillade pool");
         let fusillade_pools = TestDbPools::new(fusillade_pool.clone()).await.expect("TestDbPools");
-        let request_manager = fusillade::PostgresRequestManager::new(fusillade_pools, Default::default());
+        let request_manager = fusillade_arsenal::PostgresRequestManager::new(fusillade_pools, Default::default());
 
         // Create one batch per completion_window. The pending counts endpoint
         // partitions by service_tier; by default it should include only the
@@ -295,7 +295,7 @@ mod tests {
             .await
             .expect("Failed to create fusillade pool");
         let fusillade_pools = TestDbPools::new(fusillade_pool.clone()).await.expect("TestDbPools");
-        let request_manager = fusillade::PostgresRequestManager::new(fusillade_pools, Default::default());
+        let request_manager = fusillade_arsenal::PostgresRequestManager::new(fusillade_pools, Default::default());
 
         let model = "query-tier-model";
         let mut batch_ids = Vec::new();
@@ -390,7 +390,7 @@ mod tests {
             .await
             .expect("Failed to create fusillade pool");
         let fusillade_pools = TestDbPools::new(fusillade_pool.clone()).await.expect("TestDbPools");
-        let request_manager = fusillade::PostgresRequestManager::new(fusillade_pools, Default::default());
+        let request_manager = fusillade_arsenal::PostgresRequestManager::new(fusillade_pools, Default::default());
 
         let model = "flex-decay-model";
         let recent_id = uuid::Uuid::new_v4();

--- a/dwctl/src/api/handlers/sla_capacity.rs
+++ b/dwctl/src/api/handlers/sla_capacity.rs
@@ -186,7 +186,7 @@ pub(crate) enum CapacityError {
 /// Used by both `POST /batches` (API) and `run_activate_batch` (sync pipeline).
 pub(crate) async fn reserve_capacity<P: sqlx_pool_router::PoolProvider>(
     dwctl_pool: &PgPool,
-    request_manager: &fusillade::PostgresRequestManager<P, fusillade::ReqwestHttpClient>,
+    request_manager: &fusillade_arsenal::PostgresRequestManager<P>,
     input: &CapacityReservationInput<'_>,
 ) -> Result<Vec<Uuid>, CapacityError> {
     use crate::db::handlers::BatchCapacityReservations;

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1433,6 +1433,29 @@ impl BatchConfig {
     }
 }
 
+/// Which fusillade claim loops should run inside this daemon process.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonMode {
+    /// Run both batchless request claims and batch claims.
+    #[default]
+    Both,
+    /// Run only the batchless request claim loop.
+    RequestOnly,
+    /// Run only the batch claim loop.
+    BatchOnly,
+}
+
+impl From<DaemonMode> for fusillade::DaemonMode {
+    fn from(mode: DaemonMode) -> Self {
+        match mode {
+            DaemonMode::Both => fusillade::DaemonMode::Both,
+            DaemonMode::RequestOnly => fusillade::DaemonMode::RequestOnly,
+            DaemonMode::BatchOnly => fusillade::DaemonMode::BatchOnly,
+        }
+    }
+}
+
 /// The daemon processes batch requests asynchronously in the background.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -1442,6 +1465,13 @@ pub struct DaemonConfig {
     /// - "never": Never run the daemon
     /// - "leader": Only run if this instance is the leader
     pub enabled: DaemonEnabled,
+
+    /// Which claim loops this daemon process should run (default: "both").
+    /// - "both": Run request and batch claim loops
+    /// - "request_only": Run only batchless request claims
+    /// - "batch_only": Run only batch claims
+    #[serde(default)]
+    pub mode: DaemonMode,
 
     /// Maximum number of requests to claim in each iteration (default: 100)
     pub claim_batch_size: usize,
@@ -1695,6 +1725,7 @@ impl Default for DaemonConfig {
     fn default() -> Self {
         Self {
             enabled: DaemonEnabled::Leader,
+            mode: DaemonMode::Both,
             claim_batch_size: 100,
             default_model_concurrency: 10,
             claim_interval_ms: 1000,
@@ -1759,6 +1790,7 @@ impl DaemonConfig {
         };
 
         fusillade::daemon::DaemonConfig {
+            mode: self.mode.into(),
             claim_batch_size: self.claim_batch_size,
             model_concurrency_limits: model_capacity_limits.unwrap_or_else(|| std::sync::Arc::new(dashmap::DashMap::new())),
             model_escalations: Arc::new(DashMap::from_iter(self.model_escalations.clone())),
@@ -3774,6 +3806,62 @@ background_services:
             assert!(result.is_err());
             let err = result.unwrap_err().to_string();
             assert!(err.contains("urgency_weight must be between 0.0 and 1.0"));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_daemon_mode_default_and_override() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "test.yaml",
+                r#"
+secret_key: "test-secret-key"
+"#,
+            )?;
+            let args = Args {
+                config: "test.yaml".into(),
+                validate: false,
+            };
+            let config = Config::load(&args)?;
+            assert_eq!(config.background_services.batch_daemon.mode, DaemonMode::Both);
+            assert_eq!(
+                fusillade::DaemonMode::from(config.background_services.batch_daemon.mode),
+                fusillade::DaemonMode::Both
+            );
+
+            jail.create_file(
+                "test.yaml",
+                r#"
+secret_key: "test-secret-key"
+background_services:
+  batch_daemon:
+    mode: request_only
+"#,
+            )?;
+            let config = Config::load(&args)?;
+            assert_eq!(config.background_services.batch_daemon.mode, DaemonMode::RequestOnly);
+            assert_eq!(
+                fusillade::DaemonMode::from(config.background_services.batch_daemon.mode),
+                fusillade::DaemonMode::RequestOnly
+            );
+
+            jail.create_file(
+                "test.yaml",
+                r#"
+secret_key: "test-secret-key"
+background_services:
+  batch_daemon:
+    mode: batch_only
+"#,
+            )?;
+            let config = Config::load(&args)?;
+            assert_eq!(config.background_services.batch_daemon.mode, DaemonMode::BatchOnly);
+            assert_eq!(
+                fusillade::DaemonMode::from(config.background_services.batch_daemon.mode),
+                fusillade::DaemonMode::BatchOnly
+            );
 
             Ok(())
         });

--- a/dwctl/src/connections/sync.rs
+++ b/dwctl/src/connections/sync.rs
@@ -1333,12 +1333,18 @@ mod tests {
             .await
             .expect("fusillade pool");
 
-        fusillade::migrator().run(&fusillade_pool).await.expect("fusillade migrations");
+        fusillade_arsenal::migrator()
+            .run(&fusillade_pool)
+            .await
+            .expect("fusillade migrations");
 
         let fusillade_test_pools = sqlx_pool_router::TestDbPools::new(fusillade_pool)
             .await
             .expect("fusillade test pools");
-        let request_manager = std::sync::Arc::new(fusillade::PostgresRequestManager::new(fusillade_test_pools, Default::default()));
+        let request_manager = std::sync::Arc::new(fusillade_arsenal::PostgresRequestManager::new(
+            fusillade_test_pools,
+            Default::default(),
+        ));
 
         crate::tasks::TaskState {
             request_manager,

--- a/dwctl/src/inference/engine/loop_http_client.rs
+++ b/dwctl/src/inference/engine/loop_http_client.rs
@@ -19,7 +19,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use fusillade::http::{HttpClient as FusilladeHttpClient, HttpResponse};
-use fusillade::{FusilladeError, PoolProvider as FusilladePool, RequestData, ReqwestHttpClient, Result as FusilladeResult};
+use fusillade::{FusilladeError, RequestData, ReqwestHttpClient, Result as FusilladeResult};
+use fusillade_arsenal::PoolProvider as FusilladePool;
 use onwards::traits::{RequestContext, ToolExecutor};
 use onwards::{LoopConfig, LoopError, MultiStepStore, UpstreamTarget};
 

--- a/dwctl/src/inference/engine/processor.rs
+++ b/dwctl/src/inference/engine/processor.rs
@@ -36,9 +36,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use fusillade::request::{Canceled, Claimed, Failed, FailureReason, Request, RequestCompletionResult};
-use fusillade::{
-    CancellationFuture, DefaultRequestProcessor, PoolProvider as FusilladePool, RequestProcessor, ReqwestHttpClient, ShouldRetry, Storage,
-};
+use fusillade::{CancellationFuture, DefaultRequestProcessor, HttpClient, RequestProcessor, ReqwestHttpClient, ShouldRetry, Storage};
+use fusillade_arsenal::PoolProvider as FusilladePool;
 use onwards::LoopConfig;
 use onwards::traits::ToolExecutor;
 
@@ -432,7 +431,9 @@ where
             loop_config: self.loop_config,
         };
 
-        let processing = request.process(loop_client, storage).await?;
+        let request_data = request.data.clone();
+        let response_fut = async move { loop_client.execute(&request_data, &request_data.api_key).await };
+        let processing = request.process(storage, response_fut).await?;
         // `ShouldRetry` is an `Arc<dyn Fn>`; `complete` wants a bare `Fn`,
         // so deref through the Arc.
         processing.complete(storage, |resp| should_retry(resp), cancellation).await

--- a/dwctl/src/inference/engine/writer.rs
+++ b/dwctl/src/inference/engine/writer.rs
@@ -60,7 +60,8 @@ use crate::metrics::errors::component::RESPONSES_WRITER;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use fusillade::{PersistCompletedRealtimeInput, PostgresRequestManager, ReqwestHttpClient, Storage};
+use fusillade::{PersistCompletedRealtimeInput, Storage};
+use fusillade_arsenal::PostgresRequestManager;
 use metrics::{counter, gauge, histogram};
 use sqlx_pool_router::PoolProvider;
 use tokio::sync::mpsc;
@@ -119,7 +120,7 @@ pub type RequestsWriterSender = mpsc::Sender<RawCompletedRequest>;
 /// Generic over `PoolProvider` so the same struct works in production
 /// (`DbPools`) and tests (`TestDbPools`).
 pub struct RequestsWriter<P: PoolProvider + Clone + Send + Sync + 'static> {
-    request_manager: Arc<PostgresRequestManager<P, ReqwestHttpClient>>,
+    request_manager: Arc<PostgresRequestManager<P>>,
     receiver: mpsc::Receiver<RawCompletedRequest>,
     batch_size: usize,
     max_retries: u32,
@@ -130,7 +131,7 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> RequestsWriter<P> {
     /// Build the writer and return it alongside the sender handle. Spawn the
     /// returned future via `tokio::spawn(writer.run(token))`; pass the sender
     /// into `FusilladeOutletHandler::new`.
-    pub fn new(request_manager: Arc<PostgresRequestManager<P, ReqwestHttpClient>>, batch_size: usize) -> (Self, RequestsWriterSender) {
+    pub fn new(request_manager: Arc<PostgresRequestManager<P>>, batch_size: usize) -> (Self, RequestsWriterSender) {
         let (sender, receiver) = mpsc::channel(CHANNEL_BUFFER_SIZE);
         let writer = Self {
             request_manager,
@@ -317,7 +318,9 @@ impl<P: PoolProvider + Clone + Send + Sync + 'static> RequestsWriter<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fusillade::{PostgresRequestManager, RequestId};
+    use fusillade::RequestId;
+    use fusillade::ReqwestHttpClient;
+    use fusillade_arsenal::PostgresRequestManager;
     use sqlx_pool_router::TestDbPools;
     use std::time::Duration;
     use tokio::time::timeout;
@@ -325,7 +328,7 @@ mod tests {
     use uuid::Uuid;
 
     /// Builds a writer wired to a fresh `#[sqlx::test]` pool with the
-    /// fusillade schema installed via `fusillade::migrator()` (so we don't
+    /// fusillade schema installed via `fusillade_arsenal::migrator()` (so we don't
     /// reference the fusillade source directory, which doesn't exist in
     /// CI). The returned request manager runs against a pool scoped to
     /// the fusillade schema. Tests pass `created_by` directly on each
@@ -336,7 +339,7 @@ mod tests {
     ) -> (
         RequestsWriter<TestDbPools>,
         RequestsWriterSender,
-        Arc<PostgresRequestManager<TestDbPools, ReqwestHttpClient>>,
+        Arc<PostgresRequestManager<TestDbPools>>,
     ) {
         let fusillade_pool = crate::test::utils::setup_fusillade_pool(&pool).await;
         let pools = TestDbPools::new(fusillade_pool).await.unwrap();
@@ -350,7 +353,7 @@ mod tests {
     /// time out. Mirrors the polling-not-sleeping pattern fusillade uses
     /// (see fusillade/CLAUDE.md).
     async fn wait_until_completed(
-        manager: &PostgresRequestManager<TestDbPools, ReqwestHttpClient>,
+        manager: &PostgresRequestManager<TestDbPools>,
         request_id: Uuid,
         timeout_secs: u64,
     ) -> fusillade::RequestDetail {

--- a/dwctl/src/inference/middleware.rs
+++ b/dwctl/src/inference/middleware.rs
@@ -23,7 +23,7 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use fusillade::{PostgresRequestManager, ReqwestHttpClient};
+use fusillade_arsenal::PostgresRequestManager;
 use sqlx_pool_router::PoolProvider;
 
 use super::image_normalizer_middleware::{normalize_error_response, normalize_value_to_tokens};
@@ -35,7 +35,7 @@ use crate::image_normalizer::ImageNormalizer;
 /// State for the inference middleware.
 #[derive(Clone)]
 pub struct InferenceMiddlewareState<P: PoolProvider + Clone = sqlx_pool_router::DbPools> {
-    pub request_manager: Arc<PostgresRequestManager<P, ReqwestHttpClient>>,
+    pub request_manager: Arc<PostgresRequestManager<P>>,
     pub daemon_id: OnwardsDaemonId,
     /// Base URL for loopback requests (e.g., "http://127.0.0.1:3001/ai").
     /// Flex batches are routed back through dwctl so onwards handles the

--- a/dwctl/src/inference/store.rs
+++ b/dwctl/src/inference/store.rs
@@ -9,9 +9,10 @@ use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use fusillade::{
-    BatchInput, CreateRealtimeInput, CreateStepInput, PostgresRequestManager, PostgresResponseStepManager, RequestId, RequestTemplateInput,
-    ReqwestHttpClient, ResponseStep, ResponseStepStore, StepId, StepKind as FusilladeStepKind, StepState as FusilladeStepState, Storage,
+    BatchInput, CreateRealtimeInput, CreateStepInput, RequestId, RequestTemplateInput, ResponseStep, ResponseStepStore, StepId,
+    StepKind as FusilladeStepKind, StepState as FusilladeStepState, Storage,
 };
+use fusillade_arsenal::{PostgresRequestManager, PostgresResponseStepManager};
 use onwards::{
     ChainStep, MultiStepStore, RecordedStep, ResponseStore, StepDescriptor, StepKind as OnwardsStepKind, StepState as OnwardsStepState,
     StoreError,
@@ -68,7 +69,7 @@ pub struct OnwardsDaemonId(pub Uuid);
 
 /// ResponseStore implementation backed by fusillade's `Storage` trait.
 pub struct FusilladeResponseStore<P: PoolProvider + Clone> {
-    request_manager: Arc<PostgresRequestManager<P, ReqwestHttpClient>>,
+    request_manager: Arc<PostgresRequestManager<P>>,
     /// Step storage for multi-step responses. Optional so existing callers
     /// that only need the legacy single-step `ResponseStore` surface (e.g.
     /// the `previous_response_id` flow) can construct a store without
@@ -86,7 +87,7 @@ pub struct FusilladeResponseStore<P: PoolProvider + Clone> {
 }
 
 impl<P: PoolProvider + Clone> FusilladeResponseStore<P> {
-    pub fn new(request_manager: Arc<PostgresRequestManager<P, ReqwestHttpClient>>) -> Self {
+    pub fn new(request_manager: Arc<PostgresRequestManager<P>>) -> Self {
         Self {
             request_manager,
             step_manager: None,
@@ -188,7 +189,7 @@ impl<P: PoolProvider + Clone> FusilladeResponseStore<P> {
     /// Borrow the inner request_manager. Used by the warm-path SSE
     /// handler to call `complete_request` / `fail_request` directly
     /// after running the loop inline.
-    pub fn request_manager(&self) -> &PostgresRequestManager<P, ReqwestHttpClient> {
+    pub fn request_manager(&self) -> &PostgresRequestManager<P> {
         &self.request_manager
     }
 
@@ -340,7 +341,7 @@ fn map_fusillade_err(e: fusillade::FusilladeError) -> StoreError {
 
 /// Mark a response as failed.
 pub async fn fail_response<P: PoolProvider + Clone>(
-    request_manager: &PostgresRequestManager<P, ReqwestHttpClient>,
+    request_manager: &PostgresRequestManager<P>,
     response_id: &str,
     error: &str,
 ) -> Result<(), StoreError> {
@@ -361,7 +362,7 @@ pub async fn fail_response<P: PoolProvider + Clone>(
 /// Used by `create-response` to skip work when `complete-response` has already
 /// raced ahead and inserted the row itself.
 pub async fn request_exists<P: PoolProvider + Clone>(
-    request_manager: &PostgresRequestManager<P, ReqwestHttpClient>,
+    request_manager: &PostgresRequestManager<P>,
     request_id: Uuid,
 ) -> Result<bool, StoreError> {
     match request_manager.get_request_detail(RequestId(request_id)).await {
@@ -400,7 +401,7 @@ pub struct CreateContext<'a> {
 ///    enqueue — has already done our work)
 ///  - row in `processing` → straight UPDATE
 pub async fn complete_response_idempotent<P: PoolProvider + Clone>(
-    request_manager: &PostgresRequestManager<P, ReqwestHttpClient>,
+    request_manager: &PostgresRequestManager<P>,
     dwctl_pool: &sqlx::PgPool,
     response_id: &str,
     response_body: &str,
@@ -506,7 +507,7 @@ fn is_terminal(state: &str) -> bool {
 /// `detail_to_response_object` for the Responses API, `detail_to_chat_completion_object`
 /// for chat completions.
 pub async fn poll_until_terminal<P: PoolProvider + Clone>(
-    request_manager: &PostgresRequestManager<P, ReqwestHttpClient>,
+    request_manager: &PostgresRequestManager<P>,
     request_id: Uuid,
     poll_interval: std::time::Duration,
     timeout: std::time::Duration,
@@ -555,7 +556,7 @@ pub async fn poll_until_terminal<P: PoolProvider + Clone>(
 
 /// Poll a fusillade request until it reaches a terminal state and return a Responses-API-shaped object.
 pub async fn poll_until_complete<P: PoolProvider + Clone>(
-    request_manager: &PostgresRequestManager<P, ReqwestHttpClient>,
+    request_manager: &PostgresRequestManager<P>,
     response_id: &str,
     poll_interval: std::time::Duration,
     timeout: std::time::Duration,
@@ -599,7 +600,7 @@ pub async fn lookup_created_by(pool: &sqlx::PgPool, api_key: Option<&str>) -> Op
 ///
 /// Returns `(response_id, request_id)` where response_id is `resp_<uuid>`.
 pub async fn create_batch_of_1<P: PoolProvider + Clone>(
-    request_manager: &PostgresRequestManager<P, ReqwestHttpClient>,
+    request_manager: &PostgresRequestManager<P>,
     request: &serde_json::Value,
     model: &str,
     base_url: &str,

--- a/dwctl/src/inference/streaming.rs
+++ b/dwctl/src/inference/streaming.rs
@@ -132,7 +132,7 @@ impl ReplayFrame {
 /// terminator); the Responses surface ends on `response.completed`/`.failed`
 /// and passes `false`.
 pub async fn flex_stream_response<P, F>(
-    request_manager: Arc<fusillade::PostgresRequestManager<P, ReqwestHttpClient>>,
+    request_manager: Arc<fusillade_arsenal::PostgresRequestManager<P>>,
     flex_input: fusillade::CreateFlexInput,
     request_id: uuid::Uuid,
     done_sentinel: bool,
@@ -140,7 +140,7 @@ pub async fn flex_stream_response<P, F>(
     render: F,
 ) -> axum::response::Response
 where
-    P: fusillade::PoolProvider + Clone + Send + Sync + 'static,
+    P: fusillade_arsenal::PoolProvider + Clone + Send + Sync + 'static,
     F: FnOnce(Result<&fusillade::RequestDetail, &str>) -> Vec<ReplayFrame> + Send + 'static,
 {
     use axum::response::IntoResponse;
@@ -219,7 +219,7 @@ pub fn run_inline_streaming<P>(
     model_alias: String,
 ) -> Sse<impl Stream<Item = Result<Event, axum::Error>>>
 where
-    P: fusillade::PoolProvider + Clone + Send + Sync + 'static,
+    P: fusillade_arsenal::PoolProvider + Clone + Send + Sync + 'static,
 {
     let (tx, rx) = mpsc::channel::<Result<Event, axum::Error>>(SSE_CHANNEL_BUFFER);
 
@@ -294,7 +294,7 @@ where
 
 async fn persist_terminal_completed<P>(response_store: &FusilladeResponseStore<P>, request_id: &str) -> Result<(), String>
 where
-    P: fusillade::PoolProvider + Clone + Send + Sync + 'static,
+    P: fusillade_arsenal::PoolProvider + Clone + Send + Sync + 'static,
 {
     // Assemble the final response JSON from the chain (same path the
     // daemon processor uses), then write it onto the head step's
@@ -335,7 +335,7 @@ pub async fn run_inline_blocking<P>(
     model_alias: String,
 ) -> Result<Value, Value>
 where
-    P: fusillade::PoolProvider + Clone + Send + Sync + 'static,
+    P: fusillade_arsenal::PoolProvider + Clone + Send + Sync + 'static,
 {
     let tool_ctx = RequestContext::new()
         .with_model(model_alias)
@@ -392,7 +392,7 @@ where
 
 async fn persist_terminal_failed<P>(response_store: &FusilladeResponseStore<P>, request_id: &str, error: &Value) -> Result<(), String>
 where
-    P: fusillade::PoolProvider + Clone + Send + Sync + 'static,
+    P: fusillade_arsenal::PoolProvider + Clone + Send + Sync + 'static,
 {
     response_store
         .finalize_head_request(request_id, 500, error.clone())

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -288,7 +288,7 @@ where
     pub metrics_recorder: Option<GenAiMetrics>,
     #[builder(default = false)]
     pub is_leader: bool,
-    pub request_manager: Arc<fusillade::PostgresRequestManager<P, fusillade::ReqwestHttpClient>>,
+    pub request_manager: Arc<fusillade_arsenal::PostgresRequestManager<P>>,
     /// Background task runner for enqueuing deferred work (batch population, etc.)
     pub task_runner: Arc<tasks::TaskRunner<P>>,
     /// Resource limiters for protecting system capacity.
@@ -303,7 +303,7 @@ where
     /// don't use the multi-step Open Responses path can omit the
     /// wiring; the GET /v1/responses/{id} handler degrades to 404 in
     /// that case rather than panicking.
-    pub response_step_manager: Option<Arc<fusillade::PostgresResponseStepManager<P>>>,
+    pub response_step_manager: Option<Arc<fusillade_arsenal::PostgresResponseStepManager<P>>>,
     /// Singleton image normaliser used by the realtime middleware, the
     /// batch ingest path, the dispatcher's JIT-signing step, and the
     /// dashboard `/images/:sha256` endpoint. Built once at startup so
@@ -836,7 +836,7 @@ async fn setup_database(
             }
         }
     };
-    fusillade::migrator().run(&*fusillade_pools).await?;
+    fusillade_arsenal::migrator().run(&*fusillade_pools).await?;
 
     // Run underway migrations (background task queue)
     underway::run_migrations(&*db_pools).await?;
@@ -2014,12 +2014,12 @@ async fn inject_trace_id(request: axum::extract::Request, next: middleware::Next
 /// stop all background tasks. When dropped, the `drop_guard` will automatically cancel
 /// the shutdown token, signaling all tasks to stop.
 pub struct BackgroundServices {
-    request_manager: Arc<fusillade::PostgresRequestManager<DbPools, fusillade::ReqwestHttpClient>>,
+    request_manager: Arc<fusillade_arsenal::PostgresRequestManager<DbPools>>,
     /// Step storage for multi-step responses, sharing the same fusillade
     /// pool as the request manager. Constructed in
     /// `setup_background_services` so the manager's processor (which
     /// dwctl wires later in `Application::new_with_pool`) can use it.
-    step_manager: Arc<fusillade::PostgresResponseStepManager<DbPools>>,
+    step_manager: Arc<fusillade_arsenal::PostgresResponseStepManager<DbPools>>,
     /// The onwards-instance daemon id registered in the `daemons` table
     /// for realtime / inline-loop attribution. The graceful-shutdown
     /// drain (`shutdown()`) marks this row Dead and releases any
@@ -2329,25 +2329,23 @@ impl BackgroundTaskBuilder {
 /// cleanup (the cycle's only effect in production — where the app lives
 /// forever — is benign).
 pub(crate) struct BackgroundServicesInput {
-    /// Fusillade's HTTP request manager. The caller builds this so the
-    /// multi-step processor (which depends on it transitively via
-    /// `FusilladeResponseStore`) can be constructed and injected via
-    /// `set_processor` before any daemon spawn inside this function.
-    pub request_manager: Arc<fusillade::PostgresRequestManager<DbPools, fusillade::ReqwestHttpClient>>,
+    /// Fusillade's durable DB store. The caller builds this so the
+    /// multi-step processor can share the same storage instance as the
+    /// daemon runtime.
+    pub request_manager: Arc<fusillade_arsenal::PostgresRequestManager<DbPools>>,
+    /// Fusillade's scheduling daemon. Owns HTTP dispatch and runtime
+    /// lifecycle; durable data operations live on `request_manager`.
+    pub postgres_daemon: Arc<fusillade::PostgresDaemon<DbPools, fusillade::ReqwestHttpClient>>,
     /// Fusillade's response-step manager. Shares the same fusillade
     /// pool as the request manager.
-    pub step_manager: Arc<fusillade::PostgresResponseStepManager<DbPools>>,
+    pub step_manager: Arc<fusillade_arsenal::PostgresResponseStepManager<DbPools>>,
     /// Multi-step processor to inject onto the request manager. `None`
     /// in tests to avoid forming the `request_manager → processor →
     /// response_store → request_manager` Arc cycle that blocks
     /// `sqlx::test`'s `DROP DATABASE` cleanup.
     pub multi_step_processor: Option<
         Arc<
-            dyn fusillade::RequestProcessor<
-                    fusillade::PostgresRequestManager<DbPools, fusillade::ReqwestHttpClient>,
-                    fusillade::ReqwestHttpClient,
-                > + Send
-                + Sync,
+            dyn fusillade::RequestProcessor<fusillade_arsenal::PostgresRequestManager<DbPools>, fusillade::ReqwestHttpClient> + Send + Sync,
         >,
     >,
     /// Shared map between the fusillade daemon's concurrency control
@@ -2375,6 +2373,7 @@ pub(crate) struct BackgroundServicesInput {
 async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Result<BackgroundServices> {
     let BackgroundServicesInput {
         request_manager,
+        postgres_daemon,
         step_manager,
         multi_step_processor,
         model_capacity_limits,
@@ -2388,21 +2387,21 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         keystore,
     } = input;
 
-    // Wire the multi-step processor onto the request manager *before*
+    // Wire the multi-step processor onto the daemon *before*
     // any daemon spawn below — this is the whole reason `setup_background_services`
     // accepts these as parameters rather than constructing them itself.
     // See the function-level doc comment.
     if let Some(processor) = multi_step_processor
-        && let Err(e) = request_manager.set_processor(processor)
+        && let Err(e) = postgres_daemon.set_processor(processor)
     {
         tracing::warn!(error = e, "Multi-step processor was already set; skipping");
     }
 
     // `keystore` comes from the caller (built once and shared). Install the
-    // TRANSITIONAL ZDR response transformer on the manager before the daemon
+    // TRANSITIONAL ZDR response transformer on the daemon before it
     // spawns below, so completed bodies are persisted encrypted.
     if let Some(ks) = keystore.clone()
-        && let Err(e) = request_manager.set_response_transformer(std::sync::Arc::new(crate::inference::zdr::ZdrResponseEncryptor::new(ks)))
+        && let Err(e) = postgres_daemon.set_response_transformer(std::sync::Arc::new(crate::inference::zdr::ZdrResponseEncryptor::new(ks)))
     {
         tracing::warn!(error = e, "ZDR response transformer was already set; skipping");
     }
@@ -2536,10 +2535,9 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
 
         // Start the fusillade batch processing daemon based on config
         use crate::config::DaemonEnabled;
-        use fusillade::DaemonExecutor;
         match config.background_services.batch_daemon.enabled {
             DaemonEnabled::Always | DaemonEnabled::Leader => {
-                let daemon_handle = request_manager.clone().run(shutdown_token.clone())?;
+                let daemon_handle = postgres_daemon.clone().run(shutdown_token.clone())?;
                 // Spawn task that propagates daemon errors
                 background_tasks.spawn("fusillade-daemon", async move {
                     match daemon_handle.await {
@@ -2593,8 +2591,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         // If daemon is set to "Always", start it immediately regardless of leader election
         use crate::config::DaemonEnabled;
         if config.background_services.batch_daemon.enabled == DaemonEnabled::Always {
-            use fusillade::DaemonExecutor;
-            let daemon_handle = request_manager.clone().run(shutdown_token.clone())?;
+            let daemon_handle = postgres_daemon.clone().run(shutdown_token.clone())?;
             // Spawn task that propagates daemon errors
             background_tasks.spawn("fusillade-daemon", async move {
                 match daemon_handle.await {
@@ -2622,6 +2619,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         let leader_election_scheduler_gain = probe_scheduler.clone();
         let leader_election_scheduler_lose = probe_scheduler.clone();
         let leader_election_request_manager_gain = request_manager.clone();
+        let leader_election_postgres_daemon_gain = postgres_daemon.clone();
         let leader_election_config = config.clone();
         let leader_election_flag = is_leader_flag.clone();
 
@@ -2649,6 +2647,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
                     // This closure is run when a replica becomes the leader
                     let scheduler = leader_election_scheduler_gain.clone();
                     let request_manager = leader_election_request_manager_gain.clone();
+                    let postgres_daemon = leader_election_postgres_daemon_gain.clone();
                     let daemon_handle = daemon_handle_gain.clone();
                     let leadership_shutdown = leadership_shutdown_gain.clone();
                     async move {
@@ -2681,10 +2680,9 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
 
                         // Start the fusillade batch processing daemon based on config
                         use crate::config::DaemonEnabled;
-                        use fusillade::DaemonExecutor;
                         match config.background_services.batch_daemon.enabled {
                             DaemonEnabled::Leader => {
-                                let handle = request_manager
+                                let handle = postgres_daemon
                                     .run(session_token.clone())
                                     .map_err(|e| anyhow::anyhow!("Failed to start fusillade daemon: {}", e))?;
 
@@ -3024,20 +3022,26 @@ impl Application {
         // we build it once here.
         let model_capacity_limits: Arc<dashmap::DashMap<String, usize>> = Arc::new(dashmap::DashMap::new());
 
+        let fusillade_daemon_config = config
+            .background_services
+            .batch_daemon
+            .to_fusillade_config_with_limits(Some(model_capacity_limits.clone()));
+
         let request_manager = Arc::new(
-            fusillade::PostgresRequestManager::new(
+            fusillade_arsenal::PostgresRequestManager::new(
                 fusillade_pools.clone(),
-                config
-                    .background_services
-                    .batch_daemon
-                    .to_fusillade_config_with_limits(Some(model_capacity_limits.clone())),
+                fusillade_arsenal::PostgresStorageConfig::from(&fusillade_daemon_config),
             )
             .with_download_buffer_size(config.batches.files.download_buffer_size)
-            .with_batch_insert_strategy(fusillade::manager::postgres::BatchInsertStrategy::Batched {
+            .with_batch_insert_strategy(fusillade_arsenal::BatchInsertStrategy::Batched {
                 batch_size: config.batches.files.batch_insert_size,
             }),
         );
-        let step_manager = Arc::new(fusillade::PostgresResponseStepManager::new(fusillade_pools.clone()));
+        let postgres_daemon = Arc::new(fusillade::PostgresDaemon::from_store(
+            request_manager.clone(),
+            fusillade_daemon_config.clone(),
+        ));
+        let step_manager = Arc::new(fusillade_arsenal::PostgresResponseStepManager::new(fusillade_pools.clone()));
         // Build the ZDR keystore once and share it across the response store, the
         // daemon processor, and background services (which install the response
         // transformer). A misconfiguration is fatal.
@@ -3076,13 +3080,11 @@ impl Application {
         // streamable-endpoint dispatch. Timeouts and the streamable list
         // come from the same config knobs the daemon respects, so warm
         // path and daemon path use identical streaming semantics.
-        let batch_daemon_cfg = &config.background_services.batch_daemon;
-        let batch_daemon_fusillade_cfg = batch_daemon_cfg.to_fusillade_config();
         let multi_step_http_client: Arc<fusillade::ReqwestHttpClient> = Arc::new(fusillade::ReqwestHttpClient::new(
-            std::time::Duration::from_millis(batch_daemon_fusillade_cfg.first_chunk_timeout_ms),
-            std::time::Duration::from_millis(batch_daemon_fusillade_cfg.chunk_timeout_ms),
-            std::time::Duration::from_millis(batch_daemon_fusillade_cfg.body_timeout_ms),
-            batch_daemon_fusillade_cfg.streamable_endpoints.clone(),
+            std::time::Duration::from_millis(fusillade_daemon_config.first_chunk_timeout_ms),
+            std::time::Duration::from_millis(fusillade_daemon_config.chunk_timeout_ms),
+            std::time::Duration::from_millis(fusillade_daemon_config.body_timeout_ms),
+            fusillade_daemon_config.streamable_endpoints.clone(),
         ));
         let multi_step_loop_config = onwards::LoopConfig {
             max_response_step_depth: config.responses.max_response_step_depth,
@@ -3127,10 +3129,8 @@ impl Application {
             Some(
                 processor
                     as Arc<
-                        dyn fusillade::RequestProcessor<
-                                fusillade::PostgresRequestManager<DbPools, fusillade::ReqwestHttpClient>,
-                                fusillade::ReqwestHttpClient,
-                            > + Send
+                        dyn fusillade::RequestProcessor<fusillade_arsenal::PostgresRequestManager<DbPools>, fusillade::ReqwestHttpClient>
+                            + Send
                             + Sync,
                     >,
             )
@@ -3138,6 +3138,7 @@ impl Application {
 
         let mut bg_services = setup_background_services(BackgroundServicesInput {
             request_manager: request_manager.clone(),
+            postgres_daemon: postgres_daemon.clone(),
             step_manager: step_manager.clone(),
             multi_step_processor: multi_step_processor_for_setup,
             model_capacity_limits,
@@ -3186,9 +3187,9 @@ impl Application {
              VALUES ($1, $2, $3, $4, $5, 'running', NOW(), NOW())",
         )
         .bind(onwards_daemon_id)
-        .bind(fusillade::daemon::types::get_hostname())
-        .bind(fusillade::daemon::types::get_pid())
-        .bind(fusillade::daemon::types::get_version())
+        .bind(std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string()))
+        .bind(std::process::id() as i32)
+        .bind(env!("CARGO_PKG_VERSION"))
         .bind(serde_json::json!({"type": "onwards"}))
         .execute(&fusillade_write_pool)
         .await;

--- a/dwctl/src/notifications.rs
+++ b/dwctl/src/notifications.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use fusillade::manager::postgres::PostgresRequestManager;
+use fusillade_arsenal::PostgresRequestManager;
 use metrics::counter;
 use rust_decimal::prelude::ToPrimitive;
 use sqlx::PgPool;
@@ -134,7 +134,7 @@ impl BatchNotificationInfo {
 pub async fn run_notification_poller(
     config: NotificationsConfig,
     app_config: crate::config::Config,
-    request_manager: Arc<PostgresRequestManager<DbPools, fusillade::http::ReqwestHttpClient>>,
+    request_manager: Arc<PostgresRequestManager<DbPools>>,
     dwctl_pool: PgPool,
     shutdown: CancellationToken,
 ) {

--- a/dwctl/src/tasks.rs
+++ b/dwctl/src/tasks.rs
@@ -8,7 +8,7 @@ use crate::metrics::errors::component::TASK_WORKER;
 use std::sync::{Arc, OnceLock, Weak};
 
 use anyhow::Result;
-use fusillade::PostgresRequestManager;
+use fusillade_arsenal::PostgresRequestManager;
 use sqlx::PgPool;
 use sqlx_pool_router::PoolProvider;
 use tokio_util::sync::CancellationToken;
@@ -35,7 +35,7 @@ type WeakJobRef<I, P> = Arc<OnceLock<Weak<Job<I, TaskState<P>>>>>;
 /// upgraded when enqueueing.
 #[derive(Clone)]
 pub struct TaskState<P: PoolProvider + Clone = sqlx_pool_router::DbPools> {
-    pub request_manager: Arc<PostgresRequestManager<P, fusillade::ReqwestHttpClient>>,
+    pub request_manager: Arc<PostgresRequestManager<P>>,
     /// dwctl database pool — for querying connections, sync_operations, sync_entries.
     pub dwctl_pool: PgPool,
     /// Shared config for capacity checks and other runtime configuration.

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -1036,7 +1036,7 @@ async fn test_request_logging_disabled(pool: PgPool) {
     config.enable_analytics = false; // Disable to avoid spawning background batcher task
 
     // Build router with request logging disabled
-    let request_manager = std::sync::Arc::new(fusillade::PostgresRequestManager::new(
+    let request_manager = std::sync::Arc::new(fusillade_arsenal::PostgresRequestManager::new(
         DbPools::new(pool.clone()),
         Default::default(),
     ));
@@ -1604,7 +1604,7 @@ async fn test_build_router_with_metrics_disabled(pool: PgPool) {
     config.enable_metrics = false;
     config.enable_analytics = false; // Disable to avoid spawning background batcher task
 
-    let request_manager = std::sync::Arc::new(fusillade::PostgresRequestManager::new(
+    let request_manager = std::sync::Arc::new(fusillade_arsenal::PostgresRequestManager::new(
         DbPools::new(pool.clone()),
         Default::default(),
     ));
@@ -1666,7 +1666,7 @@ async fn test_build_router_with_metrics_enabled(pool: PgPool) {
     config.enable_metrics = true;
     config.enable_analytics = false; // Disable to avoid spawning background batcher task
 
-    let request_manager = std::sync::Arc::new(fusillade::PostgresRequestManager::new(
+    let request_manager = std::sync::Arc::new(fusillade_arsenal::PostgresRequestManager::new(
         DbPools::new(pool.clone()),
         Default::default(),
     ));

--- a/dwctl/src/test/multi_step_executor.rs
+++ b/dwctl/src/test/multi_step_executor.rs
@@ -24,9 +24,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use fusillade::{
-    PoolProvider as FusilladePoolProvider, PostgresRequestManager, PostgresResponseStepManager, ReqwestHttpClient, TestDbPools,
-};
+use fusillade::ReqwestHttpClient;
+use fusillade_arsenal::{PoolProvider as FusilladePoolProvider, PostgresRequestManager, PostgresResponseStepManager, TestDbPools};
 use onwards::traits::RequestContext;
 use onwards::{
     ChainStep, LoopConfig, MultiStepStore, NextAction, RecordedStep, StepDescriptor, StepKind, StepState, StoreError, UpstreamTarget,
@@ -202,10 +201,7 @@ fn http_client_for_tests() -> Arc<ReqwestHttpClient> {
 
 async fn store_with_real_fusillade(pool: PgPool) -> FusilladeResponseStore<TestDbPools> {
     let pools = TestDbPools::new(pool).await.unwrap();
-    let request_manager = Arc::new(PostgresRequestManager::<_, ReqwestHttpClient>::new(
-        pools.clone(),
-        Default::default(),
-    ));
+    let request_manager = Arc::new(PostgresRequestManager::new(pools.clone(), Default::default()));
     let step_manager = Arc::new(PostgresResponseStepManager::new(pools));
     FusilladeResponseStore::new(request_manager).with_step_manager(step_manager)
 }

--- a/dwctl/src/test/responses.rs
+++ b/dwctl/src/test/responses.rs
@@ -296,17 +296,14 @@ async fn test_blocking_response_id_matches_fusillade_id(pool: PgPool) {
 async fn test_multi_step_chain_assembles_and_is_retrievable_via_get(pool: PgPool) {
     use crate::inference::store::{FusilladeResponseStore, PendingResponseInput};
     use crate::test::utils::setup_fusillade_pool;
-    use fusillade::{PostgresRequestManager, PostgresResponseStepManager, ReqwestHttpClient, TestDbPools};
+    use fusillade_arsenal::{PostgresRequestManager, PostgresResponseStepManager, TestDbPools};
     use onwards::{MultiStepStore, StepDescriptor, StepKind as OnwardsStepKind};
     use serde_json::json;
     use std::sync::Arc;
 
     let pool = setup_fusillade_pool(&pool).await;
     let test_pools = TestDbPools::new(pool).await.unwrap();
-    let request_manager = Arc::new(PostgresRequestManager::<_, ReqwestHttpClient>::new(
-        test_pools.clone(),
-        Default::default(),
-    ));
+    let request_manager = Arc::new(PostgresRequestManager::new(test_pools.clone(), Default::default()));
     let step_manager = Arc::new(PostgresResponseStepManager::new(test_pools));
     let store = FusilladeResponseStore::new(request_manager.clone()).with_step_manager(step_manager);
 

--- a/dwctl/src/test/sla.rs
+++ b/dwctl/src/test/sla.rs
@@ -10,7 +10,7 @@ use crate::test::utils::{
 };
 use crate::{
     api::models::users::Role,
-    config::{DaemonConfig, DaemonEnabled, ModelSource},
+    config::{DaemonConfig, DaemonEnabled, DaemonMode, ModelSource},
     db::handlers::api_keys::ApiKeys,
     db::models::api_keys::ApiKeyPurpose,
 };
@@ -119,6 +119,7 @@ async fn test_route_at_claim_time_escalation(pool: PgPool) {
 
     config.background_services.batch_daemon = DaemonConfig {
         enabled: DaemonEnabled::Always,
+        mode: DaemonMode::Both,
         claim_batch_size: 10,
         default_model_concurrency: 5,
         claim_interval_ms: 100,
@@ -391,6 +392,7 @@ async fn test_no_escalation_when_not_near_expiry(pool: PgPool) {
     let mut config = create_test_config();
     config.background_services.batch_daemon = DaemonConfig {
         enabled: DaemonEnabled::Always,
+        mode: DaemonMode::Both,
         claim_batch_size: 10,
         default_model_concurrency: 5,
         claim_interval_ms: 100,

--- a/dwctl/src/test/utils.rs
+++ b/dwctl/src/test/utils.rs
@@ -36,7 +36,7 @@ pub async fn create_test_app_state_with_config(pool: PgPool, config: crate::conf
         .await
         .expect("Failed to create fusillade TestDbPools");
 
-    let request_manager = std::sync::Arc::new(fusillade::PostgresRequestManager::new(fusillade_pools, Default::default()));
+    let request_manager = std::sync::Arc::new(fusillade_arsenal::PostgresRequestManager::new(fusillade_pools, Default::default()));
     let limiters = crate::limits::Limiters::new(&config.limits);
     let shared_config = crate::SharedConfig::new(config);
 
@@ -102,7 +102,7 @@ pub async fn setup_fusillade_pool(pool: &PgPool) -> PgPool {
         .await
         .expect("Failed to create fusillade pool");
 
-    fusillade::migrator()
+    fusillade_arsenal::migrator()
         .run(&fusillade_pool)
         .await
         .expect("Failed to run fusillade migrations");
@@ -119,7 +119,10 @@ pub async fn create_test_app_state_with_fusillade(pool: PgPool, config: crate::c
     let fusillade_test_pools = TestDbPools::new(fusillade_pool)
         .await
         .expect("Failed to create fusillade TestDbPools");
-    let request_manager = std::sync::Arc::new(fusillade::PostgresRequestManager::new(fusillade_test_pools, Default::default()));
+    let request_manager = std::sync::Arc::new(fusillade_arsenal::PostgresRequestManager::new(
+        fusillade_test_pools,
+        Default::default(),
+    ));
     let limiters = crate::limits::Limiters::new(&config.limits);
     let shared_config = crate::SharedConfig::new(config);
 


### PR DESCRIPTION
## Summary
- Upgrade dwctl to the split Fusillade runtime using published registry crates: `fusillade 21.0.1`, `fusillade-arsenal 1.0.1`, and `onwards 0.34.6`.
- Move Postgres request/step storage usage to `fusillade-arsenal` while running the scheduling runtime through `fusillade::PostgresDaemon`.
- Expose `background_services.batch_daemon.mode` with `both` (default), `request_only`, and `batch_only`, and pass it through to Fusillade daemon config.
- Keep the default runtime behavior as `both` while allowing request and batch claim daemons to be split for independent scaling.

## Verification
- `cargo check --locked -p dwctl`
- `cargo test --locked -p dwctl test_daemon_mode_default_and_override`
- `cargo test --locked -p dwctl --lib --no-run`
- `SQLX_OFFLINE=true just lint rust`
- `cargo tree --locked -p dwctl -i onwards`
- `cargo tree --locked -p dwctl -i fusillade`

## Notes
- All Fusillade-related dependencies now resolve from crates.io; there are no temporary git pins for this upgrade path.
- The dependency graph resolves `fusillade v21.0.1` both directly and through `onwards v0.34.6`.
