### PR TITLE
fix: bump fusillade to 21.1.3 / fusillade-arsenal 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,9 +2354,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "21.1.2"
+version = "21.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93bc201160594ada000d31249f5e2fc075b299596a4bc66eb82f18cec1001631"
+checksum = "ceaf70cc0f5469c2411f8ffaff1ae2187444531b4a136c6fea10d3a38bc6f129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-arsenal"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6134665439150be151dce6dc68809a84d40a879b3ce2da919ba42719a35c6b"
+checksum = "6e7f3cb924938dc5df589d360cc3b560930c073f04d644f17bcf4fc63c8040e3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2416,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-core"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bca601bb1d43f7420f94e979f00c40b4b84b28f8a9dacaf6b637106cc5c6dfa"
+checksum = "c20b75532c2af93adc1c369fe475186fdb2a66720f27b1fe4d8de350da1bf291"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/dwctl/Cargo.lock
+++ b/dwctl/Cargo.lock
@@ -2354,9 +2354,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "21.1.0"
+version = "21.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d7bb96b70a14854f3c4546617e79082982076e3bc893eb2ae641b8d95bcdc0"
+checksum = "ceaf70cc0f5469c2411f8ffaff1ae2187444531b4a136c6fea10d3a38bc6f129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-arsenal"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6134665439150be151dce6dc68809a84d40a879b3ce2da919ba42719a35c6b"
+checksum = "6e7f3cb924938dc5df589d360cc3b560930c073f04d644f17bcf4fc63c8040e3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2416,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-core"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bca601bb1d43f7420f94e979f00c40b4b84b28f8a9dacaf6b637106cc5c6dfa"
+checksum = "c20b75532c2af93adc1c369fe475186fdb2a66720f27b1fe4d8de350da1bf291"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4263,9 +4263,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onwards"
-version = "0.34.6"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df68efd08162f124ab0d9891e05e8585d32f844b10a9baf6e121d49477d616b"
+checksum = "3ff1beb0c406ae25d8446cfcbcdc0a4772b77449bcb65a9d64395dabfd7489f9"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,8 +19,8 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = "21.1.2"
-fusillade-arsenal = "1.1.0"
+fusillade = "21.1.3"
+fusillade-arsenal = "1.1.1"
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"


### PR DESCRIPTION
Picks up the restored fusillade_daemon_up liveness gauge (lost in the fusillade workspace split, now labeled by daemon mode and cleared via drop guard on every exit path) plus fusillade-core/arsenal 1.1.1.