### PR TITLE
feat: expose reasoning capabilities on admin models

### DIFF
--- a/dwctl/src/api/handlers/deployments.rs
+++ b/dwctl/src/api/handlers/deployments.rs
@@ -186,7 +186,7 @@ fn db_component_to_response(c: DeploymentComponentDBResponse) -> ModelComponentR
         ("endpoint" = Option<i32>, Query, description = "Filter by inference endpoint ID"),
         ("group" = Option<String>, Query, description = "Filter by group IDs (comma-separated UUIDs)"),
         ("accessible" = Option<bool>, Query, description = "Filter to only models the current user can access (defaults to false for admins, true for users)"),
-        ("include" = Option<String>, Query, description = "Include additional data (comma-separated: 'groups', 'metrics', 'status', 'pricing', 'endpoints', 'facets'). Only platform managers can include groups. Status shows probe monitoring information. Pricing shows simple customer rates for regular users, full pricing structure including current active tariffs for users with Pricing::ReadAll permission. Endpoints includes full inference endpoint details. Facets returns distinct providers, capabilities, and model types for filter dropdowns."),
+        ("include" = Option<String>, Query, description = "Include additional data (comma-separated: 'groups', 'metrics', 'status', 'pricing', 'endpoints', 'facets', 'reasoning_capabilities'). Only platform managers can include groups. Status shows probe monitoring information. Pricing shows simple customer rates for regular users, full pricing structure including current active tariffs for users with Pricing::ReadAll permission. Endpoints includes full inference endpoint details. Facets returns distinct providers, capabilities, and model types for filter dropdowns. Reasoning capabilities shows efforts supported by every provider behind each model."),
         ("provider" = Option<String>, Query, description = "Filter by provider name (case-insensitive exact match against metadata.provider)"),
         ("model_type" = Option<String>, Query, description = "Filter by model type (CHAT, EMBEDDINGS, RERANKER)"),
         ("capability" = Option<String>, Query, description = "Filter by capability (returns models that have this capability)"),
@@ -423,6 +423,14 @@ pub async fn list_deployed_models<P: PoolProvider>(
     let include_pricing = includes.contains(&"pricing");
     let include_endpoints = includes.contains(&"endpoints");
     let include_components = includes.contains(&"components");
+    let include_reasoning_capabilities = includes.contains(&"reasoning_capabilities");
+
+    let reasoning_policies = if include_reasoning_capabilities {
+        let aliases = models.iter().map(|model| model.alias.clone()).collect::<Vec<_>>();
+        repo.get_reasoning_policies(&aliases).await?
+    } else {
+        Default::default()
+    };
 
     // Use ModelEnricher to add requested data
     let enricher = DeployedModelEnricher {
@@ -440,6 +448,17 @@ pub async fn list_deployed_models<P: PoolProvider>(
     };
 
     let response = enricher.enrich_many(models).await?;
+    let response = if include_reasoning_capabilities {
+        response
+            .into_iter()
+            .map(|model| {
+                let supported_efforts = reasoning_policies.get(&model.alias).and_then(|policy| policy.supported_efforts());
+                model.with_supported_reasoning_efforts(supported_efforts)
+            })
+            .collect()
+    } else {
+        response
+    };
 
     // Fetch facets if requested (reuse existing repo/connection to avoid
     // acquiring a second read connection which could self-deadlock under pool
@@ -1597,6 +1616,69 @@ mod tests {
                 .data
                 .iter()
                 .any(|it| { it.id == deployment.id && it.groups.as_deref().is_some_and(|gs| gs.iter().any(|g| g.id == group.id)) })
+        );
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_list_deployments_with_reasoning_capabilities_include(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let admin_user = create_test_admin_user(&pool, Role::PlatformManager).await;
+        let test_endpoint_id = get_test_endpoint_id(&pool).await;
+
+        sqlx::query("UPDATE inference_endpoints SET reasoning_translation = $1 WHERE id = $2")
+            .bind(json!({
+                "chat_completions": {
+                    "unsupported_efforts": ["minimal", "xhigh", "max"],
+                    "writes": [{
+                        "target_path": "/reasoning_effort",
+                        "values": {
+                            "none": "none",
+                            "low": "low",
+                            "medium": "medium",
+                            "high": "high"
+                        }
+                    }]
+                }
+            }))
+            .bind(test_endpoint_id)
+            .execute(&pool)
+            .await
+            .expect("Failed to configure reasoning translation");
+
+        let deployment = create_test_deployment(&pool, admin_user.id, "reasoning-model", "reasoning-alias").await;
+
+        let response = app
+            .get("/admin/api/v1/models")
+            .add_header(&add_auth_headers(&admin_user)[0].0, &add_auth_headers(&admin_user)[0].1)
+            .add_header(&add_auth_headers(&admin_user)[1].0, &add_auth_headers(&admin_user)[1].1)
+            .await;
+
+        response.assert_status_ok();
+        let body: serde_json::Value = response.json();
+        let model = body["data"]
+            .as_array()
+            .and_then(|models| models.iter().find(|model| model["id"] == deployment.id.to_string()))
+            .expect("Created model should be listed");
+        assert!(model.get("supported_reasoning_efforts").is_none());
+
+        let response = app
+            .get("/admin/api/v1/models?include=pricing,reasoning_capabilities")
+            .add_header(&add_auth_headers(&admin_user)[0].0, &add_auth_headers(&admin_user)[0].1)
+            .add_header(&add_auth_headers(&admin_user)[1].0, &add_auth_headers(&admin_user)[1].1)
+            .await;
+
+        response.assert_status_ok();
+        let body: serde_json::Value = response.json();
+        let model = body["data"]
+            .as_array()
+            .and_then(|models| models.iter().find(|model| model["id"] == deployment.id.to_string()))
+            .expect("Created model should be listed");
+        assert_eq!(
+            model["supported_reasoning_efforts"],
+            json!({
+                "chat_completions": ["none", "low", "medium", "high"]
+            })
         );
     }
 

--- a/dwctl/src/api/models/deployments/enrichment.rs
+++ b/dwctl/src/api/models/deployments/enrichment.rs
@@ -466,6 +466,7 @@ mod tests {
             trusted: None,
             open_responses_adapter: None,
             reasoning_translation_overrides: None,
+            supported_reasoning_efforts: None,
             traffic_routing_rules: None,
             allowed_batch_completion_windows: None,
             metadata: None,

--- a/dwctl/src/api/models/deployments/mod.rs
+++ b/dwctl/src/api/models/deployments/mod.rs
@@ -9,7 +9,7 @@ use crate::db::models::deployments::{
     BackoffConfig, DeploymentDBResponse, FallbackConfig, JitterStrategy, LoadBalancingStrategy, ModelCatalogMetadata, ModelType,
     ProviderPricing, ProviderPricingUpdate, TrafficRuleDBRow,
 };
-use crate::reasoning::ReasoningTranslationOverrides;
+use crate::reasoning::{ReasoningTranslationOverrides, SupportedReasoningEfforts};
 use crate::types::{DeploymentId, InferenceEndpointId, UserId};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -85,7 +85,7 @@ pub struct ListModelsQuery {
     pub endpoint: Option<InferenceEndpointId>,
     /// Filter by group IDs (comma-separated UUIDs)
     pub group: Option<String>,
-    /// Include related data (comma-separated: "groups", "metrics", "status", "pricing", "endpoints", "facets")
+    /// Include related data (comma-separated: "groups", "metrics", "status", "pricing", "endpoints", "facets", "reasoning_capabilities")
     pub include: Option<String>,
     /// Show deleted models when true, non-deleted when false, all when not specified (admin only for deleted=true)
     pub deleted: Option<bool>,
@@ -574,6 +574,9 @@ pub struct DeployedModelResponse {
     /// Provider reasoning translation overrides. Omitted for composite models.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_translation_overrides: Option<ReasoningTranslationOverrides>,
+    /// Reasoning efforts supported by every provider behind this model (only included if requested)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supported_reasoning_efforts: Option<SupportedReasoningEfforts>,
     /// Traffic routing rules evaluated against API key labels
     #[serde(skip_serializing_if = "Option::is_none")]
     pub traffic_routing_rules: Option<Vec<TrafficRoutingRule>>,
@@ -645,6 +648,7 @@ impl From<DeploymentDBResponse> for DeployedModelResponse {
             } else {
                 Some(db.reasoning_translation_overrides.unwrap_or_default())
             },
+            supported_reasoning_efforts: None,
             traffic_routing_rules: None, // Populated via enrichment (with_traffic_rules)
             allowed_batch_completion_windows: db.allowed_batch_completion_windows,
             metadata: serde_json::from_value::<ModelCatalogMetadata>(db.metadata)
@@ -677,6 +681,12 @@ impl DeployedModelResponse {
     /// Create a response with provider pricing included (admin only)
     pub fn with_provider_pricing(mut self, provider_pricing: Option<ProviderPricing>) -> Self {
         self.provider_pricing = provider_pricing;
+        self
+    }
+
+    /// Create a response with supported reasoning efforts included
+    pub fn with_supported_reasoning_efforts(mut self, supported_reasoning_efforts: Option<SupportedReasoningEfforts>) -> Self {
+        self.supported_reasoning_efforts = supported_reasoning_efforts;
         self
     }
 

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -1634,6 +1634,28 @@ async fn test_openapi_specs_serialize() {
 }
 
 #[test]
+fn ai_models_openapi_documents_reasoning_capabilities_query_parameter() {
+    use utoipa::OpenApi;
+
+    let spec = serde_json::to_value(AiApiDoc::openapi()).expect("AI spec serializes");
+    let parameter = spec["paths"]["/models"]["get"]["parameters"]
+        .as_array()
+        .and_then(|parameters| {
+            parameters
+                .iter()
+                .find(|parameter| parameter["name"] == "include_reasoning_capabilities")
+        })
+        .expect("GET /models should document include_reasoning_capabilities");
+
+    assert_eq!(parameter["in"], "query");
+    assert_eq!(parameter["schema"]["type"], "boolean");
+    assert!(
+        spec["components"]["schemas"]["ModelObject"]["properties"]["supported_reasoning_efforts"].is_object(),
+        "ModelObject should document supported_reasoning_efforts"
+    );
+}
+
+#[test]
 fn admin_models_openapi_documents_reasoning_capabilities_include() {
     use utoipa::OpenApi;
 

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -1633,6 +1633,27 @@ async fn test_openapi_specs_serialize() {
     assert!(ai_spec.contains("/embeddings"));
 }
 
+#[test]
+fn admin_models_openapi_documents_reasoning_capabilities_include() {
+    use utoipa::OpenApi;
+
+    let spec = serde_json::to_value(AdminApiDoc::openapi()).expect("admin spec serializes");
+    let include = spec["paths"]["/models"]["get"]["parameters"]
+        .as_array()
+        .and_then(|parameters| parameters.iter().find(|parameter| parameter["name"] == "include"))
+        .expect("GET /models should document the include query parameter");
+    let description = include["description"].as_str().expect("include should have a description");
+
+    assert!(
+        description.contains("reasoning_capabilities"),
+        "include description should advertise reasoning_capabilities: {description}"
+    );
+    assert!(
+        spec["components"]["schemas"]["DeployedModelResponse"]["properties"]["supported_reasoning_efforts"].is_object(),
+        "DeployedModelResponse should document supported_reasoning_efforts"
+    );
+}
+
 /// Access-control tests for `/admin/openapi.json`, `/admin/docs`,
 /// `/ai/openapi.json`, and `/ai/docs`. These exist because a pentest
 /// found the Admin spec was world-readable, leaking the full internal


### PR DESCRIPTION
## Summary

- add reasoning_capabilities to the admin model list include options
- expose supported_reasoning_efforts using the effective policy shared with model discovery
- omit the field and its bulk policy query unless explicitly requested
- document the include option and response field in the generated Admin OpenAPI schema
- lock in the existing include_reasoning_capabilities parameter and supported_reasoning_efforts field in the generated AI OpenAPI schema

## Validation

- just lint rust
- just test rust
- cargo test reasoning_capabilities -- --nocapture