### PR TITLE
fix(onwards): canonicalise reasoning field on strict chat completions

### DIFF
--- a/onwards/src/strict/handlers.rs
+++ b/onwards/src/strict/handlers.rs
@@ -1482,6 +1482,13 @@ async fn sanitize_chat_response(mut response: Response, original_model: String) 
     // Rewrite model field to match original request
     chat_response.model = original_model;
 
+    // Collapse the provider-specific reasoning spelling so the field name does
+    // not change under the caller when a model alias fails over between
+    // upstreams.
+    for choice in &mut chat_response.choices {
+        choice.message.canonicalise_reasoning();
+    }
+
     // Re-serialize with only our defined fields
     match serde_json::to_vec(&chat_response) {
         Ok(sanitized_bytes) => {
@@ -1608,6 +1615,12 @@ async fn sanitize_streaming_chat_response(
                             Ok(mut chunk_data) => {
                                 // Rewrite model field
                                 chunk_data.model = original_model.clone();
+
+                                // Same reasoning canonicalisation as the
+                                // non-streaming path, applied per delta.
+                                for choice in &mut chunk_data.choices {
+                                    choice.delta.canonicalise_reasoning();
+                                }
 
                                 // Re-serialize
                                 match serde_json::to_string(&chunk_data) {

--- a/onwards/src/strict/mod.rs
+++ b/onwards/src/strict/mod.rs
@@ -434,6 +434,160 @@ mod tests {
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
+    /// Build strict-mode state whose upstream returns `body` verbatim.
+    fn create_reasoning_test_app_state(body: &str) -> AppState<MockHttpClient> {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        AppState::with_client(targets, MockHttpClient::new(StatusCode::OK, body))
+    }
+
+    /// Guards the handler wiring, not just the schema helper: a refactor that
+    /// stops calling `canonicalise_reasoning` would still pass the unit tests
+    /// in `schemas::chat_completions` but fail here.
+    #[tokio::test]
+    async fn strict_chat_completions_rewrites_openrouter_reasoning_field() {
+        let upstream = r#"{
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "gpt-4",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "42",
+                    "reasoning": "let me think about this"
+                },
+                "finish_reason": "stop"
+            }]
+        }"#;
+
+        let router = build_strict_router(create_reasoning_test_app_state(upstream));
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        let message = &json["choices"][0]["message"];
+
+        assert_eq!(
+            message["reasoning_content"], "let me think about this",
+            "upstream `reasoning` should be rewritten onto `reasoning_content`"
+        );
+        assert!(
+            message.get("reasoning").is_none(),
+            "the OpenRouter spelling should not reach the caller"
+        );
+    }
+
+    /// The vLLM spelling is already canonical, so it must survive untouched.
+    #[tokio::test]
+    async fn strict_chat_completions_leaves_vllm_reasoning_content_alone() {
+        let upstream = r#"{
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "gpt-4",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "42",
+                    "reasoning_content": "vllm style reasoning"
+                },
+                "finish_reason": "stop"
+            }]
+        }"#;
+
+        let router = build_strict_router(create_reasoning_test_app_state(upstream));
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        let message = &json["choices"][0]["message"];
+
+        assert_eq!(message["reasoning_content"], "vllm style reasoning");
+        assert!(message.get("reasoning").is_none());
+    }
+
+    /// Same guarantee on the streaming path, which sanitises chunk-by-chunk in
+    /// a separate code path from the non-streaming handler.
+    #[tokio::test]
+    async fn strict_streaming_chat_completions_rewrites_reasoning_field() {
+        let chunks = concat!(
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1,",
+            "\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\"first \"},",
+            "\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1,",
+            "\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\"second\"},",
+            "\"finish_reason\":null}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let router = build_strict_router(create_reasoning_test_app_state(chunks));
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body_text = std::str::from_utf8(&body_bytes).unwrap();
+
+        assert!(
+            body_text.contains("reasoning_content"),
+            "streamed deltas should carry the canonical spelling; got: {body_text}"
+        );
+        assert!(
+            !body_text.contains("\"reasoning\""),
+            "the OpenRouter spelling should not survive in any chunk; got: {body_text}"
+        );
+    }
+
     #[tokio::test]
     async fn test_adapter_converts_responses_to_chat_completions() {
         let (state, mock_client) = create_adapter_test_app_state();

--- a/onwards/src/strict/schemas/chat_completions.rs
+++ b/onwards/src/strict/schemas/chat_completions.rs
@@ -263,6 +263,37 @@ pub struct ChatMessage {
     pub extra: Option<serde_json::Value>,
 }
 
+/// Collapse OpenRouter's `reasoning` spelling onto the vLLM / DeepSeek
+/// `reasoning_content` field.
+///
+/// A model alias can be served by several upstreams that disagree on the field
+/// name (vLLM emits `reasoning_content`, OpenRouter emits `reasoning`), so
+/// without this a caller sees the field move depending on which upstream
+/// happened to serve the request. `reasoning_content` is canonical because it is
+/// what the great majority of our fleet already emits.
+///
+/// `reasoning_details` is deliberately left alone: it carries structured data
+/// with no equivalent in the flat field, so it is additive rather than a
+/// competing spelling.
+fn collapse_reasoning_fields(
+    reasoning: &mut Option<String>,
+    reasoning_content: &mut Option<String>,
+) {
+    if let Some(text) = reasoning.take()
+        && reasoning_content.is_none()
+    {
+        *reasoning_content = Some(text);
+    }
+}
+
+impl ChatMessage {
+    /// Canonicalise the reasoning spelling on a non-streaming message.
+    /// See [`collapse_reasoning_fields`].
+    pub fn canonicalise_reasoning(&mut self) {
+        collapse_reasoning_fields(&mut self.reasoning, &mut self.reasoning_content);
+    }
+}
+
 /// Message content - either a string or array of content parts
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -451,6 +482,14 @@ pub struct ChunkDelta {
     /// Reasoning details array (OpenRouter format)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_details: Option<Vec<serde_json::Value>>,
+}
+
+impl ChunkDelta {
+    /// Canonicalise the reasoning spelling on a streaming delta.
+    /// See [`collapse_reasoning_fields`].
+    pub fn canonicalise_reasoning(&mut self) {
+        collapse_reasoning_fields(&mut self.reasoning, &mut self.reasoning_content);
+    }
 }
 
 /// Tool call in a streaming chunk
@@ -665,6 +704,134 @@ mod tests {
         let serialized = serde_json::to_string(&chunk).unwrap();
         assert!(serialized.contains("reasoning_content"));
         assert!(!serialized.contains("\"reasoning\""));
+    }
+
+    #[test]
+    fn canonicalise_moves_openrouter_reasoning_onto_reasoning_content() {
+        let mut msg = ChatMessage {
+            role: "assistant".to_string(),
+            content: None,
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning: Some("thinking...".to_string()),
+            reasoning_content: None,
+            reasoning_details: None,
+            extra: None,
+        };
+
+        msg.canonicalise_reasoning();
+
+        assert_eq!(msg.reasoning_content.as_deref(), Some("thinking..."));
+        assert!(
+            msg.reasoning.is_none(),
+            "the OpenRouter spelling should not survive canonicalisation"
+        );
+    }
+
+    #[test]
+    fn canonicalise_leaves_vllm_reasoning_content_untouched() {
+        let mut msg = ChatMessage {
+            role: "assistant".to_string(),
+            content: None,
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning: None,
+            reasoning_content: Some("let me reason...".to_string()),
+            reasoning_details: None,
+            extra: None,
+        };
+
+        msg.canonicalise_reasoning();
+
+        assert_eq!(msg.reasoning_content.as_deref(), Some("let me reason..."));
+        assert!(msg.reasoning.is_none());
+    }
+
+    #[test]
+    fn canonicalise_prefers_reasoning_content_when_both_present() {
+        let mut msg = ChatMessage {
+            role: "assistant".to_string(),
+            content: None,
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning: Some("openrouter copy".to_string()),
+            reasoning_content: Some("vllm copy".to_string()),
+            reasoning_details: None,
+            extra: None,
+        };
+
+        msg.canonicalise_reasoning();
+
+        assert_eq!(msg.reasoning_content.as_deref(), Some("vllm copy"));
+        assert!(msg.reasoning.is_none());
+    }
+
+    #[test]
+    fn canonicalise_preserves_reasoning_details() {
+        let mut msg = ChatMessage {
+            role: "assistant".to_string(),
+            content: None,
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning: Some("thinking...".to_string()),
+            reasoning_content: None,
+            reasoning_details: Some(vec![serde_json::json!({"type": "text", "text": "step 1"})]),
+            extra: None,
+        };
+
+        msg.canonicalise_reasoning();
+
+        assert_eq!(msg.reasoning_content.as_deref(), Some("thinking..."));
+        assert!(
+            msg.reasoning_details.is_some(),
+            "structured details carry data the flat field cannot represent"
+        );
+    }
+
+    #[test]
+    fn canonicalise_on_delta_matches_message_behaviour() {
+        let mut delta = ChunkDelta {
+            role: None,
+            content: None,
+            tool_calls: None,
+            reasoning: Some("streaming fragment".to_string()),
+            reasoning_content: None,
+            reasoning_details: None,
+        };
+
+        delta.canonicalise_reasoning();
+
+        assert_eq!(
+            delta.reasoning_content.as_deref(),
+            Some("streaming fragment")
+        );
+        assert!(delta.reasoning.is_none());
+
+        let serialized = serde_json::to_string(&delta).unwrap();
+        assert!(serialized.contains("reasoning_content"));
+        assert!(!serialized.contains("\"reasoning\""));
+    }
+
+    #[test]
+    fn canonicalise_is_a_noop_without_reasoning() {
+        let mut delta = ChunkDelta {
+            role: None,
+            content: Some("hello".to_string()),
+            tool_calls: None,
+            reasoning: None,
+            reasoning_content: None,
+            reasoning_details: None,
+        };
+
+        delta.canonicalise_reasoning();
+
+        assert!(delta.reasoning.is_none());
+        assert!(delta.reasoning_content.is_none());
+        assert_eq!(delta.content.as_deref(), Some("hello"));
     }
 
     #[test]

--- a/onwards/src/strict/schemas/chat_completions.rs
+++ b/onwards/src/strict/schemas/chat_completions.rs
@@ -279,10 +279,12 @@ fn collapse_reasoning_fields(
     reasoning: &mut Option<String>,
     reasoning_content: &mut Option<String>,
 ) {
-    if let Some(text) = reasoning.take()
-        && reasoning_content.is_none()
-    {
-        *reasoning_content = Some(text);
+    // `reasoning` is always cleared, whether or not its text is needed: it is
+    // the spelling we are collapsing away, so it must never reach the caller.
+    let taken = reasoning.take();
+
+    if reasoning_content.is_none() {
+        *reasoning_content = taken;
     }
 }
 


### PR DESCRIPTION
# fix: canonicalise the reasoning field on strict chat completions responses

Makes `/v1/chat/completions` always return reasoning text under
`reasoning_content`, regardless of which upstream served the request.

## Problem

A model alias can be served by more than one upstream, and they disagree on
the field name for reasoning text:

- vLLM / SGLang / DeepSeek emit `reasoning_content`
- OpenRouter emits `reasoning` (plus a structured `reasoning_details`)

The strict chat completions path deserialises both spellings into typed
fields and re-serialises them verbatim, so the field name a caller sees
changes based on which upstream happened to serve that request. Client code
reading `message.reasoning_content` silently gets nothing whenever a request
fails over to OpenRouter, and vice versa.

The Responses API is not affected: its translator already merges all three
spellings into a single reasoning item via `merge_reasoning_text`. Only chat
completions passes the divergence through.

Note there is no OpenAI field to defer to here. The Chat Completions API does
not expose reasoning text at all, only `reasoning_tokens` inside `usage`, so
both spellings are vendor extensions and we have to pick a house convention.

## Changes

- Add `collapse_reasoning_fields` in `strict/schemas/chat_completions.rs`,
  plus `ChatMessage::canonicalise_reasoning` and
  `ChunkDelta::canonicalise_reasoning` wrapping it. If `reasoning` is set and
  `reasoning_content` is not, the text moves across; `reasoning` is then
  always cleared.
- Call it from both client-facing strict paths in `strict/handlers.rs`,
  alongside the existing model rewrite: per choice in
  `sanitize_chat_response` (non-streaming) and per delta in the SSE chunk
  handler (streaming).

`reasoning_content` is canonical because it is what the majority of the fleet
already emits, so the change is a no-op for most traffic and only rewrites
the OpenRouter path.

We collapse onto one field rather than mirroring into both. Reasoning bodies
can be very large, so duplicating them would roughly double payload size on
every reasoning response and every streamed delta. Mirroring would also let a
client that reads both fields concatenate the same text twice.

`reasoning_details` is deliberately left untouched. It carries structured
data with no equivalent in the flat field, so it is additive rather than a
competing spelling.

## Deliberately not in this PR

Some upstreams do not send `completion_tokens_details.reasoning_tokens` at
all. That is a separate problem with a separate fix: no dwctl or onwards
change can recover a field the upstream never sends, so it needs the
reasoning parser configured on the affected inference endpoints. The wiring
on our side is already correct, as demonstrated by upstreams that do report
counts through the same code.

## Tests

Six new unit tests in `strict/schemas/chat_completions.rs`:

- `canonicalise_moves_openrouter_reasoning_onto_reasoning_content`
- `canonicalise_leaves_vllm_reasoning_content_untouched`
- `canonicalise_prefers_reasoning_content_when_both_present`
- `canonicalise_preserves_reasoning_details`
- `canonicalise_on_delta_matches_message_behaviour`
- `canonicalise_is_a_noop_without_reasoning`

The existing round-trip tests
(`test_streaming_chunk_with_reasoning_content_vllm_roundtrips`,
`test_nonstreaming_response_with_reasoning_roundtrips`) are unchanged and
still pass, since they exercise serde round-tripping rather than the handler
layer.

`cargo test --lib strict::` passes. `cargo fmt --check` is clean and
`cargo clippy --lib` adds no new warnings.

## Rollout notes

This is a client-visible response shape change for OpenRouter-served
requests: callers currently reading `message.reasoning` on those responses
will need to read `message.reasoning_content` instead. Given the field
already moves unpredictably between the two spellings today, any client
relying on `reasoning` is already broken part of the time, but it is worth
an API changelog note.

Only the strict router is touched. The non-strict path routes through
`response_sanitizer.rs`, which is gated on the per-model `sanitize_responses`
flag and is skipped entirely when strict mode is on. Since production runs
strict, this covers the fleet. If a non-strict deployment is ever brought
back, it will need the equivalent change.
