### PR TITLE
fix: show background work throughout dashboard

### DIFF
--- a/dashboard/src/api/control-layer/types.ts
+++ b/dashboard/src/api/control-layer/types.ts
@@ -1092,7 +1092,7 @@ export interface Transaction {
   source_id: string;
   description?: string;
   created_at: string; // ISO 8601 timestamp
-  /** Service tier: "realtime", "flex", "async", or "batch" */
+  /** Service tier: "realtime", "flex", "async", "batch", or "background" */
   service_tier?: string;
   /** Number of requests in this batch (only present for batch transactions) */
   batch_request_count?: number;

--- a/dashboard/src/components/features/async-requests/AsyncRequestDetail.tsx
+++ b/dashboard/src/components/features/async-requests/AsyncRequestDetail.tsx
@@ -12,6 +12,7 @@ import { dwImgLinkRenderer } from "../../ui/dw-img-linkify";
 import { copyToClipboard } from "../../../utils";
 import { formatTimestamp } from "../../../utils";
 import { extractErrorMessage } from "./errorMessage";
+import { getServiceTierLabel } from "../../../utils/serviceTier";
 
 
 const getStatusColor = (status: string): string => {
@@ -313,6 +314,12 @@ export function AsyncRequestDetail() {
                   <p className="text-sm text-gray-600 mb-1">Model</p>
                   <p className="font-medium text-sm">{request.model}</p>
                 </div>
+                <div>
+                  <p className="text-sm text-gray-600 mb-1">Service tier</p>
+                  <p className="font-medium text-sm">
+                    {getServiceTierLabel(request.service_tier)}
+                  </p>
+                </div>
                 {request.created_by_email && (
                   <div>
                     <p className="text-sm text-gray-600 mb-1">Created by</p>
@@ -321,14 +328,16 @@ export function AsyncRequestDetail() {
                     </p>
                   </div>
                 )}
-                <div className="border-t border-doubleword-border-light pt-4">
-                  <Link
-                    to={`/batches/${request.batch_id}`}
-                    className="text-sm text-doubleword-neutral-600 hover:text-doubleword-neutral-900 hover:underline"
-                  >
-                    View related batch →
-                  </Link>
-                </div>
+                {request.batch_id && (
+                  <div className="border-t border-doubleword-border-light pt-4">
+                    <Link
+                      to={`/batches/${request.batch_id}`}
+                      className="text-sm text-doubleword-neutral-600 hover:text-doubleword-neutral-900 hover:underline"
+                    >
+                      View related batch →
+                    </Link>
+                  </div>
+                )}
               </div>
             </CardContent>
           </Card>

--- a/dashboard/src/components/features/async-requests/AsyncRequests.test.tsx
+++ b/dashboard/src/components/features/async-requests/AsyncRequests.test.tsx
@@ -107,12 +107,12 @@ describe("AsyncRequests", () => {
     ).toBeInTheDocument();
   });
 
-  it("passes service_tiers=flex,priority to the query", () => {
+  it("includes background requests in the default query", () => {
     render(<AsyncRequests />, { wrapper: createWrapper() });
 
     expect(hooks.useAsyncRequests).toHaveBeenCalledWith(
       expect.objectContaining({
-        service_tiers: "flex,priority",
+        service_tiers: "flex,priority,background",
       }),
     );
   });

--- a/dashboard/src/components/features/async-requests/AsyncRequests.tsx
+++ b/dashboard/src/components/features/async-requests/AsyncRequests.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Code, Play, Filter, Clock, DollarSign, Check, ChevronsUpDown, Zap, FastForward, Trash2, Loader2 } from "lucide-react";
+import { Code, Play, Filter, Clock, DollarSign, Check, ChevronsUpDown, Zap, FastForward, Moon, Trash2, Loader2 } from "lucide-react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { toast } from "sonner";
 import { Button } from "../../ui/button";
@@ -48,9 +48,10 @@ import { useOrganizationContext } from "../../../contexts/organization/useOrgani
 import { useServerPagination } from "../../../hooks/useServerPagination";
 import { usePersistedFilter } from "../../../hooks/usePersistedFilter";
 import { formatTimestamp, formatLongDuration, copyToClipboard } from "../../../utils";
+import { getServiceTierLabel } from "../../../utils/serviceTier";
 
 const PERSIST_SCOPE = "responses";
-const DEFAULT_TIER_FILTER: string[] = ["flex", "priority"];
+const DEFAULT_TIER_FILTER: string[] = ["flex", "priority", "background"];
 const EMPTY_MODEL_FILTER: string[] = [];
 
 const getStatusColor = (status: string): string => {
@@ -180,7 +181,8 @@ function createColumns(
     cell: ({ row }) => {
       const tier = row.getValue("service_tier") as string | null;
       if (!tier) return <span className="text-sm text-doubleword-neutral-600">-</span>;
-      const Icon = tier === "flex" ? FastForward : Zap;
+      const Icon =
+        tier === "flex" ? FastForward : tier === "background" ? Moon : Zap;
       return (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -189,7 +191,7 @@ function createColumns(
             </span>
           </TooltipTrigger>
           <TooltipContent side="top">
-            {tier.charAt(0).toUpperCase() + tier.slice(1)}
+            {getServiceTierLabel(tier)}
           </TooltipContent>
         </Tooltip>
       );
@@ -500,7 +502,7 @@ export function AsyncRequests() {
                   <div className="flex items-center gap-1.5 truncate">
                     <Filter className="w-3.5 h-3.5 shrink-0 text-gray-500" />
                     <span className="truncate">
-                      {tierFilter.length === 2
+                      {tierFilter.length === DEFAULT_TIER_FILTER.length
                         ? "All tiers"
                         : tierFilter.length === 1
                           ? tierFilter[0].charAt(0).toUpperCase() + tierFilter[0].slice(1)
@@ -511,7 +513,7 @@ export function AsyncRequests() {
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="w-[160px] p-2" align="start">
-                {(["flex", "priority"] as const).map((tier) => (
+                {(["flex", "priority", "background"] as const).map((tier) => (
                   <label
                     key={tier}
                     className="flex items-center gap-2 px-2 py-1.5 text-sm cursor-pointer rounded hover:bg-gray-50"
@@ -529,7 +531,7 @@ export function AsyncRequests() {
                       }}
                       className="rounded border-gray-300"
                     />
-                    {tier === "flex" ? "Flex" : "Priority"}
+                    {getServiceTierLabel(tier)}
                   </label>
                 ))}
               </PopoverContent>

--- a/dashboard/src/components/features/batches/BatchInfo/BatchInfo.tsx
+++ b/dashboard/src/components/features/batches/BatchInfo/BatchInfo.tsx
@@ -37,6 +37,7 @@ import {
   downloadFile,
 } from "../../../../utils/batch";
 import BatchResults from "./BatchResults";
+import { getCompletionWindowLabel } from "../../../../utils/serviceTier";
 
 const BatchInfo: React.FC = () => {
   const { batchId } = useParams<{ batchId: string }>();
@@ -605,6 +606,14 @@ const BatchInfo: React.FC = () => {
                         <p className="text-sm text-gray-600 mb-1">Endpoint</p>
                         <p className="font-medium font-mono text-sm">
                           {batch.endpoint}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-sm text-gray-600 mb-1">
+                          Service tier
+                        </p>
+                        <p className="font-medium text-sm">
+                          {getCompletionWindowLabel(batch.completion_window)}
                         </p>
                       </div>
                       {batch.metadata?.created_by_email && (

--- a/dashboard/src/components/features/batches/Batches/Batches.test.tsx
+++ b/dashboard/src/components/features/batches/Batches/Batches.test.tsx
@@ -333,6 +333,7 @@ describe("Batches", () => {
       expect(useBatchesSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           include: "analytics",
+          completion_window: "24h,background",
         }),
       );
     });

--- a/dashboard/src/components/features/batches/Batches/Batches.tsx
+++ b/dashboard/src/components/features/batches/Batches/Batches.tsx
@@ -68,7 +68,11 @@ import { cn } from "@/lib/utils";
 // the UI selector — they're queryable via the API but live on the Responses
 // page in the dashboard.
 const BATCH_COMPLETION_WINDOW = "24h";
-const DEFAULT_COMPLETION_WINDOWS: string[] = [BATCH_COMPLETION_WINDOW];
+const BACKGROUND_COMPLETION_WINDOW = "background";
+const DEFAULT_COMPLETION_WINDOWS: string[] = [
+  BATCH_COMPLETION_WINDOW,
+  BACKGROUND_COMPLETION_WINDOW,
+];
 
 const PERSIST_SCOPE = "batches";
 
@@ -886,6 +890,8 @@ export function Batches({
                                 .map((w) =>
                                   w === asyncCompletionWindow
                                     ? "Async"
+                                    : w === BACKGROUND_COMPLETION_WINDOW
+                                      ? "Background"
                                     : w === BATCH_COMPLETION_WINDOW
                                       ? "Batch"
                                       : w,
@@ -900,6 +906,10 @@ export function Batches({
                     {(
                       [
                         { window: BATCH_COMPLETION_WINDOW, label: "Batch" },
+                        {
+                          window: BACKGROUND_COMPLETION_WINDOW,
+                          label: "Background",
+                        },
                         { window: asyncCompletionWindow, label: "Async" },
                       ] as const
                     ).map(({ window, label }) => (

--- a/dashboard/src/components/features/batches/BatchesTable/columns.tsx
+++ b/dashboard/src/components/features/batches/BatchesTable/columns.tsx
@@ -11,6 +11,7 @@ import {
   Trash2,
   Box,
   FastForward,
+  Moon,
   Zap,
 } from "lucide-react";
 import { Button } from "../../../ui/button";
@@ -22,6 +23,7 @@ import {
   copyToClipboard,
 } from "../../../../utils";
 import type { Batch, BatchStatus } from "../types";
+import { getCompletionWindowLabel } from "../../../../utils/serviceTier";
 
 interface ColumnActions {
   onCancel: (batch: Batch) => void;
@@ -120,16 +122,19 @@ export const createBatchColumns = (
           header: "Type",
           cell: ({ row }: { row: { original: Batch } }) => {
             const batch = row.original;
-            // Three classes today: realtime tracking rows ("0s"), flex/async
-            // ("1h" by default), and regular batches (anything else, typically
-            // "24h"). Anything unrecognised falls into the batch bucket.
             const asyncWindow = actions.asyncCompletionWindow ?? "1h";
-            const { Icon, label } =
-              batch.completion_window === "0s"
-                ? { Icon: Zap, label: "Realtime" }
-                : batch.completion_window === asyncWindow
-                  ? { Icon: FastForward, label: "Async" }
-                  : { Icon: Box, label: "Batch" };
+            const label = getCompletionWindowLabel(
+              batch.completion_window,
+              asyncWindow,
+            );
+            const Icon =
+              label === "Realtime"
+                ? Zap
+                : label === "Async"
+                  ? FastForward
+                  : label === "Background"
+                    ? Moon
+                    : Box;
             return (
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/dashboard/src/components/features/cost-management/CostManagement/TransactionHistory.tsx
+++ b/dashboard/src/components/features/cost-management/CostManagement/TransactionHistory.tsx
@@ -41,6 +41,7 @@ import type { Transaction } from "@/api/control-layer";
 import { useUserBalance, useTransactions, useUser } from "@/api/control-layer";
 import { useSettings } from "@/contexts";
 import { formatDollars } from "@/utils/money.ts";
+import { getServiceTierLabel } from "@/utils/serviceTier";
 import { useDebounce } from "@/hooks/useDebounce";
 
 export type AddFundsConfig =
@@ -180,14 +181,11 @@ export function TransactionHistory({
       return baseDescription;
     }
 
-    // Human label for the service tier (realtime / flex / async / batch)
+    // Human label for the service tier.
     const tierKey = tx.service_tier ?? (tx.batch_id ? "batch" : "realtime");
-    const tierLabel =
-      { realtime: "Realtime", flex: "Flex", async: "Async", batch: "Batch" }[
-        tierKey
-      ] ?? (tx.batch_id ? "Batch" : "Realtime");
-    // Aggregated tiers (async / batch) have a batch_id — show the request count
-    // rather than a single model name.
+    const tierLabel = getServiceTierLabel(tierKey);
+    // Aggregated tiers have a batch_id — show the request count rather than a
+    // single model name.
     if (tx.batch_id) {
       const requestCount = tx.batch_request_count || 0;
       const requestsText = requestCount > 0 ? `: ${requestCount} requests` : "";

--- a/dashboard/src/components/features/requests/RequestsAnalytics/RequestsAnalytics.tsx
+++ b/dashboard/src/components/features/requests/RequestsAnalytics/RequestsAnalytics.tsx
@@ -117,6 +117,9 @@ export function RequestsAnalytics({
     selectedModelPendingCounts?.["24h"] ??
     selectedModelPendingCounts?.["24hr"] ??
     0;
+  const pendingBackground =
+    selectedModelPendingCounts?.background ??
+    0;
 
   // Show loading state
   if (isLoading) {
@@ -267,6 +270,15 @@ export function RequestsAnalytics({
                   <p className="text-sm text-doubleword-neutral-600">24 hr</p>
                   <div className="text-3xl font-bold">
                     {pending24h.toLocaleString()}
+                  </div>
+                </div>
+                <div className="w-px bg-border mx-4"></div>
+                <div className="text-center">
+                  <p className="text-sm text-doubleword-neutral-600">
+                    Background
+                  </p>
+                  <div className="text-3xl font-bold">
+                    {pendingBackground.toLocaleString()}
                   </div>
                 </div>
               </>

--- a/dashboard/src/utils/serviceTier.test.ts
+++ b/dashboard/src/utils/serviceTier.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import {
+  getCompletionWindowLabel,
+  getServiceTierLabel,
+} from "./serviceTier";
+
+describe("service tier labels", () => {
+  it("labels background service tiers", () => {
+    expect(getServiceTierLabel("background")).toBe("Background");
+  });
+
+  it("labels background completion windows", () => {
+    expect(getCompletionWindowLabel("background", "1h")).toBe("Background");
+  });
+});

--- a/dashboard/src/utils/serviceTier.ts
+++ b/dashboard/src/utils/serviceTier.ts
@@ -1,0 +1,25 @@
+export function getServiceTierLabel(tier: string | null | undefined): string {
+  if (!tier) return "Unknown";
+
+  const labels: Record<string, string> = {
+    realtime: "Realtime",
+    priority: "Priority",
+    flex: "Flex",
+    async: "Async",
+    batch: "Batch",
+    background: "Background",
+  };
+
+  return labels[tier] ?? tier.charAt(0).toUpperCase() + tier.slice(1);
+}
+
+export function getCompletionWindowLabel(
+  completionWindow: string,
+  asyncWindow = "1h",
+): string {
+  if (completionWindow === "background") return "Background";
+  if (completionWindow === "0s") return "Realtime";
+  if (completionWindow === asyncWindow) return "Async";
+  if (completionWindow === "24h") return "Batch";
+  return "Batch";
+}


### PR DESCRIPTION
## What changed

- include background requests and batches in the dashboard's default list queries
- add Background options to service-tier and completion-window filters
- label background work consistently in list rows, detail views, pending-queue analytics, and transaction history
- avoid rendering a related-batch link for batchless requests
- add regression coverage for background classification and default query filters

## Why

Background work was valid in the API but omitted by dashboard defaults and fell through existing tier presentation logic. This made submitted work difficult to discover and inconsistently labelled across dashboard views.

Existing authorization and ownership scoping are unchanged.

## Validation

- `pnpm test --run` (667 passed)
- `pnpm lint`
- `pnpm build`