### PR TITLE
fix: backfill credits service_tier from fusillade.batches instead of per-row http_analytics

### DIFF
--- a/scripts/backfill_credits_denorm.sh
+++ b/scripts/backfill_credits_denorm.sh
@@ -1,48 +1,69 @@
 #!/usr/bin/env bash
 #
-# Backfill credits_transactions.service_tier from http_analytics history
+# Backfill credits_transactions.service_tier from authoritative sources
 # (COR-507, migration 112).
 #
-# Context: migration 112 adds the service_tier column, and the analytics batcher
-# (batch_insert_credits) sets it at INSERT going forward (computed in memory from
-# fusillade_batch_id + completion_window). This script fills history by recomputing
-# the same classification from the matching http_analytics row: every usage row's
-# source_id IS that http_analytics row's id (batch_insert_credits pushes
-# analytics_id.to_string() as source_id), so ha.id::text = ct.source_id joins them.
-# http_analytics carries fusillade_batch_id and batch_sla (= completion_window).
+# Context: migration 112 adds service_tier; the analytics batcher sets it at
+# INSERT going forward, computed from (fusillade_batch_id, completion_window).
+# This script fills history.
+#
+# --- Why this does NOT join http_analytics per row ---
+# The obvious backfill (recompute each row's tier from its matching
+# http_analytics row via ha.id::text = ct.source_id) means ~48M random probes
+# into the 156M-row http_analytics id-index. On the prod primary those are cold
+# Neon pageserver reads (Neon/PS_ReadIO) -> ~200s per 100k rows and days total,
+# and it competes with live traffic for pageserver I/O. Validated too heavy.
+#
+# Instead we classify from cheaper, authoritative sources (validated on a prod
+# clone, see COR-507 notes):
+#
+#   * Batch vs async (rows WITH fusillade_batch_id, ~94% of usage rows):
+#     take the SLA from fusillade.batches.completion_window, NOT http_analytics.
+#     When http_analytics.batch_sla is populated it equals
+#     batches.completion_window in 100% of sampled rows; and batch_sla was simply
+#     not populated before ~Feb 2026, so batches.completion_window is both
+#     consistent with the batcher going forward AND corrects old rows that the
+#     raw analytics would mislabel `async` (real 24h batches with an empty SLA).
+#       completion_window = '24h' -> batch ;  otherwise (incl. a deleted batch
+#       row, which we can't resolve) -> async.
+#     fusillade.batches is small and hash-joins in memory: no http_analytics.
+#
+#   * realtime vs flex (rows WITHOUT fusillade_batch_id, ~6%):
+#     default realtime; flex is a non-batch request that carried an SLA. Its SLA
+#     lives only in http_analytics.batch_sla, so flex (~0.2% of rows) is the one
+#     case that needs http_analytics -- recovered by a SINGLE bounded scan
+#     (Phase 2), not per-row probes. Pre-cutover flex was never recorded and is
+#     correctly left realtime.
 #
 # Tier rule (mirrors compute_service_tier in batcher.rs):
-#   batch id + 24h -> batch;  batch id + else -> async;
-#   no batch id + non-empty SLA -> flex;  otherwise -> realtime.
+#   batch id + '24h'      -> batch
+#   batch id + otherwise  -> async
+#   no batch id + SLA     -> flex
+#   no batch id + no SLA  -> realtime
 #
-# Run AFTER migration 112 is deployed (so the batcher populates new rows) and
-# BEFORE COR-514 drops idx_http_analytics_id_text — the join rides that index.
+# Corrective + overwriting: this recomputes every usage row (no `service_tier
+# IS NULL` guard), so it also fixes any rows written by an earlier http_analytics
+# -based run. Non-usage rows (grants/purchases) are left untouched (NULL).
+# Resumable via START_SEQ (set it to the last committed `seq<=` printed below).
 #
-# Side-script, not a migration: a single UPDATE over the whole ledger would hold
-# one long transaction and bloat. We sweep credits_transactions by seq in fixed
-# ranges, each its own committed transaction. Idempotent + resumable: the
-# `service_tier IS NULL` guard skips rows already populated by the batcher or a
-# prior run. Non-usage rows (grants/purchases) never match the join and stay NULL.
-#
-# Helper index: credits_transactions has NO standalone index on seq (the PK is
-# id; every index carrying seq leads with user_id), so an un-helped seq-range
-# sweep sequential-scans the whole ~48M-row table on EVERY batch (measured ~200s
-# per 20k window on staging -> days total). So this script first builds a partial
-# btree index on seq (CONCURRENTLY, never locks writes) and drops it when done.
-# The `WHERE service_tier IS NULL` predicate keeps it small and self-shrinking as
-# rows get filled, and makes re-running already-finished windows near-instant.
+# Run AFTER migration 112 is deployed (so the batcher populates new rows).
 #
 # Usage:
 #   DATABASE_URL=postgres://...  ./scripts/backfill_credits_denorm.sh
 # Optional env:
 #   BATCH_SIZE     seq-range width swept per batch (default 100000)
 #   SLEEP_SECONDS  pause between batches (default 0.1)
+#   START_SEQ      resume: skip seq <= this (default 0)
+#   FLEX_CUTOFF    only scan http_analytics at/after this date for flex
+#                  (default 2026-01-01; set empty to scan all history)
 
 set -euo pipefail
 
 : "${DATABASE_URL:?set DATABASE_URL to the credits/http_analytics database}"
 BATCH_SIZE="${BATCH_SIZE:-100000}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-0.1}"
+START_SEQ="${START_SEQ:-0}"
+FLEX_CUTOFF="${FLEX_CUTOFF:-2026-01-01}"
 HELPER_IDX=idx_credits_tx_seq_backfill
 
 psql_q() { psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -X -qtAc "$1"; }
@@ -53,54 +74,80 @@ if [ -z "$MAX_SEQ" ] || [ "$MAX_SEQ" -eq 0 ]; then
   exit 0
 fi
 
-echo "backfill_credits_denorm: sweeping seq (0, ${MAX_SEQ}]  batch=${BATCH_SIZE}  sleep=${SLEEP_SECONDS}s"
+echo "backfill_credits_denorm: sweeping seq (${START_SEQ}, ${MAX_SEQ}]  batch=${BATCH_SIZE}  sleep=${SLEEP_SECONDS}s"
 
-# Build the seq helper index up front. Drop any leftover first (a prior aborted
-# CONCURRENTLY build can leave an INVALID index that CREATE ... IF NOT EXISTS
-# would silently keep, sending the sweep back to full table scans). Both CREATE
-# and DROP run CONCURRENTLY, each as its own autocommit statement (never inside a
-# txn), so they never block live writes. Not counted in the sweep duration below.
+# credits_transactions has NO standalone index on seq (PK is id; every index
+# carrying seq leads with user_id), so the seq-range sweep would seq-scan the
+# whole table each batch. Build a plain btree on seq first (CONCURRENTLY, never
+# locks writes) and drop it when done. Drop any leftover first so an aborted
+# CONCURRENTLY build can't leave an INVALID index that CREATE would keep.
 echo "backfill_credits_denorm: (re)building helper index ${HELPER_IDX} CONCURRENTLY (may take a few minutes)…"
-# Best-effort cleanup on errors/interrupts; DROP INDEX CONCURRENTLY must run outside a txn.
 trap 'psql_q "DROP INDEX CONCURRENTLY IF EXISTS ${HELPER_IDX};" >/dev/null 2>&1 || true' EXIT INT TERM
 psql_q "DROP INDEX CONCURRENTLY IF EXISTS ${HELPER_IDX};"
-psql_q "CREATE INDEX CONCURRENTLY ${HELPER_IDX} ON credits_transactions (seq) WHERE service_tier IS NULL;"
-CURSOR=0
+psql_q "CREATE INDEX CONCURRENTLY ${HELPER_IDX} ON credits_transactions (seq);"
+
+# --- Phase 1: batch/async/realtime from fusillade.batches (no http_analytics) ---
+CURSOR="$START_SEQ"
 total_rows=0
 batches=0
 SECONDS=0
 while [ "$CURSOR" -lt "$MAX_SEQ" ]; do
   hi=$(( CURSOR + BATCH_SIZE ))
   if [ "$hi" -gt "$MAX_SEQ" ]; then hi="$MAX_SEQ"; fi
+  # Two UPDATEs + a count, one implicit transaction (atomic per chunk):
+  #   1. default every usage row: batch id -> async, else -> realtime
+  #   2. upgrade to batch where the batch's window is 24h (deleted batch rows
+  #      have no batches match and stay async)
   affected=$(psql_q "
-    WITH upd AS (
-      UPDATE credits_transactions ct
-         SET service_tier = CASE
-               WHEN ha.fusillade_batch_id IS NOT NULL AND ha.batch_sla = '24h' THEN 'batch'
-               WHEN ha.fusillade_batch_id IS NOT NULL                          THEN 'async'
-               WHEN COALESCE(ha.batch_sla, '') <> ''                           THEN 'flex'
-               ELSE 'realtime'
-             END
-        FROM http_analytics ha
-       WHERE ct.seq > ${CURSOR} AND ct.seq <= ${hi}
-             AND ct.service_tier IS NULL
-             AND ha.id::text = ct.source_id
-      RETURNING 1
-    )
-    SELECT count(*) FROM upd;")
+    UPDATE credits_transactions ct
+       SET service_tier = CASE WHEN ct.fusillade_batch_id IS NOT NULL THEN 'async' ELSE 'realtime' END
+     WHERE ct.seq > ${CURSOR} AND ct.seq <= ${hi}
+           AND ct.transaction_type = 'usage';
+    UPDATE credits_transactions ct
+       SET service_tier = 'batch'
+      FROM fusillade.batches b
+     WHERE ct.fusillade_batch_id = b.id
+           AND b.completion_window = '24h'
+           AND ct.seq > ${CURSOR} AND ct.seq <= ${hi}
+           AND ct.service_tier = 'async';
+    SELECT count(*) FROM credits_transactions
+     WHERE seq > ${CURSOR} AND seq <= ${hi} AND transaction_type = 'usage';")
   total_rows=$(( total_rows + affected ))
   batches=$(( batches + 1 ))
   CURSOR="$hi"
-  printf '  seq<=%-12s  rows +%-6s  (total %s)\n' "$hi" "$affected" "$total_rows"
+  printf '  seq<=%-12s  rows %-7s  (total %s)\n' "$hi" "$affected" "$total_rows"
   sleep "${SLEEP_SECONDS}"
 done
 
+# --- Phase 2: flex, one bounded scan of http_analytics ---
+# A non-batch request that carried an SLA. Only source is http_analytics.batch_sla.
+# Single set-based UPDATE: scan http_analytics once (bounded by FLEX_CUTOFF),
+# upgrade the matching realtime rows to flex. Not per-row probing.
+flex_where_cutoff=""
+if [ -n "$FLEX_CUTOFF" ]; then flex_where_cutoff="AND ha.timestamp >= '${FLEX_CUTOFF}'"; fi
+echo "backfill_credits_denorm: Phase 2 flex — scanning http_analytics ${FLEX_CUTOFF:+from ${FLEX_CUTOFF} }…"
+flex_rows=$(psql_q "
+  WITH f AS (
+    UPDATE credits_transactions ct
+       SET service_tier = 'flex'
+      FROM http_analytics ha
+     WHERE ha.id::text = ct.source_id
+           ${flex_where_cutoff}
+           AND ha.fusillade_batch_id IS NULL
+           AND COALESCE(ha.batch_sla, '') <> ''
+           AND ct.fusillade_batch_id IS NULL
+           AND ct.service_tier = 'realtime'
+    RETURNING 1
+  )
+  SELECT count(*) FROM f;")
+
 elapsed=$SECONDS
 echo "backfill_credits_denorm: DONE"
-printf '  ledger rows updated : %s\n' "$total_rows"
-printf '  duration            : %dm %02ds (wall-clock, incl. throttle sleeps)\n' $(( elapsed / 60 )) $(( elapsed % 60 ))
-printf '  batches             : %s  (BATCH_SIZE=%s, SLEEP_SECONDS=%s)\n' "$batches" "$BATCH_SIZE" "$SLEEP_SECONDS"
-printf '  seq swept           : up to %s\n' "$MAX_SEQ"
+printf '  usage rows classified : %s\n' "$total_rows"
+printf '  flex rows (Phase 2)   : %s\n' "$flex_rows"
+printf '  duration              : %dm %02ds (sweep only, excl. index build)\n' $(( elapsed / 60 )) $(( elapsed % 60 ))
+printf '  batches               : %s  (BATCH_SIZE=%s, SLEEP_SECONDS=%s)\n' "$batches" "$BATCH_SIZE" "$SLEEP_SECONDS"
+printf '  seq swept             : (%s, %s]\n' "$START_SEQ" "$MAX_SEQ"
 
 echo "backfill_credits_denorm: dropping helper index ${HELPER_IDX} CONCURRENTLY…"
 psql_q "DROP INDEX CONCURRENTLY IF EXISTS ${HELPER_IDX};"


### PR DESCRIPTION
Follow-up to #1259. Reworks `scripts/backfill_credits_denorm.sh` after a first prod attempt showed the per-row `http_analytics` join is too heavy for the primary.

## Problem
The prior approach recomputed each row's `service_tier` from its matching `http_analytics` row (`ha.id::text = ct.source_id`) — **~48M random probes into the 156M-row `http_analytics` id-index**. On the prod primary those are cold Neon pageserver reads (`Neon/PS_ReadIO`): ~200s per 100k rows, **days** total, competing with live traffic for pageserver I/O. The first prod run was halted after confirming this (ledger left clean: ~200k rows committed, rest untouched, resumable).

## New approach — classify from authoritative, cheap sources
Validated on a production clone (Neon branch):

| Tier | Share | Source |
|---|---|---|
| `batch` / `async` | ~94% | `fusillade.batches.completion_window` (small hash join) — **no http_analytics** |
| `realtime` | ~6% | default for non-batch rows — **no join** |
| `flex` | ~0.2% | single bounded `http_analytics` scan (Phase 2) — **not per-row probes** |

**Why `fusillade.batches` is authoritative (and corrective):** where `http_analytics.batch_sla` is populated it equals `batches.completion_window` in **100%** of sampled rows (217,268/217,268). `batch_sla` simply wasn't populated before ~Feb 2026, so `batches.completion_window` is both consistent with how the batcher labels new rows *and* corrects old 24h batches the raw analytics would mislabel `async`.

## Behaviour
- **Corrective + overwriting:** recomputes every usage row (no `service_tier IS NULL` guard), so it also fixes rows written by the earlier `http_analytics`-based partial run. Non-usage rows stay NULL.
- **Deleted-batch rows** (no surviving `batches` row): fall back to `async`.
- **Resumable** via `START_SEQ`; helper seq index built/dropped `CONCURRENTLY` as before.
- Phase 2 `flex` scan bounded by `FLEX_CUTOFF` (default `2026-01-01`; pre-cutover flex was never recorded and is correctly left `realtime`).

## Validation (prod clone)
- Representative 0.5% sample: redesign vs raw `http_analytics` truth differ **only** by the intended pre-cutover corrections (5,249 `async`→`batch`, all `batch_sla=(empty)`) and the accepted deleted-batch `async` fallback (48 rows, ~0.02%). No unexpected mismatches.
- End-to-end script run (index build → chunked Phase 1 → Phase 2 → drop): exit 0; **written tiers match expected classification 100%** on the swept window (299,784 `batch` / 216 `realtime`, zero off-diagonal).
- `bash -n` clean.