### PR TITLE
fix: emit required checks for release-only changes

### DIFF
--- a/.github/scripts/test-local-rust-workspace.sh
+++ b/.github/scripts/test-local-rust-workspace.sh
@@ -440,8 +440,14 @@ require_scoped_line "$semantic_title_step" "        if: github.event_name == 'pu
 require_scoped_line "$semantic_title_step" '        uses: amannn/action-semantic-pull-request@v6' 'PR title semantic action must stay in its pull-request step'
 require_scoped_line "$merge_group_title_step" "        if: github.event_name == 'merge_group'" 'PR title no-op must be scoped to merge groups'
 
+crate_test_job="$(extract_workflow_job .github/workflows/ci.yaml backend-crate-test)"
+require_scoped_line "$crate_test_job" '    if: always()' 'Crate test matrix must expand for release-only changes'
+require_scoped_line "$crate_test_job" "      RUN_CI: \${{ needs.changes.outputs.run-ci }}" 'Crate tests must consume the release-only decision at step level'
+crate_skip_step="$(extract_workflow_step "$crate_test_job" 'Skip crate tests for release-only changes')"
+require_scoped_line "$crate_skip_step" "        if: env.RUN_CI != 'true'" 'Crate tests must declare a release-only no-op path'
+
 onwards_compliance_job="$(extract_workflow_job .github/workflows/ci.yaml onwards-openresponses-compliance)"
-require_scoped_line "$onwards_compliance_job" "    if: always() && needs.changes.outputs.run-ci == 'true'" 'Onwards compliance matrix must expand after relevant change detection'
+require_scoped_line "$onwards_compliance_job" '    if: always()' 'Onwards compliance matrix must expand for release-only changes'
 trusted_pull_request_condition="github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'"
 require_scoped_line "$onwards_compliance_job" "      RUN_STRICT_COMPLIANCE: \${{ needs.onwards-compliance-changes.outputs.strict == 'true' && ${trusted_pull_request_condition} }}" 'Onwards strict compliance must gate secret use to trusted pull requests'
 if grep -Fq "github.event_name == 'merge_group'" <<< "$onwards_compliance_job" || \

--- a/.github/scripts/test-rust-ci-matrix.sh
+++ b/.github/scripts/test-rust-ci-matrix.sh
@@ -129,6 +129,11 @@ if grep -Fq -- '- package: dwctl' <<< "$crate_test_job"; then
   exit 1
 fi
 
+require_block_line "$crate_test_job" '    if: always()' 'expand the crate matrix for release-only changes'
+require_block_line "$crate_test_job" "      RUN_CI: \${{ needs.changes.outputs.run-ci }}" 'expose the release-only decision to crate test steps'
+crate_skip_step="$(extract_step "$crate_test_job" 'Skip crate tests for release-only changes')"
+require_block_line "$crate_skip_step" "        if: env.RUN_CI != 'true'" 'declare the no-op crate test path'
+
 if ! grep -Fxq '    needs: changes' <<< "$onwards_image_job" || \
    ! grep -Fxq '    needs: changes' <<< "$dwctl_image_job"; then
   echo "Onwards and dwctl image builds must start together after change classification" >&2
@@ -145,7 +150,7 @@ if grep -Fq 'git checkout fa29df5' <<< "$onwards_compliance_job"; then
   exit 1
 fi
 
-require_block_line "$onwards_compliance_job" "    if: always() && needs.changes.outputs.run-ci == 'true'" 'expand the Onwards compliance matrix after relevant change detection'
+require_block_line "$onwards_compliance_job" '    if: always()' 'expand the Onwards compliance matrix for release-only changes'
 require_block_line "$onwards_compliance_job" "    needs: [changes, onwards-compliance-changes]" 'wait for the change classifiers'
 trusted_pull_request_condition="github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'"
 require_block_line "$onwards_compliance_job" "      RUN_STRICT_COMPLIANCE: \${{ needs.onwards-compliance-changes.outputs.strict == 'true' && ${trusted_pull_request_condition} }}" 'only run strict compliance for trusted pull requests'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -238,7 +238,7 @@ jobs:
           fi
 
   backend-crate-test:
-    if: needs.changes.outputs.run-ci == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+    if: always()
     needs: changes
     name: ${{ matrix.package }} / test
     strategy:
@@ -259,17 +259,24 @@ jobs:
             database: false
             cargo_args: --all-features
     runs-on: ${{ matrix.runner }}
+    env:
+      RUN_CI: ${{ needs.changes.outputs.run-ci }}
 
     # Postgres is started manually below (not via `services:`) so we can pass
     # `-c max_connections=300`. SQLx tests open their own pools and underway
     # PgListener connections, so the default 100 is insufficient.
 
     steps:
+      - name: Skip crate tests for release-only changes
+        if: env.RUN_CI != 'true'
+        run: echo "Skipping crate tests because this pull request only contains release metadata."
+
       - name: Checkout code
+        if: env.RUN_CI == 'true'
         uses: actions/checkout@v6
 
       - name: Start Postgres
-        if: matrix.database
+        if: env.RUN_CI == 'true' && matrix.database
         run: |
           docker run -d --name postgres \
             -e POSTGRES_DB=test \
@@ -285,21 +292,25 @@ jobs:
           done
 
       - name: Install Rust
+        if: env.RUN_CI == 'true'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
 
       - name: Cache Rust build
+        if: env.RUN_CI == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: backend-test-${{ matrix.package }}
 
       - name: Install just
+        if: env.RUN_CI == 'true'
         uses: extractions/setup-just@v3
         with:
           just-version: "1.46.0"
 
       - name: Install sqlx-cli and cargo-llvm-cov
+        if: env.RUN_CI == 'true'
         run: |
           cargo install cargo-llvm-cov --locked
           if [[ "${{ matrix.database }}" == "true" ]]; then
@@ -308,12 +319,13 @@ jobs:
           fi
 
       - name: Set up test databases
-        if: matrix.database
+        if: env.RUN_CI == 'true' && matrix.database
         env:
           DB_PASS: postgres
         run: just db-setup
 
       - name: Compile and test ${{ matrix.package }}
+        if: env.RUN_CI == 'true'
         run: |
           START_TIME=$(date +%s)
           cargo llvm-cov --package "${{ matrix.package }}" \
@@ -327,6 +339,7 @@ jobs:
             "https://charts.somnial.co/doubleword-control-layer/backend-${{ matrix.package }}-ci-duration?value=${CI_DURATION}" || true
 
       - name: Upload ${{ matrix.package }} coverage
+        if: env.RUN_CI == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: rust-coverage-${{ matrix.package }}
@@ -560,7 +573,7 @@ jobs:
           fi
 
   onwards-openresponses-compliance:
-    if: always() && needs.changes.outputs.run-ci == 'true'
+    if: always()
     needs: [changes, onwards-compliance-changes]
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary

- expand required matrix jobs for release-only pull requests
- skip expensive crate and compliance steps after matrix expansion
- add workflow contract coverage for the release-only no-op path

## Validation

- `.github/scripts/test-rust-ci-matrix.sh`
- `.github/scripts/test-local-rust-workspace.sh`
- `ruby scripts/tests/preview_workflow_test.rb`
- `just lint rust`