### PR TITLE
feat: filter model discovery by group and realtime availability

### DIFF
--- a/docs/src/how-to/api.md
+++ b/docs/src/how-to/api.md
@@ -73,6 +73,18 @@ Use model names exactly as shown on the Models page. The Control Layer routes re
 
 If your admin configured model aliases, you can use either the original name or the alias.
 
+You can list models with the OpenAI-compatible `GET /ai/v1/models` endpoint. By default it returns every active model your API key can access, using the standard OpenAI response shape.
+
+Doubleword also supports optional query-string filters for discovery:
+
+```bash
+curl "https://your-control-layer/ai/v1/models?group=<group-id>&available_for_realtime=true" \
+  -H "Authorization: Bearer your-api-key"
+```
+
+- `group`: comma-separated group UUIDs. Results are still limited to models your API key can access.
+- `available_for_realtime`: `true` returns models without a realtime deny rule; `false` returns models with one.
+
 ## Streaming responses
 
 Streaming works the same as with OpenAI directly:

--- a/dwctl/src/api/handlers/ai_models.rs
+++ b/dwctl/src/api/handlers/ai_models.rs
@@ -2,13 +2,13 @@
 
 use axum::{
     Json,
-    extract::State,
+    extract::{Query, State},
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
-use sqlx::Row;
+use sqlx::{QueryBuilder, Row};
 use sqlx_pool_router::PoolProvider;
 
 use crate::AppState;
@@ -19,6 +19,36 @@ const EVERYONE_GROUP_ID: uuid::Uuid = uuid::Uuid::nil();
 pub struct ModelsListResponse {
     object: String,
     data: Vec<ModelObject>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ModelsListQuery {
+    group: Option<String>,
+    available_for_realtime: Option<String>,
+}
+
+enum ModelsListQueryError {
+    InvalidGroup,
+    InvalidBoolean { param: &'static str },
+}
+
+impl ModelsListQueryError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::InvalidGroup => openai_error(
+                StatusCode::BAD_REQUEST,
+                "Invalid group query parameter. Expected comma-separated UUIDs.",
+                "invalid_request_error",
+                "invalid_group",
+            ),
+            Self::InvalidBoolean { param } => openai_error(
+                StatusCode::BAD_REQUEST,
+                &format!("Invalid {param} query parameter. Expected true or false."),
+                "invalid_request_error",
+                "invalid_query_parameter",
+            ),
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -63,6 +93,31 @@ fn database_error(operation: &str, error: impl std::fmt::Display) -> Response {
     )
 }
 
+fn parse_group_filter(group: Option<&str>) -> Result<Vec<uuid::Uuid>, ModelsListQueryError> {
+    let Some(group) = group else {
+        return Ok(Vec::new());
+    };
+
+    group
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.parse::<uuid::Uuid>().map_err(|_| ModelsListQueryError::InvalidGroup))
+        .collect()
+}
+
+fn parse_optional_bool(param: &'static str, value: Option<&str>) -> Result<Option<bool>, ModelsListQueryError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" => Ok(Some(true)),
+        "false" => Ok(Some(false)),
+        _ => Err(ModelsListQueryError::InvalidBoolean { param }),
+    }
+}
+
 /// List active models that the presented inference API key has group access to.
 ///
 /// This intentionally does not filter by credit balance. Credit balance controls
@@ -70,6 +125,7 @@ fn database_error(operation: &str, error: impl std::fmt::Display) -> Response {
 /// access grants so users can still see what would be available after top-up.
 pub async fn list_ai_models<P: PoolProvider>(
     State(state): State<AppState<P>>,
+    Query(query): Query<ModelsListQuery>,
     headers: HeaderMap,
 ) -> Result<Json<ModelsListResponse>, Response> {
     let Some(token) = bearer_token(&headers) else {
@@ -80,6 +136,10 @@ pub async fn list_ai_models<P: PoolProvider>(
             "missing_authorization",
         ));
     };
+
+    let group_ids = parse_group_filter(query.group.as_deref()).map_err(ModelsListQueryError::into_response)?;
+    let available_for_realtime = parse_optional_bool("available_for_realtime", query.available_for_realtime.as_deref())
+        .map_err(ModelsListQueryError::into_response)?;
 
     let mut conn = state
         .db
@@ -114,7 +174,7 @@ pub async fn list_ai_models<P: PoolProvider>(
         ));
     };
 
-    let rows = sqlx::query(
+    let mut models_query = QueryBuilder::new(
         r#"
         SELECT DISTINCT
             dm.alias,
@@ -124,21 +184,59 @@ pub async fn list_ai_models<P: PoolProvider>(
         WHERE dm.deleted = FALSE
           AND dm.status = 'active'
           AND (
-              dg.group_id = $2
+              dg.group_id = "#,
+    );
+    models_query.push_bind(EVERYONE_GROUP_ID);
+    models_query.push(
+        r#"
               OR dg.group_id IN (
                   SELECT ug.group_id
                   FROM user_groups ug
-                  WHERE ug.user_id = $1
+                  WHERE ug.user_id = "#,
+    );
+    models_query.push_bind(user_id);
+    models_query.push(
+        r#"
               )
-        )
-        ORDER BY dm.alias
         "#,
-    )
-    .bind(user_id)
-    .bind(EVERYONE_GROUP_ID)
-    .fetch_all(&mut *conn)
-    .await
-    .map_err(|e| database_error("list_accessible_models", e))?;
+    );
+    models_query.push(")");
+
+    if !group_ids.is_empty() {
+        models_query.push(" AND dg.group_id = ANY(");
+        models_query.push_bind(group_ids);
+        models_query.push(")");
+    }
+
+    if let Some(available_for_realtime) = available_for_realtime {
+        if available_for_realtime {
+            models_query.push(
+                " AND NOT EXISTS (
+                    SELECT 1 FROM model_traffic_rules mtr
+                    WHERE mtr.deployed_model_id = dm.id
+                    AND mtr.api_key_purpose = 'realtime'
+                    AND mtr.action = 'deny'
+                )",
+            );
+        } else {
+            models_query.push(
+                " AND EXISTS (
+                    SELECT 1 FROM model_traffic_rules mtr
+                    WHERE mtr.deployed_model_id = dm.id
+                    AND mtr.api_key_purpose = 'realtime'
+                    AND mtr.action = 'deny'
+                )",
+            );
+        }
+    }
+
+    models_query.push(" ORDER BY dm.alias");
+
+    let rows = models_query
+        .build()
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(|e| database_error("list_accessible_models", e))?;
 
     Ok(Json(ModelsListResponse {
         object: "list".to_string(),

--- a/dwctl/src/api/handlers/deployments.rs
+++ b/dwctl/src/api/handlers/deployments.rs
@@ -171,14 +171,16 @@ fn db_component_to_response(c: DeploymentComponentDBResponse) -> ModelComponentR
     path = "/models",
     tag = "models",
     summary = "List deployed models",
-    description = "List all deployed models, optionally filtered by endpoint",
+    description = "List all deployed models, optionally filtered by endpoint, group, or availability",
     params(
         ("endpoint" = Option<i32>, Query, description = "Filter by inference endpoint ID"),
+        ("group" = Option<String>, Query, description = "Filter by group IDs (comma-separated UUIDs)"),
         ("accessible" = Option<bool>, Query, description = "Filter to only models the current user can access (defaults to false for admins, true for users)"),
         ("include" = Option<String>, Query, description = "Include additional data (comma-separated: 'groups', 'metrics', 'status', 'pricing', 'endpoints', 'facets'). Only platform managers can include groups. Status shows probe monitoring information. Pricing shows simple customer rates for regular users, full pricing structure including current active tariffs for users with Pricing::ReadAll permission. Endpoints includes full inference endpoint details. Facets returns distinct providers, capabilities, and model types for filter dropdowns."),
         ("provider" = Option<String>, Query, description = "Filter by provider name (case-insensitive exact match against metadata.provider)"),
         ("model_type" = Option<String>, Query, description = "Filter by model type (CHAT, EMBEDDINGS, RERANKER)"),
         ("capability" = Option<String>, Query, description = "Filter by capability (returns models that have this capability)"),
+        ("available_for_realtime" = Option<bool>, Query, description = "Filter by realtime availability. true returns models without a realtime deny rule; false returns models with one."),
         ("sort" = Option<String>, Query, description = "Sort field: created_at (default), alias, intelligence_index, released_at, context_window, provider, price_from"),
         ("sort_direction" = Option<String>, Query, description = "Sort direction: asc or desc (default depends on sort field)"),
         ("deleted" = Option<bool>, Query, description = "Show deleted models when true (admin only), non-deleted models when false, and all models when not specified"),
@@ -328,6 +330,10 @@ pub async fn list_deployed_models<P: PoolProvider>(
         && !capability.trim().is_empty()
     {
         filter = filter.with_capability(capability.trim().to_string());
+    }
+
+    if let Some(available_for_realtime) = query.available_for_realtime {
+        filter = filter.with_realtime_availability(available_for_realtime);
     }
 
     // Apply sort if specified
@@ -1335,8 +1341,8 @@ mod tests {
             models::{pagination::PaginatedResponse, users::Role},
         },
         db::{
-            handlers::{Groups, Repository},
-            models::groups::GroupCreateDBRequest,
+            handlers::{Deployments, Groups, Repository},
+            models::{api_keys::ApiKeyPurpose, deployments::TrafficRuleAction, groups::GroupCreateDBRequest},
         },
         test::utils::*,
         types::DeploymentId,
@@ -3063,6 +3069,72 @@ mod tests {
         response.assert_status_ok();
         let all_models: PaginatedResponse<DeployedModelResponse> = response.json();
         assert!(all_models.data.len() >= 3, "Empty group list should return all models");
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_list_models_with_available_for_realtime_filter(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let admin_user = create_test_admin_user(&pool, Role::PlatformManager).await;
+
+        let allowed_deployment = create_test_deployment(&pool, admin_user.id, "realtime-allowed-model", "realtime-allowed-alias").await;
+        let denied_deployment = create_test_deployment(&pool, admin_user.id, "realtime-denied-model", "realtime-denied-alias").await;
+        let redirected_deployment =
+            create_test_deployment(&pool, admin_user.id, "realtime-redirected-model", "realtime-redirected-alias").await;
+        let redirect_target = create_test_deployment(&pool, admin_user.id, "realtime-target-model", "realtime-target-alias").await;
+        let other_group_deployment = create_test_deployment(&pool, admin_user.id, "other-group-model", "other-group-alias").await;
+
+        let mut conn = pool.acquire().await.unwrap();
+
+        let group = {
+            let mut group_repo = Groups::new(&mut conn);
+            let group = group_repo
+                .create(&GroupCreateDBRequest {
+                    name: "Realtime Test Group".to_string(),
+                    description: Some("Models used for realtime availability filtering".to_string()),
+                    created_by: admin_user.id,
+                })
+                .await
+                .unwrap();
+
+            for deployment_id in [allowed_deployment.id, denied_deployment.id, redirected_deployment.id] {
+                group_repo
+                    .add_deployment_to_group(deployment_id, group.id, admin_user.id)
+                    .await
+                    .unwrap();
+            }
+
+            group
+        };
+
+        {
+            let mut deployment_repo = Deployments::new(&mut conn);
+            deployment_repo
+                .set_traffic_rules(denied_deployment.id, &[(ApiKeyPurpose::Realtime, TrafficRuleAction::Deny)])
+                .await
+                .unwrap();
+            deployment_repo
+                .set_traffic_rules(
+                    redirected_deployment.id,
+                    &[(ApiKeyPurpose::Realtime, TrafficRuleAction::Redirect(redirect_target.id))],
+                )
+                .await
+                .unwrap();
+        }
+
+        let response = app
+            .get(&format!("/admin/api/v1/models?group={}&available_for_realtime=true", group.id))
+            .add_header(&add_auth_headers(&admin_user)[0].0, &add_auth_headers(&admin_user)[0].1)
+            .add_header(&add_auth_headers(&admin_user)[1].0, &add_auth_headers(&admin_user)[1].1)
+            .await;
+        response.assert_status_ok();
+
+        let realtime_models: PaginatedResponse<DeployedModelResponse> = response.json();
+        assert_eq!(realtime_models.total_count, 2);
+        assert!(get_model_by_id(allowed_deployment.id, &realtime_models).is_some());
+        assert!(get_model_by_id(redirected_deployment.id, &realtime_models).is_some());
+        assert!(get_model_by_id(denied_deployment.id, &realtime_models).is_none());
+        assert!(get_model_by_id(other_group_deployment.id, &realtime_models).is_none());
     }
 
     // ===== Traffic Routing Rules Tests =====

--- a/dwctl/src/api/models/deployments/mod.rs
+++ b/dwctl/src/api/models/deployments/mod.rs
@@ -102,6 +102,8 @@ pub struct ListModelsQuery {
     pub model_type: Option<ModelType>,
     /// Filter by capability (returns models that have this capability)
     pub capability: Option<String>,
+    /// Filter by realtime availability (true = no realtime deny rule, false = realtime deny rule)
+    pub available_for_realtime: Option<bool>,
     /// Sort field (default: created_at)
     pub sort: Option<ModelSortField>,
     /// Sort direction (default depends on sort field)

--- a/dwctl/src/db/handlers/deployments.rs
+++ b/dwctl/src/db/handlers/deployments.rs
@@ -45,6 +45,7 @@ pub struct DeploymentFilter {
     pub provider: Option<String>,              // Filter by metadata provider (case-insensitive exact match)
     pub model_type: Option<ModelType>,         // Filter by model type column
     pub capability: Option<String>,            // Filter to models that have this capability
+    pub available_for_realtime: Option<bool>,  // Filter by whether realtime traffic is denied
     pub sort_field: Option<ModelSortField>,    // Sort field (default: created_at)
     pub sort_direction: Option<SortDirection>, // Sort direction (default depends on field)
 }
@@ -61,12 +62,13 @@ impl DeploymentFilter {
             group_ids: None,     // Default: show all groups
             aliases: None,
             search: None,
-            is_composite: None,   // Default: show all models
-            provider: None,       // Default: no provider filter
-            model_type: None,     // Default: no type filter
-            capability: None,     // Default: no capability filter
-            sort_field: None,     // Default: created_at
-            sort_direction: None, // Default: depends on field
+            is_composite: None,           // Default: show all models
+            provider: None,               // Default: no provider filter
+            model_type: None,             // Default: no type filter
+            capability: None,             // Default: no capability filter
+            available_for_realtime: None, // Default: no realtime availability filter
+            sort_field: None,             // Default: created_at
+            sort_direction: None,         // Default: depends on field
         }
     }
 
@@ -122,6 +124,11 @@ impl DeploymentFilter {
 
     pub fn with_capability(mut self, capability: String) -> Self {
         self.capability = Some(capability);
+        self
+    }
+
+    pub fn with_realtime_availability(mut self, available: bool) -> Self {
+        self.available_for_realtime = Some(available);
         self
     }
 
@@ -810,6 +817,28 @@ impl<'c> Deployments<'c> {
             query.push(" AND ");
             query.push_bind(capability.clone());
             query.push(" = ANY(dm.capabilities)");
+        }
+
+        if let Some(available_for_realtime) = filter.available_for_realtime {
+            if available_for_realtime {
+                query.push(
+                    " AND NOT EXISTS (
+                        SELECT 1 FROM model_traffic_rules mtr
+                        WHERE mtr.deployed_model_id = dm.id
+                        AND mtr.api_key_purpose = 'realtime'
+                        AND mtr.action = 'deny'
+                    )",
+                );
+            } else {
+                query.push(
+                    " AND EXISTS (
+                        SELECT 1 FROM model_traffic_rules mtr
+                        WHERE mtr.deployed_model_id = dm.id
+                        AND mtr.api_key_purpose = 'realtime'
+                        AND mtr.action = 'deny'
+                    )",
+                );
+            }
         }
     }
 

--- a/dwctl/src/openapi/ai.rs
+++ b/dwctl/src/openapi/ai.rs
@@ -103,7 +103,13 @@ fn embeddings() {}
     summary = "List models",
     description = "Lists the models available to your API key.
 
-The response includes model IDs that can be used in chat completion and embedding requests.",
+The response includes model IDs that can be used in chat completion and embedding requests.
+
+By default, this endpoint follows the OpenAI-compatible models-list shape. Doubleword also supports optional query-string extensions for model discovery: `group` filters to comma-separated group UUIDs, and `available_for_realtime` filters by whether realtime traffic is allowed for the model.",
+    params(
+        ("group" = Option<String>, Query, description = "Doubleword extension. Filter to models in one or more groups (comma-separated UUIDs). This is intersected with the API key's normal model access."),
+        ("available_for_realtime" = Option<bool>, Query, description = "Doubleword extension. true returns models without a realtime deny rule; false returns models with one."),
+    ),
     responses(
         (status = 200, description = "List of models your API key can access.", body = extra_types::ModelsListResponse),
         (status = 401, description = "Invalid or missing API key. Ensure your `Authorization` header is set to `Bearer YOUR_API_KEY`.", body = extra_types::OpenAIErrorResponse),

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -192,6 +192,34 @@ async fn wait_for_model(server: &TestServer, api_key: &str, alias: &str) {
     assert_eq!(status, 200, "Model should be available in onwards config after polling");
 }
 
+async fn create_standard_model_for_test(
+    server: &TestServer,
+    admin_headers: &[(String, String)],
+    endpoint_id: Uuid,
+    alias: &str,
+    traffic_routing_rules: Option<serde_json::Value>,
+) -> crate::api::models::deployments::DeployedModelResponse {
+    let mut body = serde_json::json!({
+        "type": "standard",
+        "model_name": alias,
+        "alias": alias,
+        "hosted_on": endpoint_id
+    });
+
+    if let Some(traffic_routing_rules) = traffic_routing_rules {
+        body["traffic_routing_rules"] = traffic_routing_rules;
+    }
+
+    let response = server
+        .post("/admin/api/v1/models")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&body)
+        .await;
+    assert_eq!(response.status_code(), 200, "Failed to create model: {body}");
+    response.json()
+}
+
 #[sqlx::test]
 async fn ai_models_lists_group_accessible_paid_models_without_credits(pool: PgPool) {
     let mut config = crate::test::utils::create_test_config();
@@ -309,6 +337,167 @@ async fn ai_models_lists_group_accessible_paid_models_without_credits(pool: PgPo
         404,
         "Zero-credit key should remain absent from the dispatch target pool"
     );
+}
+
+#[sqlx::test]
+async fn ai_models_supports_optional_group_and_realtime_filters(pool: PgPool) {
+    let config = crate::test::utils::create_test_config();
+
+    let app = crate::Application::new_with_pool(config, Some(pool.clone()), None)
+        .await
+        .expect("Failed to create application");
+    let (server, _bg_services) = app.into_test_server();
+
+    let admin_user = create_test_admin_user(&pool, Role::PlatformManager).await;
+    let admin_headers = add_auth_headers(&admin_user);
+
+    let regular_user = create_test_user(&pool, Role::StandardUser).await;
+    let regular_headers = add_auth_headers(&regular_user);
+
+    let group_one_response = server
+        .post("/admin/api/v1/groups")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&serde_json::json!({
+            "name": format!("ai-model-filter-one-{}", Uuid::new_v4()),
+            "description": "First AI models filter group"
+        }))
+        .await;
+    assert_eq!(group_one_response.status_code(), 201, "Failed to create first group");
+    let group_one: GroupResponse = group_one_response.json();
+
+    let group_two_response = server
+        .post("/admin/api/v1/groups")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&serde_json::json!({
+            "name": format!("ai-model-filter-two-{}", Uuid::new_v4()),
+            "description": "Second AI models filter group"
+        }))
+        .await;
+    assert_eq!(group_two_response.status_code(), 201, "Failed to create second group");
+    let group_two: GroupResponse = group_two_response.json();
+
+    for group_id in [group_one.id, group_two.id] {
+        let add_user_response = server
+            .post(&format!("/admin/api/v1/groups/{}/users/{}", group_id, regular_user.id))
+            .add_header(&admin_headers[0].0, &admin_headers[0].1)
+            .add_header(&admin_headers[1].0, &admin_headers[1].1)
+            .await;
+        assert_eq!(add_user_response.status_code(), 204, "Failed to add user to group");
+    }
+
+    let endpoint_response = server
+        .post("/admin/api/v1/endpoints")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&serde_json::json!({
+            "name": format!("AI Model Filters Endpoint {}", Uuid::new_v4()),
+            "url": "https://example.invalid/v1/",
+            "description": "Endpoint for AI model filter tests"
+        }))
+        .await;
+    assert_eq!(endpoint_response.status_code(), 201, "Failed to create endpoint");
+    let endpoint: crate::api::models::inference_endpoints::InferenceEndpointResponse = endpoint_response.json();
+
+    let allowed_alias = format!("ai-filter-allowed-{}", Uuid::new_v4());
+    let denied_alias = format!("ai-filter-denied-{}", Uuid::new_v4());
+    let redirected_alias = format!("ai-filter-redirected-{}", Uuid::new_v4());
+    let redirect_target_alias = format!("ai-filter-target-{}", Uuid::new_v4());
+    let other_group_alias = format!("ai-filter-other-{}", Uuid::new_v4());
+
+    create_standard_model_for_test(&server, &admin_headers, endpoint.id, &redirect_target_alias, None).await;
+    let allowed_model = create_standard_model_for_test(&server, &admin_headers, endpoint.id, &allowed_alias, None).await;
+    let denied_model = create_standard_model_for_test(
+        &server,
+        &admin_headers,
+        endpoint.id,
+        &denied_alias,
+        Some(serde_json::json!([{ "api_key_purpose": "realtime", "action": { "type": "deny" } }])),
+    )
+    .await;
+    let redirected_model = create_standard_model_for_test(
+        &server,
+        &admin_headers,
+        endpoint.id,
+        &redirected_alias,
+        Some(serde_json::json!([{
+            "api_key_purpose": "realtime",
+            "action": { "type": "redirect", "target": redirect_target_alias }
+        }])),
+    )
+    .await;
+    let other_group_model = create_standard_model_for_test(&server, &admin_headers, endpoint.id, &other_group_alias, None).await;
+
+    for deployment_id in [allowed_model.id, denied_model.id, redirected_model.id] {
+        let add_model_response = server
+            .post(&format!("/admin/api/v1/groups/{}/models/{}", group_one.id, deployment_id))
+            .add_header(&admin_headers[0].0, &admin_headers[0].1)
+            .add_header(&admin_headers[1].0, &admin_headers[1].1)
+            .await;
+        assert_eq!(add_model_response.status_code(), 204, "Failed to add model to first group");
+    }
+
+    let add_other_model_response = server
+        .post(&format!("/admin/api/v1/groups/{}/models/{}", group_two.id, other_group_model.id))
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .await;
+    assert_eq!(add_other_model_response.status_code(), 204, "Failed to add model to second group");
+
+    let api_key_response = server
+        .post(&format!("/admin/api/v1/users/{}/api-keys", regular_user.id))
+        .add_header(&regular_headers[0].0, &regular_headers[0].1)
+        .add_header(&regular_headers[1].0, &regular_headers[1].1)
+        .json(&serde_json::json!({
+            "name": "AI Models Filter Key",
+            "purpose": "realtime"
+        }))
+        .await;
+    assert_eq!(api_key_response.status_code(), 201, "Failed to create API key");
+    let api_key: crate::api::models::api_keys::ApiKeyResponse = api_key_response.json();
+
+    let extract_ids = |models: serde_json::Value| -> Vec<String> {
+        models["data"]
+            .as_array()
+            .expect("models response data should be an array")
+            .iter()
+            .map(|model| model["id"].as_str().expect("model id should be a string").to_string())
+            .collect()
+    };
+
+    let default_response = server
+        .get("/ai/v1/models")
+        .add_header("authorization", format!("Bearer {}", api_key.key))
+        .await;
+    assert_eq!(default_response.status_code(), 200);
+    let default_ids = extract_ids(default_response.json());
+    assert!(default_ids.contains(&allowed_alias));
+    assert!(default_ids.contains(&denied_alias));
+    assert!(default_ids.contains(&redirected_alias));
+    assert!(default_ids.contains(&other_group_alias));
+
+    let group_response = server
+        .get(&format!("/ai/v1/models?group={}", group_one.id))
+        .add_header("authorization", format!("Bearer {}", api_key.key))
+        .await;
+    assert_eq!(group_response.status_code(), 200);
+    let group_ids = extract_ids(group_response.json());
+    assert!(group_ids.contains(&allowed_alias));
+    assert!(group_ids.contains(&denied_alias));
+    assert!(group_ids.contains(&redirected_alias));
+    assert!(!group_ids.contains(&other_group_alias));
+
+    let realtime_response = server
+        .get(&format!("/ai/v1/models?group={}&available_for_realtime=true", group_one.id))
+        .add_header("authorization", format!("Bearer {}", api_key.key))
+        .await;
+    assert_eq!(realtime_response.status_code(), 200);
+    let realtime_ids = extract_ids(realtime_response.json());
+    assert!(realtime_ids.contains(&allowed_alias));
+    assert!(realtime_ids.contains(&redirected_alias));
+    assert!(!realtime_ids.contains(&denied_alias));
+    assert!(!realtime_ids.contains(&other_group_alias));
 }
 
 async fn assert_usage_recorded(fixture: &StreamingFixture, expected_uri: &str, prompt_tokens: i64, completion_tokens: i64) {


### PR DESCRIPTION
## Summary
- add optional group and realtime availability filters to model discovery
- keep default models-list behavior unchanged when filters are omitted
- document the query parameters in API docs

## Verification
- just lint rust
- just test rust
