### PR TITLE
feat(docs): link Onwards from mdBook sidebar

### DIFF
--- a/.github/scripts/test-docs-sidebar-link.mjs
+++ b/.github/scripts/test-docs-sidebar-link.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import vm from "node:vm";
+
+const sidebarScriptUrl = new URL("../../docs/sidebar-links.js", import.meta.url);
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.attributes = new Map();
+    this.className = "";
+    this.href = "";
+    this.rel = "";
+    this.target = "";
+    this.textContent = "";
+  }
+
+  append(...children) {
+    this.children.push(...children);
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, value);
+  }
+}
+
+async function loadSidebarScript() {
+  try {
+    return await readFile(sidebarScriptUrl, "utf8");
+  } catch (error) {
+    assert.fail(`Unable to load the sidebar extension: ${error.message}`);
+  }
+}
+
+async function runSidebarScript(chapterList) {
+  const source = await loadSidebarScript();
+  const document = {
+    createElement(tagName) {
+      return new FakeElement(tagName);
+    },
+    querySelector(selector) {
+      assert.equal(selector, "#mdbook-sidebar .chapter");
+      return chapterList;
+    },
+  };
+
+  vm.runInNewContext(source, { document });
+}
+
+test("appends an accessible Onwards link after a divider", async () => {
+  const chapterList = new FakeElement("ol");
+
+  await runSidebarScript(chapterList);
+
+  assert.equal(chapterList.children.length, 2);
+
+  const [divider, item] = chapterList.children;
+  assert.equal(divider.tagName, "LI");
+  assert.equal(divider.className, "spacer");
+  assert.equal(divider.getAttribute("aria-hidden"), "true");
+
+  assert.equal(item.tagName, "LI");
+  assert.equal(item.className, "chapter-item");
+
+  const [wrapper] = item.children;
+  assert.equal(wrapper.tagName, "SPAN");
+  assert.equal(wrapper.className, "chapter-link-wrapper");
+
+  const [link] = wrapper.children;
+  assert.equal(link.tagName, "A");
+  assert.equal(
+    link.href,
+    "https://doublewordai.github.io/control-layer/onwards/",
+  );
+  assert.equal(link.target, "_blank");
+  assert.equal(link.rel, "noopener noreferrer");
+  assert.equal(link.textContent, "Onwards ↗");
+  assert.equal(
+    link.getAttribute("aria-label"),
+    "Onwards documentation (opens in a new tab)",
+  );
+});
+
+test("does nothing when the sidebar chapter list is absent", async () => {
+  await runSidebarScript(null);
+});

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,12 +35,19 @@ jobs:
           curl -sSL "https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar -xz
           echo "$PWD" >> "$GITHUB_PATH"
 
+      - name: Test documentation extensions
+        run: node --test .github/scripts/test-docs-sidebar-link.mjs
+
       - name: Build documentation
         run: |
           mdbook build docs --dest-dir "$RUNNER_TEMP/pages"
           mdbook build onwards/docs --dest-dir "$RUNNER_TEMP/pages/onwards"
           test -f "$RUNNER_TEMP/pages/index.html"
           test -f "$RUNNER_TEMP/pages/onwards/index.html"
+          sidebar_script_count="$(find "$RUNNER_TEMP/pages" -maxdepth 1 -type f -name 'sidebar-links-*.js' | wc -l | tr -d ' ')"
+          test "$sidebar_script_count" -eq 1
+          sidebar_script="$(find "$RUNNER_TEMP/pages" -maxdepth 1 -type f -name 'sidebar-links-*.js' -print -quit)"
+          grep -Fq "src=\"$(basename "$sidebar_script")\"" "$RUNNER_TEMP/pages/index.html"
           grep -q '/edit/main/docs/src/control-layer-overview.md' "$RUNNER_TEMP/pages/control-layer-overview.html"
           grep -q '/edit/main/onwards/docs/src/introduction.md' "$RUNNER_TEMP/pages/onwards/introduction.html"
           ! grep -R -q '/src/src/' "$RUNNER_TEMP/pages"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,3 +8,4 @@ src = "src"
 [output.html]
 git-repository-url = "https://github.com/doublewordai/control-layer"
 edit-url-template = "https://github.com/doublewordai/control-layer/edit/main/docs/{path}"
+additional-js = ["sidebar-links.js"]

--- a/docs/sidebar-links.js
+++ b/docs/sidebar-links.js
@@ -1,0 +1,30 @@
+(() => {
+  const chapterList = document.querySelector("#mdbook-sidebar .chapter");
+  if (!chapterList) {
+    return;
+  }
+
+  const divider = document.createElement("li");
+  divider.className = "spacer";
+  divider.setAttribute("aria-hidden", "true");
+
+  const item = document.createElement("li");
+  item.className = "chapter-item";
+
+  const wrapper = document.createElement("span");
+  wrapper.className = "chapter-link-wrapper";
+
+  const link = document.createElement("a");
+  link.href = "https://doublewordai.github.io/control-layer/onwards/";
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  link.textContent = "Onwards ↗";
+  link.setAttribute(
+    "aria-label",
+    "Onwards documentation (opens in a new tab)",
+  );
+
+  wrapper.appendChild(link);
+  item.appendChild(wrapper);
+  chapterList.append(divider, item);
+})();


### PR DESCRIPTION
## Summary

- add an Onwards documentation shortcut at the bottom of the Control Layer mdBook sidebar
- open the related documentation in a new tab with an explicit accessible label and safe link attributes
- test the sidebar extension directly and verify its fingerprinted asset in the composed documentation build

## Why

The related Onwards documentation is published alongside the primary book, but it is not directly discoverable from the generated sidebar. This adds a small mdBook-supported extension without overriding the built-in theme.

## Validation

- `node --test .github/scripts/test-docs-sidebar-link.mjs`
- `actionlint .github/workflows/docs.yaml`
- `yamllint .github/workflows/docs.yaml`
- both books built with mdBook 0.5.3 and all composed-artifact assertions passed
- headless Chrome verified final sidebar placement and new-tab behavior
