### PR TITLE
test: poll through transient 403 in ZDR sentinel realtime helper

### DIFF
--- a/dwctl/src/test/zdr_sentinel.rs
+++ b/dwctl/src/test/zdr_sentinel.rs
@@ -181,6 +181,12 @@ async fn setup_sentinel_fixture(pool: &PgPool) -> SentinelFixture {
 
 /// Send the sentinel-bearing realtime request, polling until onwards has the
 /// model (sync is asynchronous). Returns once a 200 is observed.
+///
+/// Onwards config sync is applied asynchronously through a watch channel, and
+/// every admin write in the fixture also triggers an automatic LISTEN/NOTIFY
+/// reload. Those reloads race, so before the config settles onwards can hold the
+/// model pool without the key grant yet - which answers 403, not 404. Both
+/// statuses are therefore treated as "not converged yet" and polled through.
 async fn send_sentinel_request(fixture: &SentinelFixture) {
     let body = serde_json::json!({
         "model": MODEL_ALIAS,
@@ -193,16 +199,16 @@ async fn send_sentinel_request(fixture: &SentinelFixture) {
             .add_header("authorization", format!("Bearer {}", fixture.realtime_key))
             .json(&body)
             .await;
-        if resp.status_code().as_u16() != 404 {
-            assert_eq!(
-                resp.status_code().as_u16(),
-                200,
-                "realtime request should succeed; body: {}",
-                resp.text()
-            );
+        let status = resp.status_code().as_u16();
+        if status == 200 {
             return;
         }
-        assert!(attempt < 99, "model never became routable after polling");
+        assert!(
+            matches!(status, 403 | 404),
+            "realtime request should succeed; got {status}, body: {}",
+            resp.text()
+        );
+        assert!(attempt < 99, "model never became routable after polling, last status: {status}");
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     }
 }


### PR DESCRIPTION
## What this fixes

`zdr_sentinel_realtime_request_does_not_persist_to_analytics` fails
intermittently on `main` under full-suite load. It passes in isolation every
time, which is why it looks fine when you run it on its own.

## Root cause

`send_sentinel_request` polled for onwards config convergence like this:

```rust
if resp.status_code().as_u16() != 404 {
    assert_eq!(resp.status_code().as_u16(), 200, ...);
    return;
}
```

It treats any non-404 as "converged". That is not true. Onwards returns **403**,
not 404, when the model pool exists but the API key grant has not yet synced
into that pool (`onwards/src/handlers.rs:489`).

The fixture performs several admin writes (group, membership, transaction,
endpoint, model, group-model grant, api key). Each fires a LISTEN/NOTIFY reload,
and `sync_onwards_config` pushes targets through a watch channel that is applied
asynchronously. A reload computed after the model-to-group grant but before the
key exists leaves onwards holding the pool without the key, so the request is
403. The helper then panics at the `assert_eq`.

Reproduced on `main` at `dwctl/src/test/zdr_sentinel.rs:197:13` in one of four
full `cargo test -p dwctl --lib` runs. Thirty consecutive isolated runs passed,
so the race only opens under suite-level scheduling pressure.

## The change

Poll through both 403 and 404, return on 200, and assert with the observed
status for anything else. A genuine regression still fails, and now reports the
status it actually saw instead of hiding it behind an equality check.

This is the same readiness pattern already used by
`test_e2e_traffic_routing_rules`, which was hardened for this exact race in
5fc036db.

Test-only change, so no release bump.

## Verification

- `cargo test -p dwctl zdr_sentinel` passes (2 passed, 1 ignored)
- Failure reproduced on unmodified `main` before the change

Not yet run across repeated full-suite iterations with the fix applied. The
mechanism is confirmed and the fix is the established pattern in this repo, but
at a roughly 1-in-4 failure rate a few clean suite runs would make it airtight.

## Unrelated, seen while investigating

Three tests failed in the same suite runs with
`sorry, too many clients already` from `sqlx-core/testing/mod.rs:255`. The test
container has `max_connections = 100` and the parallel suite overruns it. Not
addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhAvTNYwRTFrMi8CSayRz4
