### PR TITLE
fix: index seq before credits backfill sweep + day-level model-usage ranges

### DIFF
--- a/dashboard/src/components/features/models/manage/UserUsageTable.tsx
+++ b/dashboard/src/components/features/models/manage/UserUsageTable.tsx
@@ -2,7 +2,6 @@ import React, { useState, useMemo } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { useRequestsAggregateByUser } from "../../../../api/control-layer";
 import { type UserUsage } from "../../../../api/control-layer";
-import { DateTimeRangeSelector } from "../../../ui/date-time-range-selector";
 import { DataTable } from "../../../ui/data-table";
 import { Button } from "../../../ui/button";
 import {
@@ -11,6 +10,18 @@ import {
   HoverCardTrigger,
 } from "../../../ui/hover-card";
 import { ArrowUpDown, Users, Download } from "lucide-react";
+
+// Usage is served from a per-UTC-day rollup (COR-516: get_model_user_usage reads
+// user_model_usage_daily), so this table offers whole-UTC-day ranges only — no
+// sub-day custom picker. Each value spans N whole UTC days (today inclusive),
+// mirroring the /usage page.
+const RANGE_DAYS: Record<string, number> = { "1d": 1, "7d": 7, "30d": 30, "90d": 90 };
+const RANGE_OPTIONS = [
+  { value: "1d", label: "Today" },
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+  { value: "90d", label: "90d" },
+];
 
 interface UserUsageTableProps {
   modelAlias: string;
@@ -21,18 +32,26 @@ const UserUsageTable: React.FC<UserUsageTableProps> = ({
   modelAlias,
   showPricing = true,
 }) => {
-  const [dateRange, setDateRange] = useState<{ from: Date; to: Date }>({
-    from: new Date(new Date().getTime() - 24 * 60 * 60 * 1000), // 24 hours ago
-    to: new Date(), // now
-  });
+  const [rangeKey, setRangeKey] = useState("7d");
 
-  // Convert date range to ISO strings
+  // Align the window to whole UTC days (the rollup buckets by UTC usage_date):
+  // start at midnight UTC of (today - (days - 1)), end at "now". The backend
+  // truncates both bounds to their UTC date.
   const { startDate, endDate } = useMemo(() => {
+    const days = RANGE_DAYS[rangeKey] ?? 7;
+    const now = new Date();
+    const startUtcMidnight = new Date(
+      Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate() - (days - 1),
+      ),
+    );
     return {
-      startDate: dateRange.from.toISOString(),
-      endDate: dateRange.to.toISOString(),
+      startDate: startUtcMidnight.toISOString(),
+      endDate: now.toISOString(),
     };
-  }, [dateRange]);
+  }, [rangeKey]);
 
   const { data, isLoading, error } = useRequestsAggregateByUser(
     modelAlias,
@@ -54,13 +73,20 @@ const UserUsageTable: React.FC<UserUsageTableProps> = ({
     if (!dateStr) return "-";
     const date = new Date(dateStr);
     const now = new Date();
-    const diff = now.getTime() - date.getTime();
-    const hours = Math.floor(diff / (1000 * 60 * 60));
+    // last_active_at is day-granular — the UTC midnight of MAX(usage_date)
+    // (COR-516), not an exact timestamp — so compare by whole UTC day rather
+    // than elapsed hours. Otherwise same-day usage viewed just after UTC
+    // midnight reads "1d ago" instead of "Today".
+    const utcDay = (d: Date) =>
+      Math.floor(
+        Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) /
+          86_400_000,
+      );
+    const dayDiff = utcDay(now) - utcDay(date);
 
-    if (hours < 1) return "Just now";
-    if (hours < 24) return `${hours}h ago`;
-    const days = Math.floor(hours / 24);
-    if (days < 30) return `${days}d ago`;
+    if (dayDiff <= 0) return "Today";
+    if (dayDiff === 1) return "Yesterday";
+    if (dayDiff < 30) return `${dayDiff}d ago`;
     return date.toLocaleDateString();
   };
 
@@ -318,15 +344,20 @@ const UserUsageTable: React.FC<UserUsageTableProps> = ({
             </div>
           )}
 
-          <DateTimeRangeSelector
-            value={dateRange}
-            onChange={(range) => {
-              if (range) {
-                setDateRange(range);
-              }
-            }}
-            className="w-auto"
-          />
+          <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-1">
+            {RANGE_OPTIONS.map((opt) => (
+              <Button
+                key={opt.value}
+                variant={rangeKey === opt.value ? "secondary" : "ghost"}
+                size="sm"
+                className="h-7 px-3"
+                aria-pressed={rangeKey === opt.value}
+                onClick={() => setRangeKey(opt.value)}
+              >
+                {opt.label}
+              </Button>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/dashboard/src/components/features/models/manage/UserUsageTable.tsx
+++ b/dashboard/src/components/features/models/manage/UserUsageTable.tsx
@@ -350,6 +350,7 @@ const UserUsageTable: React.FC<UserUsageTableProps> = ({
                 key={opt.value}
                 variant={rangeKey === opt.value ? "secondary" : "ghost"}
                 size="sm"
+                type="button"
                 className="h-7 px-3"
                 aria-pressed={rangeKey === opt.value}
                 onClick={() => setRangeKey(opt.value)}

--- a/dwctl/src/request_logging/utils.rs
+++ b/dwctl/src/request_logging/utils.rs
@@ -330,7 +330,7 @@ pub(crate) fn extract_header_as_string(request_data: &outlet::RequestData, heade
         .map(|s| s.to_string())
 }
 
-// Mylena & Sebastien 2026 <3 :-)
+// Mylena & Sebastien 2026 <3 :^)
 
 #[cfg(test)]
 mod tests {

--- a/scripts/backfill_credits_denorm.sh
+++ b/scripts/backfill_credits_denorm.sh
@@ -61,9 +61,10 @@ echo "backfill_credits_denorm: sweeping seq (0, ${MAX_SEQ}]  batch=${BATCH_SIZE}
 # and DROP run CONCURRENTLY, each as its own autocommit statement (never inside a
 # txn), so they never block live writes. Not counted in the sweep duration below.
 echo "backfill_credits_denorm: (re)building helper index ${HELPER_IDX} CONCURRENTLY (may take a few minutes)…"
+# Best-effort cleanup on errors/interrupts; DROP INDEX CONCURRENTLY must run outside a txn.
+trap 'psql_q "DROP INDEX CONCURRENTLY IF EXISTS ${HELPER_IDX};" >/dev/null 2>&1 || true' EXIT INT TERM
 psql_q "DROP INDEX CONCURRENTLY IF EXISTS ${HELPER_IDX};"
 psql_q "CREATE INDEX CONCURRENTLY ${HELPER_IDX} ON credits_transactions (seq) WHERE service_tier IS NULL;"
-
 CURSOR=0
 total_rows=0
 batches=0

--- a/scripts/backfill_credits_denorm.sh
+++ b/scripts/backfill_credits_denorm.sh
@@ -24,17 +24,26 @@
 # `service_tier IS NULL` guard skips rows already populated by the batcher or a
 # prior run. Non-usage rows (grants/purchases) never match the join and stay NULL.
 #
+# Helper index: credits_transactions has NO standalone index on seq (the PK is
+# id; every index carrying seq leads with user_id), so an un-helped seq-range
+# sweep sequential-scans the whole ~48M-row table on EVERY batch (measured ~200s
+# per 20k window on staging -> days total). So this script first builds a partial
+# btree index on seq (CONCURRENTLY, never locks writes) and drops it when done.
+# The `WHERE service_tier IS NULL` predicate keeps it small and self-shrinking as
+# rows get filled, and makes re-running already-finished windows near-instant.
+#
 # Usage:
 #   DATABASE_URL=postgres://...  ./scripts/backfill_credits_denorm.sh
 # Optional env:
-#   BATCH_SIZE     seq-range width swept per batch (default 20000)
+#   BATCH_SIZE     seq-range width swept per batch (default 100000)
 #   SLEEP_SECONDS  pause between batches (default 0.1)
 
 set -euo pipefail
 
 : "${DATABASE_URL:?set DATABASE_URL to the credits/http_analytics database}"
-BATCH_SIZE="${BATCH_SIZE:-20000}"
+BATCH_SIZE="${BATCH_SIZE:-100000}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-0.1}"
+HELPER_IDX=idx_credits_tx_seq_backfill
 
 psql_q() { psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -X -qtAc "$1"; }
 
@@ -45,6 +54,15 @@ if [ -z "$MAX_SEQ" ] || [ "$MAX_SEQ" -eq 0 ]; then
 fi
 
 echo "backfill_credits_denorm: sweeping seq (0, ${MAX_SEQ}]  batch=${BATCH_SIZE}  sleep=${SLEEP_SECONDS}s"
+
+# Build the seq helper index up front. Drop any leftover first (a prior aborted
+# CONCURRENTLY build can leave an INVALID index that CREATE ... IF NOT EXISTS
+# would silently keep, sending the sweep back to full table scans). Both CREATE
+# and DROP run CONCURRENTLY, each as its own autocommit statement (never inside a
+# txn), so they never block live writes. Not counted in the sweep duration below.
+echo "backfill_credits_denorm: (re)building helper index ${HELPER_IDX} CONCURRENTLY (may take a few minutes)…"
+psql_q "DROP INDEX CONCURRENTLY IF EXISTS ${HELPER_IDX};"
+psql_q "CREATE INDEX CONCURRENTLY ${HELPER_IDX} ON credits_transactions (seq) WHERE service_tier IS NULL;"
 
 CURSOR=0
 total_rows=0
@@ -82,6 +100,10 @@ printf '  ledger rows updated : %s\n' "$total_rows"
 printf '  duration            : %dm %02ds (wall-clock, incl. throttle sleeps)\n' $(( elapsed / 60 )) $(( elapsed % 60 ))
 printf '  batches             : %s  (BATCH_SIZE=%s, SLEEP_SECONDS=%s)\n' "$batches" "$BATCH_SIZE" "$SLEEP_SECONDS"
 printf '  seq swept           : up to %s\n' "$MAX_SEQ"
+
+echo "backfill_credits_denorm: dropping helper index ${HELPER_IDX} CONCURRENTLY…"
+psql_q "DROP INDEX CONCURRENTLY IF EXISTS ${HELPER_IDX};"
+
 echo
 echo "Spot-check tier distribution:"
 echo "  psql \"\$DATABASE_URL\" -c \"SELECT service_tier, count(*) FROM credits_transactions WHERE transaction_type='usage' GROUP BY 1 ORDER BY 2 DESC;\""


### PR DESCRIPTION
Follow-up to #1254 (COR-507 / COR-516 billing & usage read-model work). Two independent fixes surfaced while testing the backfill on staging.

## 1. `scripts/backfill_credits_denorm.sh` — index `seq` before sweeping

The script sweeps `credits_transactions` by `seq` range, but **`seq` has no standalone index** (PK is `id`; every index carrying `seq` leads with `user_id`). So each batch **sequential-scanned the whole ~48M-row table**.

Measured on a staging Neon branch: **~203 s per 20k-row window** → on the order of **days** for a full run (effectively O(n²)). Running it on prod as-is would have hammered the DB for days.

Fix:
- Build a **partial** btree index `idx_credits_tx_seq_backfill ON credits_transactions(seq) WHERE service_tier IS NULL` **CONCURRENTLY** up front; drop it CONCURRENTLY at the end.
- Drop any leftover first, so a prior aborted `CONCURRENTLY` build can't leave an INVALID index that `CREATE ... IF NOT EXISTS` would silently keep (which would send the sweep back to full scans).
- Raise default `BATCH_SIZE` 20000 → **100000** (~2× throughput on staging) so a full prod run fits an overnight window.

After the fix: batches drop to **~26–33 s** (20k) / **~1,549 rows/s** (100k+) on the cold staging branch.

**Correctness was validated on staging** (unchanged by this PR): the SQL tier rule matches `compute_service_tier` exactly, and recomputing tiers from `http_analytics` reproduced the batcher's INSERT-time values on 5,000 sampled rows with **zero mismatches**; idempotent re-runs update 0 rows; non-usage rows stay NULL.

## 2. Model usage table — day-level ranges + "Today"

`get_model_user_usage` now reads the per-UTC-day rollup (COR-516), so the per-user usage table's data is day-granular:
- Replaced the shared sub-day calendar+time custom picker with whole-UTC-day presets (**Today / 7d / 30d / 90d**), matching the `/usage` page. (The shared `DateTimeRangeSelector` is untouched — still used by Requests/AsyncRequests/Transactions/Batches.)
- `last_active_at` is the UTC midnight of `MAX(usage_date)`, not an exact timestamp, so the old hours-based label showed "1d ago" when viewed just after UTC midnight. Now compares by **UTC calendar day** → same-day usage reads **"Today"**.

## Validation
- Dashboard: `tsc -b` clean, `eslint` clean, **617/617** vitest pass.
- Script: `bash -n` clean; index/plan/timing/idempotency/correctness exercised against the staging Neon branch.