### PR TITLE
fix: show background batches in filtered lists

### DIFF
--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -12,7 +12,7 @@ use crate::api::models::batches::{
     BatchAnalytics, BatchErrors, BatchListResponse, BatchObjectType, BatchResponse, BatchResultsQuery, CreateBatchRequest,
     ListBatchesQuery, ListObjectType, RequestCounts, RetryRequestsRequest,
 };
-use crate::api::models::users::CurrentUser;
+use crate::api::models::users::{CurrentUser, Role};
 use crate::auth::permissions::{
     RequiresPermission, can_read_all_resources, can_run_background_inference, has_permission, operation, resource,
 };
@@ -206,15 +206,47 @@ pub async fn build_cascade_batch_state_job<P: sqlx_pool_router::PoolProvider + C
 
 // ---------------------------------------------------------------------------
 
+fn parse_comma_separated_filter(raw: Option<&str>) -> Option<Vec<String>> {
+    let raw = raw?;
+    let values: Vec<String> = raw.split(',').map(str::trim).filter(|s| !s.is_empty()).map(String::from).collect();
+    if values.is_empty() { None } else { Some(values) }
+}
+
 /// Parse the comma-separated `completion_window` query param into the vec of
 /// values passed to fusillade. Returns `None` (no filter) when the param is
 /// missing or contains only whitespace. Values are forwarded as-is so callers
 /// can match any window string fusillade understands (e.g. `"24h"`, `"1h"`,
 /// `"0s"`, `"7d"`).
 fn parse_completion_window_filter(raw: Option<&str>) -> Option<Vec<String>> {
-    let raw = raw?;
-    let windows: Vec<String> = raw.split(',').map(str::trim).filter(|s| !s.is_empty()).map(String::from).collect();
-    if windows.is_empty() { None } else { Some(windows) }
+    parse_comma_separated_filter(raw)
+}
+
+#[derive(Debug)]
+struct BatchClassFilter {
+    completion_windows: Option<Vec<String>>,
+    service_tiers: Option<Vec<String>>,
+}
+
+fn parse_batch_class_filter(raw: Option<&str>, is_platform_manager: bool) -> Result<BatchClassFilter> {
+    let Some(values) = parse_completion_window_filter(raw) else {
+        return Ok(BatchClassFilter {
+            completion_windows: None,
+            service_tiers: None,
+        });
+    };
+
+    let includes_background = values.iter().any(|value| value == "background");
+    if includes_background && !is_platform_manager {
+        return Err(Error::BadRequest {
+            message: "completion_window=background is only available to platform managers".to_string(),
+        });
+    }
+
+    let completion_windows: Vec<_> = values.into_iter().filter(|value| value != "background").collect();
+    Ok(BatchClassFilter {
+        completion_windows: (!completion_windows.is_empty()).then_some(completion_windows),
+        service_tiers: includes_background.then(|| vec!["background".to_string()]),
+    })
 }
 
 /// Check if the current user "owns" a batch, considering org context.
@@ -1785,7 +1817,8 @@ pub async fn list_batches<P: PoolProvider>(
     // Parse the comma-separated `completion_window` filter into the list
     // passed to fusillade. An empty/whitespace-only param is treated as "no
     // filter" so callers can send `completion_window=` to disable the default.
-    let completion_windows = parse_completion_window_filter(query.completion_window.as_deref());
+    let is_platform_manager = current_user.roles.contains(&Role::PlatformManager);
+    let batch_class_filter = parse_batch_class_filter(query.completion_window.as_deref(), is_platform_manager)?;
 
     // Fetch batches with ownership filtering, search, and cursor-based pagination
     let batches = state
@@ -1800,8 +1833,8 @@ pub async fn list_batches<P: PoolProvider>(
             created_after: query.created_after,
             created_before: query.created_before,
             active_first: query.active_first,
-            completion_windows,
-            service_tiers: None,
+            completion_windows: batch_class_filter.completion_windows,
+            service_tiers: batch_class_filter.service_tiers,
         })
         .await
         .map_err(|e| match &e {
@@ -2015,7 +2048,7 @@ pub async fn list_batches<P: PoolProvider>(
 
 #[cfg(test)]
 mod tests {
-    use super::{load_and_validate_batch_models, parse_completion_window_filter, to_batch_response_with_email};
+    use super::{load_and_validate_batch_models, parse_batch_class_filter, parse_completion_window_filter, to_batch_response_with_email};
     use crate::api::models::batches::CreateBatchRequest;
     use crate::api::models::users::Role;
     use crate::db::handlers::Credits;
@@ -2131,6 +2164,25 @@ mod tests {
             parse_completion_window_filter(Some(" 24h , , 1h ,   ")),
             Some(vec!["24h".to_string(), "1h".to_string()])
         );
+    }
+
+    #[test]
+    fn platform_manager_background_filter_maps_to_internal_service_tier() {
+        let filter = parse_batch_class_filter(Some("24h,background"), true).expect("platform manager filter should be valid");
+
+        assert_eq!(filter.completion_windows, Some(vec!["24h".to_string()]));
+        assert_eq!(filter.service_tiers, Some(vec!["background".to_string()]));
+    }
+
+    #[test]
+    fn non_platform_manager_background_filter_is_bad_request() {
+        let error = parse_batch_class_filter(Some("background"), false).expect_err("background filter should be restricted");
+
+        assert!(matches!(
+            error,
+            Error::BadRequest { message }
+                if message == "completion_window=background is only available to platform managers"
+        ));
     }
 
     #[sqlx::test]

--- a/dwctl/src/api/models/batches.rs
+++ b/dwctl/src/api/models/batches.rs
@@ -346,6 +346,7 @@ pub struct ListBatchesQuery {
     /// - `24h` — long-running batch jobs
     /// - `1h` — async flex requests
     /// - `0s` — realtime tracking rows for the Open Responses API
+    /// - `background` — best-effort background batches (platform managers only)
     ///
     /// When omitted the server returns batches with any completion window; the
     /// dashboard sends `completion_window=24h` by default so realtime tracking

--- a/fusillade-arsenal/src/postgres.rs
+++ b/fusillade-arsenal/src/postgres.rs
@@ -4676,24 +4676,37 @@ impl<P: PoolProvider> Storage for PostgresRequestManager<P> {
             }
         }
 
-        // Restrict to a specific set of completion windows (e.g., ["24h"] for
-        // batch tier, ["1h"] for flex, ["0s"] for realtime tracking rows).
-        // Uses idx_batches_completion_window. An empty vec returns no rows.
-        if let Some(ref windows) = completion_windows {
-            query_builder.push(" AND b.completion_window = ANY(");
-            query_builder.push_bind(windows.as_slice());
-            query_builder.push(")");
+        if let Some(ref tiers) = service_tiers
+            && let Some(unknown) = tiers.iter().find(|tier| tier.as_str() != "background")
+        {
+            return Err(FusilladeError::ValidationError(format!(
+                "Unknown batch service tier filter: '{unknown}'. Valid value: background"
+            )));
         }
 
-        if let Some(ref tiers) = service_tiers {
-            if let Some(unknown) = tiers.iter().find(|tier| tier.as_str() != "background") {
-                return Err(FusilladeError::ValidationError(format!(
-                    "Unknown batch service tier filter: '{unknown}'. Valid value: background"
-                )));
+        // Completion windows and service tiers are two representations of the
+        // same user-facing batch class filter. Combine them as a union when
+        // both are present so callers can request regular and background
+        // batches together.
+        match (&completion_windows, &service_tiers) {
+            (Some(windows), Some(tiers)) => {
+                query_builder.push(" AND (b.completion_window = ANY(");
+                query_builder.push_bind(windows.as_slice());
+                query_builder.push(") OR b.service_tier = ANY(");
+                query_builder.push_bind(tiers.as_slice());
+                query_builder.push("))");
             }
-            query_builder.push(" AND b.service_tier = ANY(");
-            query_builder.push_bind(tiers.as_slice());
-            query_builder.push(")");
+            (Some(windows), None) => {
+                query_builder.push(" AND b.completion_window = ANY(");
+                query_builder.push_bind(windows.as_slice());
+                query_builder.push(")");
+            }
+            (None, Some(tiers)) => {
+                query_builder.push(" AND b.service_tier = ANY(");
+                query_builder.push_bind(tiers.as_slice());
+                query_builder.push(")");
+            }
+            (None, None) => {}
         }
 
         // ORDER BY: when active_first is enabled, sort by the `priority` column
@@ -22486,6 +22499,19 @@ mod tests {
         );
         let created =
             create_background_batch_for_test(&manager, "filter-model", "filter-owner").await;
+        let sla = manager
+            .create_batch(BatchInput {
+                file_id: created.file_id.unwrap(),
+                endpoint: "/v1/chat/completions".to_string(),
+                completion_window: "24h".to_string(),
+                metadata: None,
+                created_by: Some("filter-owner".to_string()),
+                api_key_id: None,
+                api_key: None,
+                total_requests: Some(1),
+            })
+            .await
+            .unwrap();
 
         let background = manager
             .list_batches(ListBatchesFilter {
@@ -22507,7 +22533,20 @@ mod tests {
             })
             .await
             .unwrap();
-        assert!(sla_window.is_empty());
+        assert_eq!(sla_window.len(), 1);
+        assert_eq!(sla_window[0].id, sla.id);
+
+        let mixed = manager
+            .list_batches(ListBatchesFilter {
+                completion_windows: Some(vec!["24h".to_string()]),
+                service_tiers: Some(vec!["background".to_string()]),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(mixed.len(), 2);
+        assert!(mixed.iter().any(|batch| batch.id == created.id));
+        assert!(mixed.iter().any(|batch| batch.id == sla.id));
 
         let error = manager
             .list_batches(ListBatchesFilter {


### PR DESCRIPTION
## Summary

- send the dashboard's Background selection as `completion_window=background`
- translate that virtual completion window to the stored background service tier inside the Rust handler
- restrict the background list filter to platform managers with a `400 Bad Request` for other callers
- combine regular completion windows and background selections as a union internally
- preserve the existing unfiltered “All windows” behaviour

## Why

Background batches have `service_tier = background` and no stored completion window. The dashboard uses `background` as a virtual completion-window value; the Rust API translates it internally without adding a service-tier query parameter to the public API.

## Verification

- `cargo test -p fusillade-arsenal`
- `cargo test -p dwctl api::handlers::batches::tests --lib`
- `just lint rust -- -D warnings`
- `just lint ts`
- `just test ts`
