### PR TITLE
fix: preserve release component identity

### DIFF
--- a/.github/scripts/test-local-rust-workspace.sh
+++ b/.github/scripts/test-local-rust-workspace.sh
@@ -94,6 +94,10 @@ for manifest_path, dependencies in local_dependencies.items():
 release_config = json.loads((root / "release-please-config.json").read_text())
 if set(release_config["packages"]) != {".", "onwards"}:
     raise SystemExit("Release Please must manage the application and Onwards independently")
+if release_config.get("separate-pull-requests") is not True:
+    raise SystemExit(
+        "Release Please must use component-specific PRs so single-component releases can be identified"
+    )
 root_release = release_config["packages"]["."]
 if root_release.get("release-type") != "simple":
     raise SystemExit("root application release must use the annotated simple strategy")

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": false,
+  "separate-pull-requests": true,
   "packages": {
     ".": {
       "component": "dwctl",


### PR DESCRIPTION
## Summary

- make Release Please open component-specific PRs for the multi-package manifest
- guard the configuration with the existing local workspace validation
- preserve the existing `v<version>` application tags and `onwards-v<version>` Onwards tags

## Root cause

Combined manifest PRs use a generic release branch. When only one component is present, Release Please treats the PR as standalone but cannot match that generic branch to the configured component, so it skips tag and GitHub release creation while reporting a successful workflow run.

## Impact

Application-only and Onwards-only releases retain component identity through their PR branches, allowing Release Please to publish them normally. Release contents, versioning strategies, and downstream workflow triggers are unchanged.

## Validation

- `bash .github/scripts/test-local-rust-workspace.sh`
- `jq empty release-please-config.json`
- `git diff --check origin/main...HEAD`

