### PR TITLE
feat: expose upload watchdog configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,12 +2354,13 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "22.1.2"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4739eb7815c57086176c4c6764a5c68732f4327de1f38bde8f6144c0b26278"
+checksum = "7b650ac6823f234ab771fae06742830a7ff4d2f02e473a83474a750c89436595"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "chrono",
  "dashmap",
  "eventsource-stream",
@@ -2367,6 +2368,7 @@ dependencies = [
  "fusillade-core",
  "futures",
  "hostname",
+ "http-body 1.0.1",
  "humantime",
  "metrics",
  "openai-reassembler",
@@ -2388,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-arsenal"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb445349754b9866893e98e16c8a41ef35e5c13ce2be81b4912c0af855ef7ca"
+checksum = "eb2a8f1fe5984d118df81a1cde3521f5ae506531957a2d0af53bf67fbeae2bde"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2416,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-core"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4281cab927baff1e2f41ac6da9d77486e90a85da523e375115e9539f0d330f2"
+checksum = "0636f2967b04f6c761189d3aa5709c8306b280758dbd2751630cf04e7f0a6096"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4263,9 +4265,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onwards"
-version = "0.35.3"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cadbe82d7efb76209562f3ae8fafa804d9852873455cd061cad3a756c2d58ec"
+checksum = "1e532da390fee12ba972cdd7ad125fa53afe058df74d9bf282e60bd3fd9c474e"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/config.yaml
+++ b/config.yaml
@@ -548,6 +548,11 @@ background_services:
     first_chunk_timeout_ms: 86400000 # Max time waiting for response headers (24 hours)
     chunk_timeout_ms: 86400000 # Max idle time between response body chunks (24 hours)
     body_timeout_ms: 86400000 # Max total time for entire response body (24 hours)
+    # Upload watchdog only covers sending the request body. Keep its stall
+    # timeout below first_chunk_timeout_ms so a stalled upload is reported first.
+    upload_stall_timeout_ms: 60000 # Max time without upload progress (1 minute)
+    upload_chunk_bytes: 65536 # Upload progress granularity (64 KiB)
+    upload_stall_poll_ms: 100 # Upload progress check interval (100 ms)
     claim_timeout_ms: 60000 # Max time in "claimed" state before auto-unclaim (1 minute)
     processing_timeout_ms: 600000 # Max time in "processing" state before auto-unclaim (10 minutes)
     pending_request_counts_timeout_ms: 60000 # Statement timeout for pending request count queries (1 minute)

--- a/dwctl/Cargo.lock
+++ b/dwctl/Cargo.lock
@@ -2354,12 +2354,13 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fusillade"
-version = "22.1.2"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4739eb7815c57086176c4c6764a5c68732f4327de1f38bde8f6144c0b26278"
+checksum = "7b650ac6823f234ab771fae06742830a7ff4d2f02e473a83474a750c89436595"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "chrono",
  "dashmap",
  "eventsource-stream",
@@ -2367,6 +2368,7 @@ dependencies = [
  "fusillade-core",
  "futures",
  "hostname",
+ "http-body 1.0.1",
  "humantime",
  "metrics",
  "openai-reassembler",
@@ -2388,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-arsenal"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb445349754b9866893e98e16c8a41ef35e5c13ce2be81b4912c0af855ef7ca"
+checksum = "eb2a8f1fe5984d118df81a1cde3521f5ae506531957a2d0af53bf67fbeae2bde"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2416,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-core"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4281cab927baff1e2f41ac6da9d77486e90a85da523e375115e9539f0d330f2"
+checksum = "0636f2967b04f6c761189d3aa5709c8306b280758dbd2751630cf04e7f0a6096"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4263,9 +4265,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onwards"
-version = "0.35.3"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cadbe82d7efb76209562f3ae8fafa804d9852873455cd061cad3a756c2d58ec"
+checksum = "1e532da390fee12ba972cdd7ad125fa53afe058df74d9bf282e60bd3fd9c474e"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -19,8 +19,8 @@ embedded-db = ["dep:postgresql_embedded"]
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-fusillade = "22.1.2"
-fusillade-arsenal = "2.1.2"
+fusillade = "23.0.1"
+fusillade-arsenal = "2.1.3"
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
@@ -81,7 +81,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 argon2 = "0.5"
 base64 = "0.22"
 bytes = "1.5"
-onwards = { version = "0.35.3", features = ["multi-step"] }
+onwards = { version = "0.35.4", features = ["multi-step"] }
 thiserror = "2.0.14"
 axum-prometheus = "0.10"
 # Metrics facade and exporter (same versions as axum-prometheus uses)

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1528,6 +1528,20 @@ pub struct DaemonConfig {
     /// Default: 86,400,000 (24 hours).
     pub body_timeout_ms: u64,
 
+    /// Maximum time without progress while sending the request body, in milliseconds.
+    /// This only covers upload; keep it below first_chunk_timeout_ms so an upload
+    /// stall is reported before the broader first-response timeout. Default: 60,000.
+    pub upload_stall_timeout_ms: u64,
+
+    /// Request-body bytes per upload progress unit. Smaller values detect progress
+    /// more finely at the cost of more body frames. Must be greater than zero.
+    /// Default: 65,536 (64 KiB).
+    pub upload_chunk_bytes: usize,
+
+    /// How often the upload watchdog checks progress, in milliseconds. Keep this
+    /// well below upload_stall_timeout_ms. Must be greater than zero. Default: 100.
+    pub upload_stall_poll_ms: u64,
+
     /// Interval for logging daemon status (requests in flight) in milliseconds
     /// Set to None to disable periodic status logging (default: Some(2000))
     pub status_log_interval_ms: Option<u64>,
@@ -1851,6 +1865,9 @@ impl Default for DaemonConfig {
             first_chunk_timeout_ms: 86_400_000,
             chunk_timeout_ms: 86_400_000,
             body_timeout_ms: 86_400_000,
+            upload_stall_timeout_ms: 60_000,
+            upload_chunk_bytes: 64 * 1024,
+            upload_stall_poll_ms: 100,
             status_log_interval_ms: Some(2000),
             claim_timeout_ms: 60000,
             processing_timeout_ms: 600000,
@@ -1926,6 +1943,9 @@ impl DaemonConfig {
             first_chunk_timeout_ms,
             chunk_timeout_ms,
             body_timeout_ms,
+            upload_stall_timeout_ms: self.upload_stall_timeout_ms,
+            upload_chunk_bytes: self.upload_chunk_bytes,
+            upload_stall_poll_ms: self.upload_stall_poll_ms,
             status_log_interval_ms: self.status_log_interval_ms,
             claim_timeout_ms: self.claim_timeout_ms,
             processing_timeout_ms: self.processing_timeout_ms,
@@ -4038,6 +4058,47 @@ background_services:
                 fusillade::DaemonMode::from(config.background_services.batch_daemon.mode),
                 fusillade::DaemonMode::BatchOnly
             );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_upload_watchdog_defaults_override_and_mapping() {
+        Jail::expect_with(|jail| {
+            jail.create_file("test.yaml", "secret_key: test-secret-key\n")?;
+            let args = Args {
+                config: "test.yaml".into(),
+                validate: false,
+            };
+
+            let config = Config::load(&args)?;
+            let daemon = &config.background_services.batch_daemon;
+            assert_eq!(daemon.upload_stall_timeout_ms, 60_000);
+            assert_eq!(daemon.upload_chunk_bytes, 64 * 1024);
+            assert_eq!(daemon.upload_stall_poll_ms, 100);
+
+            jail.create_file(
+                "test.yaml",
+                r#"
+secret_key: test-secret-key
+background_services:
+  batch_daemon:
+    upload_stall_timeout_ms: 30000
+    upload_chunk_bytes: 8192
+    upload_stall_poll_ms: 25
+"#,
+            )?;
+            let config = Config::load(&args)?;
+            let daemon = &config.background_services.batch_daemon;
+            assert_eq!(daemon.upload_stall_timeout_ms, 30_000);
+            assert_eq!(daemon.upload_chunk_bytes, 8 * 1024);
+            assert_eq!(daemon.upload_stall_poll_ms, 25);
+
+            let fusillade = daemon.to_fusillade_config();
+            assert_eq!(fusillade.upload_stall_timeout_ms, 30_000);
+            assert_eq!(fusillade.upload_chunk_bytes, 8 * 1024);
+            assert_eq!(fusillade.upload_stall_poll_ms, 25);
 
             Ok(())
         });


### PR DESCRIPTION
## Summary

- update Fusillade, Fusillade Arsenal, and Onwards to compatible releases
- expose upload stall timeout, progress chunk size, and watchdog poll interval in the batch daemon configuration
- document how the upload watchdog relates to the first-response and response-body timeouts
- preserve the existing watchdog defaults

## Validation

- targeted configuration regression test passes
- Rust lint gate passes with warnings denied
- full Rust suite reached 1,813 passing tests with one existing notification-listener timeout; the timed-out test passed immediately when rerun in isolation
