### PR TITLE
perf: add covering indexes for TTFT analytics

### DIFF
--- a/dwctl/migrations/118_add_realtime_ttft_analytics_index.sql
+++ b/dwctl/migrations/118_add_realtime_ttft_analytics_index.sql
@@ -1,0 +1,20 @@
+-- no-transaction
+
+-- Support exact time-window TTFT aggregates without scanning all analytics rows.
+-- This index is partial so it only covers successful realtime streaming responses,
+-- and is built concurrently because http_analytics is write-heavy.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_analytics_realtime_ttft_window
+ON http_analytics (
+    ((timestamp AT TIME ZONE 'UTC')
+        + duration_to_first_byte_ms * INTERVAL '1 millisecond') DESC
+)
+INCLUDE (timestamp, duration_to_first_byte_ms)
+WHERE request_origin IN ('api', 'frontend')
+  AND batch_sla = ''
+  AND status_code BETWEEN 200 AND 299
+  AND response_type IN (
+      'chat_completion_stream',
+      'completion_stream',
+      'response_stream'
+  )
+  AND duration_to_first_byte_ms IS NOT NULL;

--- a/dwctl/migrations/119_add_async_ttft_analytics_index.sql
+++ b/dwctl/migrations/119_add_async_ttft_analytics_index.sql
@@ -1,0 +1,22 @@
+-- no-transaction
+
+-- Async TTFT needs the originating queue request so its first-byte event can be
+-- joined to the appropriate batch or batchless acceptance timestamp. Keep the
+-- index partial and build it concurrently because http_analytics is write-heavy.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_analytics_async_ttft_window
+ON http_analytics (
+    ((timestamp AT TIME ZONE 'UTC')
+        + duration_to_first_byte_ms * INTERVAL '1 millisecond') DESC,
+    fusillade_request_id
+)
+INCLUDE (timestamp, duration_to_first_byte_ms)
+WHERE request_origin = 'fusillade'
+  AND batch_sla = '1h'
+  AND status_code BETWEEN 200 AND 299
+  AND response_type IN (
+      'chat_completion_stream',
+      'completion_stream',
+      'response_stream'
+  )
+  AND duration_to_first_byte_ms IS NOT NULL
+  AND fusillade_request_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- add concurrent partial covering indexes for successful streaming TTFT window queries
- order each index by the computed first-byte event time
- cover queued-request correlation fields without widening the indexed population

## Verification

- applied migrations 1 through 119 to a clean PostgreSQL database
- confirmed both indexes are ready and valid
- confirmed realtime and queued-request 30-day scans plan as index-only scans