### PR TITLE
fix: emit credits metric in nanocredits, not rounded cents

### DIFF
--- a/dwctl/src/request_logging/batcher.rs
+++ b/dwctl/src/request_logging/batcher.rs
@@ -1550,14 +1550,21 @@ where
         // Record metrics only for successfully inserted credit transactions
         for row in &inserted_rows {
             if let Some((_, user_id, amount, model, served_by)) = source_id_to_record.get(&row.source_id) {
-                let cents = (amount.to_f64().unwrap_or(0.0) * 100.0).round() as u64;
+                // Nanocredits (1 credit = 1e9). Tariffs price tokens at
+                // DECIMAL(12,8), so a single token can cost 1e-8 credits; nano
+                // is the coarsest power of ten that represents every
+                // token-priced amount exactly. The predecessor counted whole
+                // rounded cents per transaction, which floored the (typical)
+                // sub-cent flex/batch deductions to zero and hid entire
+                // revenue tiers from the metric.
+                let nanocredits = (amount.to_f64().unwrap_or(0.0) * 1_000_000_000.0).round() as u64;
                 counter!(
-                    "dwctl_credits_deducted_total",
+                    "dwctl_credits_deducted_nanocredits_total",
                     "user_id" => user_id.to_string(),
                     "model" => model.clone(),
                     "served_by" => served_by.clone()
                 )
-                .increment(cents);
+                .increment(nanocredits);
             }
         }
 


### PR DESCRIPTION
## What

`dwctl_credits_deducted_total` incremented by `round(amount × 100)` per transaction — whole cents. Flex/batch-tier requests routinely cost fractions of a cent (measured in prod: ~1e-4 credits/request on gpt-oss-20b flex), so every such transaction incremented by **zero**: entire revenue tiers were invisible to the metric while `credits_transactions` held exact decimals.

## Why nanocredits

Tariffs price tokens at `DECIMAL(12,8)` — a single token can cost 1e-8 credits — so nano (1 credit = 1e9) is the coarsest power-of-ten unit that represents every token-priced amount exactly, with 10× headroom. u64 overflow is not a concern (1.8e10 credits cumulative per series).

## Old metric removed, not deprecated

It under-reports by construction (most transactions floor to 0), has one day of history (the `served_by` label shipped this morning), and no consumers exist beyond the margin dashboard, which switches to the new name (checked internal/scouter/korin repos and all Grafana dashboards).

Same labels: `user_id`, `model`, `served_by`.