### PR TITLE
fix: bump fusillade to 21.2.0 / fusillade-arsenal 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,9 +2354,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "21.1.3"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceaf70cc0f5469c2411f8ffaff1ae2187444531b4a136c6fea10d3a38bc6f129"
+checksum = "26462d1306ea4b2477524213dfedead4f45638b8c94eb700f03e97c65487db29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-arsenal"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7f3cb924938dc5df589d360cc3b560930c073f04d644f17bcf4fc63c8040e3"
+checksum = "36d7768bf2e064266c19eb5973fc57f171bd710310d53c0572ceb70b47420b2f"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/dwctl/Cargo.lock
+++ b/dwctl/Cargo.lock
@@ -2354,9 +2354,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "21.1.3"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceaf70cc0f5469c2411f8ffaff1ae2187444531b4a136c6fea10d3a38bc6f129"
+checksum = "26462d1306ea4b2477524213dfedead4f45638b8c94eb700f03e97c65487db29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-arsenal"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7f3cb924938dc5df589d360cc3b560930c073f04d644f17bcf4fc63c8040e3"
+checksum = "36d7768bf2e064266c19eb5973fc57f171bd710310d53c0572ceb70b47420b2f"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,8 +19,8 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = "21.1.3"
-fusillade-arsenal = "1.1.1"
+fusillade = "21.2.0"
+fusillade-arsenal = "1.2.0"
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"


### PR DESCRIPTION
Brings the Phase 3 schema expand (batch_requests_archive partitioned archive + batches.location/archive_bucket routing columns + partition maintenance function — all dark, nothing reads them until the config-gated sweeper ships) and two index fixes from the prod baseline: drops the superseded idx_requests_active_first_sort (4.1 GB, 0 scans) and re-predicates idx_batches_pending_notification so the freeze/ notification poller stops seq-scanning ~800k batch rows every few seconds.

Deploy note: the index rebuild scans batches inside the boot migration — expect a few seconds of migration time and a brief write-queue on batches while old pods still serve (writes wait, nothing fails).