### PR TITLE
fix(deps): remediate available high-severity vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5036,9 +5036,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -105,9 +105,10 @@
       "lodash": "^4.18.0",
       "mdast-util-to-hast": "^13.2.1",
       "minimatch@<3.1.3": "^3.1.3",
-      "brace-expansion@>=5.0.0 <5.0.6": "^5.0.6",
+      "brace-expansion@<2.0.0": "1.1.16",
+      "brace-expansion@>=5.0.0 <5.0.7": "5.0.7",
       "esbuild@>=0.17.0 <0.28.1": "^0.28.1",
-      "js-yaml@<=4.1.1": "^4.2.0",
+      "js-yaml@<=4.2.0": "4.3.0",
       "@babel/core@<=7.29.0": "^7.29.6",
       "@ungap/structured-clone@<1.3.1": "^1.3.1"
     },

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -57,7 +57,7 @@
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.16.0",
+    "react-router-dom": "7.18.1",
     "react-syntax-highlighter": "^16.1.0",
     "recharts": "2.15.4",
     "remark-gfm": "^4.0.1",
@@ -109,6 +109,7 @@
       "brace-expansion@>=5.0.0 <5.0.7": "5.0.7",
       "esbuild@>=0.17.0 <0.28.1": "^0.28.1",
       "js-yaml@<=4.2.0": "4.3.0",
+      "postcss@<=8.5.17": "8.5.18",
       "@babel/core@<=7.29.0": "^7.29.6",
       "@ungap/structured-clone@<1.3.1": "^1.3.1"
     },

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -9,9 +9,10 @@ overrides:
   lodash: ^4.18.0
   mdast-util-to-hast: ^13.2.1
   minimatch@<3.1.3: ^3.1.3
-  brace-expansion@>=5.0.0 <5.0.6: ^5.0.6
+  brace-expansion@<2.0.0: 1.1.16
+  brace-expansion@>=5.0.0 <5.0.7: 5.0.7
   esbuild@>=0.17.0 <0.28.1: ^0.28.1
-  js-yaml@<=4.1.1: ^4.2.0
+  js-yaml@<=4.2.0: 4.3.0
   '@babel/core@<=7.29.0': ^7.29.6
   '@ungap/structured-clone@<1.3.1': ^1.3.1
 
@@ -1800,11 +1801,11 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -2597,8 +2598,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@29.0.2:
@@ -4123,7 +4124,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5349,12 +5350,12 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6245,7 +6246,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -6749,11 +6750,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.16
 
   ms@2.1.3: {}
 

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   brace-expansion@>=5.0.0 <5.0.7: 5.0.7
   esbuild@>=0.17.0 <0.28.1: ^0.28.1
   js-yaml@<=4.2.0: 4.3.0
+  postcss@<=8.5.17: 8.5.18
   '@babel/core@<=7.29.0': ^7.29.6
   '@ungap/structured-clone@<1.3.1': ^1.3.1
 
@@ -112,7 +113,7 @@ importers:
         version: 15.5.13
       autoprefixer:
         specifier: ^10.4.21
-        version: 10.4.27(postcss@8.5.14)
+        version: 10.4.27(postcss@8.5.18)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -150,8 +151,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
       react-router-dom:
-        specifier: ^7.16.0
-        version: 7.16.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 7.18.1
+        version: 7.18.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-syntax-highlighter:
         specifier: ^16.1.0
         version: 16.1.1(react@19.2.5)
@@ -1777,7 +1778,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.18
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -2928,8 +2929,8 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3062,8 +3063,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -3148,15 +3149,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.16.0:
-    resolution: {integrity: sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==}
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.16.0:
-    resolution: {integrity: sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -5325,13 +5326,13 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  autoprefixer@10.4.27(postcss@8.5.14):
+  autoprefixer@10.4.27(postcss@8.5.18):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001787
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.14
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -6785,7 +6786,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -6916,9 +6917,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.14:
+  postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7006,13 +7007,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-router-dom@7.16.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router-dom@7.18.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      react-router: 7.16.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router: 7.18.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  react-router@7.16.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router@7.18.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       cookie: 1.1.1
       react: 19.2.5
@@ -7579,7 +7580,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.18
       rollup: '@rollup/wasm-node@4.62.2'
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/dwctl/Cargo.lock
+++ b/dwctl/Cargo.lock
@@ -5028,9 +5028,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary

- resolve `brace-expansion` to 1.1.16 and 5.0.7
- resolve `js-yaml` to 4.3.0
- resolve `quinn-proto` to 0.11.15 in both Cargo lockfiles
- upgrade `react-router` and `react-router-dom` to 7.18.1
- resolve `postcss` to 8.5.18
- covers Dependabot alerts #144–#146, #149, #152, #153, and #156

## Unresolved dependency

Dependabot alert #154 remains open. GitHub reports `react-router 8.3.0` as the first patched version, but npm currently has no `react-router` or `react-router-dom` 8.3.0 release; 7.18.1 is the latest available version. This alert cannot be fully remediated until the patched package is published or GitHub corrects the advisory metadata.

## Validation

- `pnpm why` confirms all listed npm versions
- both Cargo lockfiles contain `quinn-proto 0.11.15`
- `pnpm lint`
- `pnpm test --run` (665 passed)
- `pnpm build`
- `cargo check --workspace --locked`
