### PR TITLE
ci: cache Rust compilation with sccache

### DIFF
--- a/.github/scripts/test-rust-ci-matrix.sh
+++ b/.github/scripts/test-rust-ci-matrix.sh
@@ -123,6 +123,37 @@ onwards_compliance_job="$(extract_job onwards-openresponses-compliance)"
 onwards_image_job="$(extract_job onwards-pr-image)"
 dwctl_image_job="$(extract_job build)"
 crate_test_job="$(extract_job backend-crate-test)"
+dwctl_shard_job="$(extract_job backend-dwctl-test-shard)"
+
+require_block_line "$dwctl_shard_job" '    env:' \
+  'declare the compiler cache environment for every dwctl shard'
+require_block_line "$dwctl_shard_job" '      CARGO_INCREMENTAL: "0"' \
+  'disable incremental compilation so dwctl artifacts are cacheable'
+require_block_line "$dwctl_shard_job" '      RUSTC_WRAPPER: sccache' \
+  'compile dwctl through sccache'
+require_block_line "$dwctl_shard_job" '      SCCACHE_IGNORE_SERVER_IO_ERROR: "1"' \
+  'fall back to rustc when the remote cache is unavailable'
+require_block_line "$dwctl_shard_job" '      - name: Install sccache' \
+  'install sccache before compiling dwctl'
+require_block_line "$dwctl_shard_job" \
+  '        uses: mozilla-actions/sccache-action@v0.0.10' \
+  'use the current sccache GitHub Action'
+
+dwctl_sccache_step="$(extract_step "$dwctl_shard_job" 'Install sccache')"
+require_block_line "$dwctl_sccache_step" '          version: "v0.16.0"' \
+  'pin the sccache compiler cache version'
+
+dwctl_rust_cache_step="$(
+  extract_step "$dwctl_shard_job" 'Cache Rust dependencies and tools'
+)"
+require_block_line "$dwctl_rust_cache_step" '          cache-targets: "false"' \
+  'avoid restoring target artifacts that cargo-llvm-cov immediately deletes'
+
+if grep -Eq 'SCCACHE_(GHA_ENABLED|WEBDAV_(TOKEN|USERNAME|PASSWORD))' \
+  <<< "$dwctl_shard_job"; then
+  echo "Depot runners must provide sccache authentication without GitHub cache mode or a long-lived token" >&2
+  exit 1
+fi
 
 if grep -Fq -- '- package: dwctl' <<< "$crate_test_job"; then
   echo "dwctl must run in its partition matrix, not the generic crate matrix" >&2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,10 @@ jobs:
       matrix:
         partition: [1, 2, 3, 4]
     runs-on: depot-ubuntu-24.04-16
+    env:
+      CARGO_INCREMENTAL: "0"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
 
     # Each partition has an isolated PostgreSQL instance. SQLx tests create
     # their own databases, pools, and listeners, so retain the raised
@@ -136,11 +140,17 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - name: Cache Rust build
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: "v0.16.0"
+
+      - name: Cache Rust dependencies and tools
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: backend-test-dwctl-sharded
           cache-on-failure: true
+          cache-targets: "false"
 
       - name: Install just
         uses: extractions/setup-just@v3


### PR DESCRIPTION
## Summary

- route the four sharded `dwctl` coverage builds through sccache on Depot runners
- use Depot's runner-provided WebDAV cache credentials, with compiler cache failures treated as non-fatal
- retain `Swatinem/rust-cache` for Cargo dependencies/tools while disabling its target cache to avoid caching build outputs twice
- pin the sccache action and binary versions
- add a workflow contract test that keeps the cache configuration scoped to the intended job and rejects long-lived/manual cache credentials

## Result: not recommended for merge

This reproduces the Depot article's configuration successfully, but it does **not** improve this repository's existing sharded coverage build. Even with a 100% sccache hit rate, fetching hundreds of individual compiler objects is slower here than restoring the existing compressed Rust target cache and compiling the remaining work locally on a 16-core Depot runner.

| Scenario | Median Cargo compile | Median compile + test step | Median shard job | sccache hit rate |
| --- | ---: | ---: | ---: | ---: |
| Existing workflow baseline | 131s | 154.5s | 211.5s | n/a |
| Empty sccache | 211.5s | 239s | 368s | 4.9–25.1% |
| Warm sccache, attempt 1 | 141s | 165s | 219s | 100% |
| Warm sccache, attempt 2 | 141s | 165s | 218s | 100% |

Against the existing workflow, the two warm attempts consistently regressed median Cargo compilation by **7.6%**, the measured compile/test step by **6.8%**, and the complete shard job by about **3.1%**. The empty-cache attempt was substantially slower, as expected.

The first warm attempt had one failure in `test_flush_emits_single_notification_for_multiple_depletions`; the second identical warm attempt passed the complete workflow. The timing regression was the same in both attempts, so it is independent of that test flake.

## Runs

- [Existing workflow baseline](https://github.com/doublewordai/control-layer/actions/runs/30005549298)
- [sccache benchmark: cold plus two warm attempts](https://github.com/doublewordai/control-layer/actions/runs/30011621388)

## Validation

- `bash .github/scripts/test-rust-ci-matrix.sh`
- `ruby scripts/tests/preview_workflow_test.rb` (4 runs, 63 assertions)
- `shellcheck .github/scripts/test-rust-ci-matrix.sh`
- `actionlint -ignore 'label "depot-' -ignore 'shellcheck reported issue' .github/workflows/ci.yaml`
- complete GitHub Actions workflow passed on the final warm attempt

This PR is intentionally left as a draft experiment. Based on the measurements above, I recommend closing it rather than merging the implementation.