### PR TITLE
feat: add first-class background billing

### DIFF
--- a/dashboard/src/api/control-layer/types.ts
+++ b/dashboard/src/api/control-layer/types.ts
@@ -190,7 +190,7 @@ export interface ModelTariff {
   valid_from: string; // ISO 8601 timestamp
   valid_until?: string | null; // ISO 8601 timestamp, null means currently active
   api_key_purpose?: TariffApiKeyPurpose | null;
-  completion_window?: string | null; // Completion window like "24h", "1h"
+  completion_window?: string | null; // Completion window like "24h", "1h", "background"
   is_active: boolean;
 }
 
@@ -222,7 +222,7 @@ export interface TariffDefinition {
   input_price_per_token: string; // Decimal string to preserve precision
   output_price_per_token: string; // Decimal string to preserve precision
   api_key_purpose?: TariffApiKeyPurpose | null;
-  completion_window?: string | null; // Completion window like "24h", "1h" (display as priority in UI)
+  completion_window?: string | null; // Completion window like "24h", "1h", "background" (display as priority in UI)
 }
 
 // Model metadata (enriched model information from provider data)
@@ -1313,7 +1313,7 @@ export interface Batch {
   endpoint: string;
   errors?: BatchErrors | null;
   input_file_id: string;
-  completion_window: string; // Completion window like "24h", "1h"
+  completion_window: string; // Completion window like "24h", "1h", "background"
   status: BatchStatus;
   output_file_id?: string | null;
   error_file_id?: string | null;
@@ -1359,7 +1359,7 @@ export interface BatchListResponse {
 export interface BatchCreateRequest {
   input_file_id: string;
   endpoint: string;
-  completion_window: string; // Completion window like "24h", "1h"
+  completion_window: string; // Completion window like "24h", "1h", "background"
   metadata?: Record<string, string>;
   output_expires_after?: {
     anchor: "created_at";

--- a/dashboard/src/components/features/models/manage/ModelTariffTable.test.tsx
+++ b/dashboard/src/components/features/models/manage/ModelTariffTable.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ModelTariffTable } from "./ModelTariffTable";
+
+describe("ModelTariffTable", () => {
+  it("offers an explicit background tariff independently of foreground SLAs", async () => {
+    const user = userEvent.setup();
+    render(
+      <ModelTariffTable
+        tariffs={[]}
+        onChange={vi.fn()}
+        availableSLAs={["1h", "24h"]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add tariff/i }));
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(await screen.findByRole("option", { name: "Batch" }));
+    await user.click(screen.getAllByRole("combobox")[1]);
+
+    const listbox = await screen.findByRole("listbox");
+    expect(
+      within(listbox).getByRole("option", { name: "Background" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/features/models/manage/ModelTariffTable.tsx
+++ b/dashboard/src/components/features/models/manage/ModelTariffTable.tsx
@@ -75,6 +75,9 @@ export const ModelTariffTable: React.FC<ModelTariffTableProps> = ({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [formData, setFormData] = useState<TariffFormData>(EMPTY_FORM);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
+  const availableTariffWindows = Array.from(
+    new Set([...availableSLAs, "background"]),
+  );
 
   // Initialize local state from props (only active tariffs)
   useEffect(() => {
@@ -108,7 +111,7 @@ export const ModelTariffTable: React.FC<ModelTariffTableProps> = ({
   ): string => {
     if (purpose === "none") return "";
     if (purpose === "batch" && priority) {
-      return priority; // Completion window value like "24h", "1h"
+      return priority === "background" ? "Background" : priority;
     }
     return API_KEY_PURPOSE_LABELS[purpose];
   };
@@ -358,9 +361,9 @@ export const ModelTariffTable: React.FC<ModelTariffTableProps> = ({
                     <SelectValue placeholder="Select completion window" />
                   </SelectTrigger>
                   <SelectContent>
-                    {availableSLAs.map((sla) => (
+                    {availableTariffWindows.map((sla) => (
                       <SelectItem key={sla} value={sla}>
-                        {sla}
+                        {sla === "background" ? "Background" : sla}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -605,9 +608,9 @@ export const ModelTariffTable: React.FC<ModelTariffTableProps> = ({
                           <SelectValue placeholder="Select completion window" />
                         </SelectTrigger>
                         <SelectContent>
-                          {availableSLAs.map((sla) => (
+                          {availableTariffWindows.map((sla) => (
                             <SelectItem key={sla} value={sla}>
-                              {sla}
+                              {sla === "background" ? "Background" : sla}
                             </SelectItem>
                           ))}
                         </SelectContent>
@@ -653,7 +656,8 @@ export const ModelTariffTable: React.FC<ModelTariffTableProps> = ({
 
       <p className="text-sm text-gray-500">
         Prices are in dollars per million tokens. Different purposes allow you
-        to charge different rates for Realtime, Batch, and playground usage.
+        to charge different rates for Realtime, Batch, Background, and
+        playground usage.
       </p>
     </div>
   );

--- a/dashboard/src/components/features/models/manage/ModelsContent.tsx
+++ b/dashboard/src/components/features/models/manage/ModelsContent.tsx
@@ -71,6 +71,7 @@ const COMPLETION_WINDOWS: Record<
 > = {
   "1h": { label: "Async", icon: Zap, sort: 0 },
   "24h": { label: "Batch", icon: Clock, sort: 1 },
+  background: { label: "Background", icon: Clock, sort: 2 },
 };
 
 const formatReleaseDate = (dateStr: string): string => {
@@ -714,9 +715,12 @@ export const ModelsContent: React.FC<ModelsContentProps> = ({
 
                                 // Determine which batch windows this model supports:
                                 // per-model override > global config defaults
-                                const availableWindows = [...(batchDenied
+                                const availableWindows = [...new Set(batchDenied
                                   ? []
-                                  : model.allowed_batch_completion_windows ?? globalBatchWindows
+                                  : [
+                                      ...(model.allowed_batch_completion_windows ?? globalBatchWindows),
+                                      "background",
+                                    ]
                                 )].sort((a: string, b: string) =>
                                   (COMPLETION_WINDOWS[a]?.sort ?? 99) - (COMPLETION_WINDOWS[b]?.sort ?? 99)
                                 );
@@ -750,14 +754,21 @@ export const ModelsContent: React.FC<ModelsContentProps> = ({
                                   },
                                   ...availableWindows.map((window: string) => {
                                     const cw = COMPLETION_WINDOWS[window];
-                                    const tariff = batchTariffsByWindow.get(window);
+                                    const tariff =
+                                      batchTariffsByWindow.get(window) ??
+                                      (window === "background"
+                                        ? batchTariffsByWindow.get("24h")
+                                        : undefined);
                                     return {
                                       key: `batch-${window}`,
                                       label: cw?.label ?? window,
                                       icon: cw?.icon ?? Clock,
                                       denied: false,
                                       deniedMessage: "",
-                                      description: `${window} completion window`,
+                                      description:
+                                        window === "background"
+                                          ? "Best-effort background processing"
+                                          : `${window} completion window`,
                                       inputPrice: tariff?.input_price_per_token ?? null,
                                       outputPrice: tariff?.output_price_per_token ?? null,
                                     };

--- a/dashboard/src/utils/formatters.test.ts
+++ b/dashboard/src/utils/formatters.test.ts
@@ -322,6 +322,10 @@ describe("formatters", () => {
       expect(getTariffDisplayName("batch", "24h")).toBe("Batch");
     });
 
+    it("should return Background for the background batch window", () => {
+      expect(getTariffDisplayName("batch", "background")).toBe("Background");
+    });
+
     it("should return Batch for batch with other windows", () => {
       expect(getTariffDisplayName("batch", "12h")).toBe("Batch");
     });
@@ -354,8 +358,9 @@ describe("formatters", () => {
       expect(result[0].api_key_purpose).toBe("realtime");
     });
 
-    it("should sort: Realtime → Async → Batch", () => {
+    it("should sort: Realtime → Async → Batch → Background", () => {
       const tariffs = [
+        { api_key_purpose: "batch", completion_window: "background", is_active: true },
         { api_key_purpose: "batch", completion_window: "24h", is_active: true },
         { api_key_purpose: "batch", completion_window: "1h", is_active: true },
         { api_key_purpose: "realtime", completion_window: null, is_active: true },
@@ -365,9 +370,11 @@ describe("formatters", () => {
         "realtime",
         "batch",
         "batch",
+        "batch",
       ]);
       expect(result[1].completion_window).toBe("1h");
       expect(result[2].completion_window).toBe("24h");
+      expect(result[3].completion_window).toBe("background");
     });
 
     it("should handle empty array", () => {

--- a/dashboard/src/utils/formatters.ts
+++ b/dashboard/src/utils/formatters.ts
@@ -177,17 +177,19 @@ export function getTariffDisplayName(
   if (apiKeyPurpose === "realtime") return "Realtime";
   if (apiKeyPurpose === "batch") {
     if (completionWindow === "1h") return "Async";
+    if (completionWindow === "background") return "Background";
     return "Batch"; // 24h or any other batch window
   }
   return "Realtime"; // fallback for null/undefined purpose
 }
 
-/** Tariff sort order for consistent display: Realtime → Async → Batch */
+/** Tariff sort order for consistent display: Realtime → Async → Batch → Background */
 const TARIFF_SORT_ORDER: Record<string, number> = {
   realtime: 0,
   "batch:1h": 1,
   "batch:24h": 2,
-  batch: 3,
+  "batch:background": 3,
+  batch: 4,
 };
 
 function tariffSortKey(
@@ -195,7 +197,7 @@ function tariffSortKey(
   completionWindow: string | null | undefined,
 ): number {
   if (apiKeyPurpose === "batch" && completionWindow) {
-    return TARIFF_SORT_ORDER[`batch:${completionWindow}`] ?? 3;
+    return TARIFF_SORT_ORDER[`batch:${completionWindow}`] ?? 4;
   }
   return TARIFF_SORT_ORDER[apiKeyPurpose ?? "realtime"] ?? 0;
 }

--- a/dwctl/migrations/125_add_background_billing_tier.sql
+++ b/dwctl/migrations/125_add_background_billing_tier.sql
@@ -1,0 +1,33 @@
+-- Add the distinct background inference tier to the usage ledger and its
+-- per-batch read model. Install the broader checks before removing the old
+-- ones so every committed application write remains constrained throughout
+-- the migration.
+ALTER TABLE credits_transactions
+    ADD CONSTRAINT credits_transactions_service_tier_check_v2
+    CHECK (service_tier IN ('realtime', 'flex', 'async', 'batch', 'background')) NOT VALID;
+
+ALTER TABLE credits_transactions
+    DROP CONSTRAINT credits_transactions_service_tier_check;
+
+ALTER TABLE credits_transactions
+    RENAME CONSTRAINT credits_transactions_service_tier_check_v2
+    TO credits_transactions_service_tier_check;
+
+-- Deliberately leave the replacement NOT VALID: PostgreSQL still enforces it
+-- for every new or updated row, while the previously validated narrower check
+-- proves all existing rows are in this broader set. Avoiding VALIDATE here
+-- prevents a full scan of the large, hot ledger.
+
+ALTER TABLE batch_aggregates
+    ADD CONSTRAINT batch_aggregates_service_tier_check_v2
+    CHECK (service_tier IN ('async', 'batch', 'background')) NOT VALID;
+
+ALTER TABLE batch_aggregates
+    DROP CONSTRAINT batch_aggregates_service_tier_check;
+
+ALTER TABLE batch_aggregates
+    RENAME CONSTRAINT batch_aggregates_service_tier_check_v2
+    TO batch_aggregates_service_tier_check;
+
+ALTER TABLE batch_aggregates
+    VALIDATE CONSTRAINT batch_aggregates_service_tier_check;

--- a/dwctl/src/api/handlers/connections.rs
+++ b/dwctl/src/api/handlers/connections.rs
@@ -14,11 +14,12 @@ use crate::api::models::connections::{
     ExternalFileResponse, ListConnectionsQuery, ListExternalFilesQuery, SyncEntryListResponse, SyncEntryResponse,
     SyncOperationListResponse, SyncOperationResponse, SyncedKeyResponse, TriggerSyncRequest,
 };
-use crate::auth::permissions::{RequiresPermission, operation, resource};
+use crate::auth::permissions::{RequiresPermission, can_run_background_inference, operation, resource};
 use crate::connections::provider::{self, ProviderError};
 use crate::db::handlers::connections::{Connections, SyncEntries, SyncOperations};
 use crate::encryption;
 use crate::errors::{Error, Result};
+use crate::types::{Operation, Permission, Resource};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -343,6 +344,19 @@ pub async fn trigger_sync<P: PoolProvider>(
         });
     }
 
+    let config = state.config.snapshot();
+    let completion_window = req
+        .completion_window
+        .as_deref()
+        .unwrap_or(&config.connections.sync.default_completion_window);
+    if completion_window == "background" && !can_run_background_inference(&current_user) {
+        return Err(Error::InsufficientPermissions {
+            required: Permission::Allow(Resource::Connections, Operation::CreateOwn),
+            action: Operation::CreateOwn,
+            resource: "background inference; assign the BackgroundInferenceUser role to submit this completion_window".to_string(),
+        });
+    }
+
     // Verify connection exists and user owns it
     let mut conn = state.db.write().acquire().await.map_err(|e| Error::Database(e.into()))?;
     let connection = Connections::new(&mut conn)
@@ -362,12 +376,11 @@ pub async fn trigger_sync<P: PoolProvider>(
     }
 
     // Build sync config from request + defaults
-    let config = state.config.snapshot();
     let host = if config.host == "0.0.0.0" { "127.0.0.1" } else { &config.host };
     let ai_base_url = format!("http://{}:{}/ai", host, config.port);
     let sync_config = serde_json::json!({
         "endpoint": req.endpoint.as_deref().unwrap_or(&config.connections.sync.default_endpoint),
-        "completion_window": req.completion_window.as_deref().unwrap_or(&config.connections.sync.default_completion_window),
+        "completion_window": completion_window,
         "ai_base_url": ai_base_url,
     });
 
@@ -698,6 +711,7 @@ pub async fn list_connection_files<P: PoolProvider>(
 mod tests {
     use axum::http::StatusCode;
     use sqlx::PgPool;
+    use uuid::Uuid;
 
     use crate::api::models::users::Role;
     use crate::test::utils::{add_auth_headers, create_test_app, create_test_user_with_roles};
@@ -937,6 +951,81 @@ mod tests {
         let body: serde_json::Value = resp.json();
         assert_eq!(body["status"], "pending");
         assert_eq!(body["strategy"], "snapshot");
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn background_sync_requires_background_inference_role(pool: PgPool) {
+        let (app, _bg) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user_with_roles(&pool, vec![Role::StandardUser, Role::PlatformManager]).await;
+        let auth = add_auth_headers(&user);
+
+        let conn: serde_json::Value = app
+            .post("/admin/api/v1/connections")
+            .json(&create_connection_body("background-role-test"))
+            .add_header(&auth[0].0, &auth[0].1)
+            .add_header(&auth[1].0, &auth[1].1)
+            .await
+            .json();
+        let conn_id = conn["id"].as_str().unwrap();
+
+        let response = app
+            .post(&format!("/admin/api/v1/connections/{conn_id}/sync"))
+            .json(&serde_json::json!({
+                "strategy": "snapshot",
+                "completion_window": "background"
+            }))
+            .add_header(&auth[0].0, &auth[0].1)
+            .add_header(&auth[1].0, &auth[1].1)
+            .await;
+
+        response.assert_status(StatusCode::FORBIDDEN);
+        assert!(
+            response.text().contains("BackgroundInferenceUser"),
+            "error should explain how to enable background syncs"
+        );
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn background_sync_with_role_preserves_background_class(pool: PgPool) {
+        let (app, _bg) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user_with_roles(
+            &pool,
+            vec![Role::StandardUser, Role::PlatformManager, Role::BackgroundInferenceUser],
+        )
+        .await;
+        let auth = add_auth_headers(&user);
+
+        let conn: serde_json::Value = app
+            .post("/admin/api/v1/connections")
+            .json(&create_connection_body("background-sync-test"))
+            .add_header(&auth[0].0, &auth[0].1)
+            .add_header(&auth[1].0, &auth[1].1)
+            .await
+            .json();
+        let conn_id = conn["id"].as_str().unwrap();
+
+        let response = app
+            .post(&format!("/admin/api/v1/connections/{conn_id}/sync"))
+            .json(&serde_json::json!({
+                "strategy": "snapshot",
+                "completion_window": "background"
+            }))
+            .add_header(&auth[0].0, &auth[0].1)
+            .add_header(&auth[1].0, &auth[1].1)
+            .await;
+        response.assert_status(StatusCode::ACCEPTED);
+        let body: serde_json::Value = response.json();
+        let sync_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+
+        let completion_window: Option<String> =
+            sqlx::query_scalar("SELECT sync_config->>'completion_window' FROM sync_operations WHERE id = $1")
+                .bind(sync_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(completion_window.as_deref(), Some("background"));
     }
 
     #[sqlx::test]

--- a/dwctl/src/api/models/connections.rs
+++ b/dwctl/src/api/models/connections.rs
@@ -60,7 +60,8 @@ pub struct TriggerSyncRequest {
     pub file_keys: Option<Vec<String>>,
     /// Override default endpoint for batch creation.
     pub endpoint: Option<String>,
-    /// Override default completion window.
+    /// Override the default completion window. Use `background` for
+    /// best-effort processing (requires the BackgroundInferenceUser role).
     pub completion_window: Option<String>,
     /// When true, skip dedup and re-ingest files even if already synced.
     #[serde(default)]

--- a/dwctl/src/api/models/deployments/enrichment.rs
+++ b/dwctl/src/api/models/deployments/enrichment.rs
@@ -783,6 +783,42 @@ mod tests {
     }
 
     #[test]
+    fn background_tariff_is_not_filtered_by_foreground_completion_windows() {
+        let mut model = create_test_model();
+        model.allowed_batch_completion_windows = Some(vec!["1h".to_string()]);
+        model.tariffs = Some(vec![
+            create_test_tariff(Some(ApiKeyPurpose::Batch), Some("1h")),
+            create_test_tariff(Some(ApiKeyPurpose::Batch), Some("24h")),
+            create_test_tariff(Some(ApiKeyPurpose::Batch), Some("background")),
+        ]);
+
+        let tariffs = model.filter_disabled_batch_tariffs().tariffs.unwrap();
+        assert_eq!(tariffs.len(), 2);
+        assert!(
+            tariffs
+                .iter()
+                .any(|tariff| tariff.completion_window.as_deref() == Some("background"))
+        );
+    }
+
+    #[test]
+    fn background_pricing_fallback_is_not_filtered_by_foreground_completion_windows() {
+        let mut model = create_test_model();
+        model.allowed_batch_completion_windows = Some(vec!["1h".to_string()]);
+        model.tariffs = Some(vec![
+            create_test_tariff(Some(ApiKeyPurpose::Batch), Some("1h")),
+            create_test_tariff(Some(ApiKeyPurpose::Batch), Some("24h")),
+        ]);
+
+        let tariffs = model.filter_disabled_batch_tariffs().tariffs.unwrap();
+        assert_eq!(tariffs.len(), 2);
+        assert!(
+            tariffs.iter().any(|tariff| tariff.completion_window.as_deref() == Some("24h")),
+            "the 24h tariff is the background pricing fallback"
+        );
+    }
+
+    #[test]
     fn test_filter_disabled_batch_tariffs_none_allowed() {
         let mut model = create_test_model();
         model.allowed_batch_completion_windows = None;
@@ -798,7 +834,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_disabled_batch_tariffs_empty_allowed() {
+    fn test_filter_disabled_batch_tariffs_empty_foreground_keeps_background_fallback() {
         let mut model = create_test_model();
         model.allowed_batch_completion_windows = Some(vec![]);
         model.tariffs = Some(vec![
@@ -809,10 +845,11 @@ mod tests {
 
         let result = model.filter_disabled_batch_tariffs();
 
-        // Empty allowed list means no batch windows allowed — all batch tariffs removed, realtime kept
+        // Empty foreground list still keeps the 24h tariff used to price background.
         let tariffs = result.tariffs.unwrap();
-        assert_eq!(tariffs.len(), 1);
-        assert_eq!(tariffs[0].api_key_purpose, Some(ApiKeyPurpose::Realtime));
+        assert_eq!(tariffs.len(), 2);
+        assert_eq!(tariffs[0].completion_window.as_deref(), Some("24h"));
+        assert_eq!(tariffs[1].api_key_purpose, Some(ApiKeyPurpose::Realtime));
     }
 
     #[test]

--- a/dwctl/src/api/models/deployments/mod.rs
+++ b/dwctl/src/api/models/deployments/mod.rs
@@ -731,16 +731,26 @@ impl DeployedModelResponse {
         self
     }
 
-    /// Filter out batch tariffs for completion windows that aren't in allowed_batch_completion_windows.
+    /// Filter out foreground batch tariffs for completion windows that aren't in
+    /// allowed_batch_completion_windows. Background is scheduled independently of
+    /// the foreground SLA configuration and always remains visible.
     /// - `None` → all tariffs pass through (global defaults apply).
-    /// - `Some([])` → no batch windows allowed, all batch tariffs removed.
-    /// - `Some(["24h", ...])` → keep batch tariffs whose window is in the list, plus generic
-    ///   batch tariffs (no window) since they serve as billing fallbacks for allowed windows.
+    /// - `Some([])` → no foreground batch windows are allowed.
+    /// - `Some(["24h", ...])` → keep foreground batch tariffs whose window is in the list.
+    ///
+    /// Background and its 24h pricing fallback remain available independently
+    /// of foreground windows. Generic batch tariffs remain when any foreground
+    /// batch window is enabled.
     pub fn filter_disabled_batch_tariffs(mut self) -> Self {
         if let Some(ref allowed) = self.allowed_batch_completion_windows
             && let Some(ref mut tariffs) = self.tariffs
         {
+            let has_background_tariff = tariffs.iter().any(|tariff| {
+                tariff.api_key_purpose.as_ref() == Some(&ApiKeyPurpose::Batch) && tariff.completion_window.as_deref() == Some("background")
+            });
             tariffs.retain(|t| match (&t.api_key_purpose, &t.completion_window) {
+                (Some(ApiKeyPurpose::Batch), Some(window)) if window == "background" => true,
+                (Some(ApiKeyPurpose::Batch), Some(window)) if window == "24h" => allowed.contains(window) || !has_background_tariff,
                 (Some(ApiKeyPurpose::Batch), Some(window)) => allowed.contains(window),
                 (Some(ApiKeyPurpose::Batch), None) => !allowed.is_empty(), // Generic fallback kept when batch is allowed
                 _ => true,                                                 // Non-batch tariffs always pass through

--- a/dwctl/src/api/models/tariffs.rs
+++ b/dwctl/src/api/models/tariffs.rs
@@ -27,7 +27,7 @@ pub struct TariffResponse {
     /// Optional API key purpose this tariff applies to (realtime, batch, playground)
     /// If null, tariff is not automatically applied
     pub api_key_purpose: Option<ApiKeyPurpose>,
-    /// Optional completion window for batch tariffs (e.g., "24h", "1h")
+    /// Optional completion window for batch tariffs (e.g., "24h", "1h", "background")
     /// Only applicable when api_key_purpose is Batch
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = "24h")]

--- a/dwctl/src/api/models/transactions.rs
+++ b/dwctl/src/api/models/transactions.rs
@@ -68,7 +68,7 @@ pub struct CreditTransactionResponse {
     pub description: Option<String>,
     /// When the transaction was created
     pub created_at: DateTime<Utc>,
-    /// Service tier: "realtime", "flex", "async", or "batch".
+    /// Service tier: "realtime", "flex", "async", "batch", or "background".
     /// Only present for usage transactions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,

--- a/dwctl/src/connections/sync.rs
+++ b/dwctl/src/connections/sync.rs
@@ -906,6 +906,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
         .and_then(|v| v.as_str())
         .unwrap_or("24h")
         .to_string();
+    let is_background = completion_window == "background";
 
     // 3. Load sync entry early — needed for retry detection (batch_id already set)
     //    and for provenance metadata / validation errors later.
@@ -933,7 +934,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
     //     file is re-ingested and retried automatically on the next sync once the
     //     creditor verifies or earlier volume drains. No batch row is created,
     //     and the actionable message rides on the entry's `error` column.
-    if sync_entry.batch_id.is_none() {
+    if sync_entry.batch_id.is_none() && !is_background {
         use crate::db::handlers::users::Users;
 
         let (owner_id, owner_verified) = {
@@ -982,7 +983,9 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
         }
     }
 
-    // 4. Capacity check — reserve capacity before creating the batch.
+    // 4. Validate referenced models, then reserve foreground SLA capacity before
+    //    creating the batch. Background work must still target existing models,
+    //    but deliberately bypasses the foreground reservation.
     //    On retries where a previous attempt already created AND populated a batch,
     //    skip reservation since those requests are already counted in pending.
     //    If the batch exists but isn't populated yet (failure between create and populate),
@@ -1000,7 +1003,6 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
     let reservation_ids = if batch_already_populated {
         Vec::new()
     } else {
-        use crate::api::handlers::sla_capacity::{CapacityError, CapacityReservationInput, reserve_capacity};
         use crate::db::handlers::deployments::Deployments;
 
         let file_stats = state
@@ -1022,17 +1024,12 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
         } else {
             let model_aliases: Vec<String> = file_model_counts.keys().cloned().collect();
 
-            let batch_model_info = {
-                let mut conn = dwctl.acquire().await?;
-                Deployments::new(&mut conn).get_batch_model_info(&model_aliases).await?
-            };
-
             let model_ids_by_alias = {
                 let mut conn = dwctl.acquire().await?;
                 Deployments::new(&mut conn).get_model_ids_by_aliases(&model_aliases).await?
             };
 
-            // Validate all models exist (deleted/missing models would bypass capacity checks)
+            // Validate all models exist before creating any kind of batch.
             let missing: Vec<&str> = model_aliases
                 .iter()
                 .filter(|a| !model_ids_by_alias.contains_key(*a))
@@ -1042,28 +1039,38 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
                 return Err(ActivateError::Fatal(format!("model(s) no longer available: {}", missing.join(", "))).into());
             }
 
-            let config = state.config.snapshot();
-            let cap_input = CapacityReservationInput {
-                completion_window: &completion_window,
-                file_model_counts: &file_model_counts,
-                model_throughputs: &batch_model_info.throughputs,
-                model_ids_by_alias: &model_ids_by_alias,
-                default_throughput: config.batches.default_throughput,
-                relaxation_factor: config.batches.relaxation_factor(&completion_window),
-                reservation_ttl_secs: config.batches.reservation_ttl_secs,
-                include_pending_counts: config.batches.pending_capacity_counts_enabled,
-            };
+            if is_background {
+                Vec::new()
+            } else {
+                use crate::api::handlers::sla_capacity::{CapacityError, CapacityReservationInput, reserve_capacity};
 
-            match reserve_capacity(dwctl, &*state.request_manager, &cap_input).await {
-                Ok(ids) => ids,
-                Err(CapacityError::InsufficientCapacity { completion_window, models }) => {
-                    return Err(ActivateError::Retryable(format!(
-                        "insufficient capacity for {completion_window} window (models: {models})"
-                    ))
-                    .into());
-                }
-                Err(CapacityError::Internal(msg)) => {
-                    return Err(anyhow::anyhow!("capacity reservation: {msg}"));
+                let batch_model_info = {
+                    let mut conn = dwctl.acquire().await?;
+                    Deployments::new(&mut conn).get_batch_model_info(&model_aliases).await?
+                };
+                let config = state.config.snapshot();
+                let cap_input = CapacityReservationInput {
+                    completion_window: &completion_window,
+                    file_model_counts: &file_model_counts,
+                    model_throughputs: &batch_model_info.throughputs,
+                    model_ids_by_alias: &model_ids_by_alias,
+                    default_throughput: config.batches.default_throughput,
+                    relaxation_factor: config.batches.relaxation_factor(&completion_window),
+                    reservation_ttl_secs: config.batches.reservation_ttl_secs,
+                    include_pending_counts: config.batches.pending_capacity_counts_enabled,
+                };
+
+                match reserve_capacity(dwctl, &*state.request_manager, &cap_input).await {
+                    Ok(ids) => ids,
+                    Err(CapacityError::InsufficientCapacity { completion_window, models }) => {
+                        return Err(ActivateError::Retryable(format!(
+                            "insufficient capacity for {completion_window} window (models: {models})"
+                        ))
+                        .into());
+                    }
+                    Err(CapacityError::Internal(msg)) => {
+                        return Err(anyhow::anyhow!("capacity reservation: {msg}"));
+                    }
                 }
             }
         }
@@ -1128,22 +1135,36 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
             "dw_external_key": external_key,
         });
 
-        let batch_input = fusillade::BatchInput {
-            file_id: fusillade::FileId(input.file_id),
-            endpoint,
-            completion_window,
-            metadata: Some(metadata),
-            created_by: Some(batch_owner.to_string()),
-            api_key_id: Some(api_key_id),
-            api_key: Some(batch_api_key),
-            total_requests: Some(input.template_count as i64),
+        let batch = if is_background {
+            state
+                .request_manager
+                .create_background_batch_record(fusillade::BackgroundBatchInput {
+                    file_id: fusillade::FileId(input.file_id),
+                    endpoint,
+                    metadata: Some(metadata),
+                    created_by: Some(batch_owner.to_string()),
+                    api_key_id: Some(api_key_id),
+                    api_key: Some(batch_api_key),
+                    total_requests: Some(input.template_count as i64),
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("create background batch record: {e}"))?
+        } else {
+            state
+                .request_manager
+                .create_batch_record(fusillade::BatchInput {
+                    file_id: fusillade::FileId(input.file_id),
+                    endpoint,
+                    completion_window,
+                    metadata: Some(metadata),
+                    created_by: Some(batch_owner.to_string()),
+                    api_key_id: Some(api_key_id),
+                    api_key: Some(batch_api_key),
+                    total_requests: Some(input.template_count as i64),
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("create batch record: {e}"))?
         };
-
-        let batch = state
-            .request_manager
-            .create_batch_record(batch_input)
-            .await
-            .map_err(|e| anyhow::anyhow!("create batch record: {e}"))?;
 
         let bid = *batch.id;
 
@@ -1764,5 +1785,136 @@ mod tests {
         let error = error.expect("an actionable error message should be stored");
         assert!(error.contains("unverified upload limit"), "message should explain the cap: {error}");
         assert!(error.contains("next sync"), "message should explain the auto-retry: {error}");
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn background_activation_bypasses_sla_admission_and_creates_background_batch(pool: PgPool) {
+        use crate::api::models::users::Role;
+        use crate::test::utils::{create_test_endpoint, create_test_model};
+
+        let mut config = create_test_config();
+        config.batches.default_throughput = 0.001;
+        config.batches.unverified_requests_per_completion_hour = 1;
+        let state = setup_task_state_with_config(pool.clone(), config).await;
+
+        let user = create_test_user(&pool, Role::BackgroundInferenceUser).await;
+        let endpoint_id = create_test_endpoint(&pool, "background-sync-endpoint", user.id).await;
+        let model_alias = "background-sync-model";
+        create_test_model(&pool, "background-sync-model-internal", model_alias, endpoint_id, user.id).await;
+
+        let connection_id = insert_test_connection(&pool, user.id).await;
+        let sync_id = insert_test_sync_op(&pool, connection_id, user.id).await;
+        sqlx::query!(
+            "UPDATE sync_operations SET sync_config = $2 WHERE id = $1",
+            sync_id,
+            serde_json::json!({
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "background"
+            }),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let entry_id = insert_test_sync_entry(&pool, sync_id, connection_id, "data/background.jsonl").await;
+
+        let templates: Vec<_> = (0..200).map(|_| valid_template(model_alias)).collect();
+        let file_id = create_test_file(&state, user.id, templates).await;
+        sqlx::query!(
+            "UPDATE sync_entries SET file_id = $2, template_count = 200 WHERE id = $1",
+            entry_id,
+            file_id,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        run_activate_batch(
+            &state,
+            &ActivateBatchInput {
+                sync_id,
+                sync_entry_id: entry_id,
+                connection_id,
+                file_id,
+                template_count: 200,
+            },
+        )
+        .await
+        .expect("background activation should not be rejected by SLA admission");
+
+        let batch_id: Uuid = sqlx::query_scalar("SELECT batch_id FROM sync_entries WHERE id = $1")
+            .bind(entry_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let (service_tier, completion_window, expires_at): (Option<String>, Option<String>, Option<chrono::DateTime<chrono::Utc>>) =
+            sqlx::query_as("SELECT service_tier, completion_window, expires_at FROM fusillade.batches WHERE id = $1")
+                .bind(batch_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(service_tier.as_deref(), Some("background"));
+        assert_eq!(completion_window, None);
+        assert_eq!(expires_at, None);
+
+        let reservations: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM batch_capacity_reservations WHERE completion_window = 'background'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(reservations, 0);
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn background_activation_rejects_missing_models_before_batch_creation(pool: PgPool) {
+        use crate::api::models::users::Role;
+
+        let state = setup_task_state_with_config(pool.clone(), create_test_config()).await;
+        let user = create_test_user(&pool, Role::BackgroundInferenceUser).await;
+        let connection_id = insert_test_connection(&pool, user.id).await;
+        let sync_id = insert_test_sync_op(&pool, connection_id, user.id).await;
+        sqlx::query!(
+            "UPDATE sync_operations SET sync_config = $2 WHERE id = $1",
+            sync_id,
+            serde_json::json!({
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "background"
+            }),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let entry_id = insert_test_sync_entry(&pool, sync_id, connection_id, "data/missing-model.jsonl").await;
+        let file_id = create_test_file(&state, user.id, vec![valid_template("deleted-model")]).await;
+        sqlx::query!(
+            "UPDATE sync_entries SET file_id = $2, template_count = 1 WHERE id = $1",
+            entry_id,
+            file_id,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let error = run_activate_batch(
+            &state,
+            &ActivateBatchInput {
+                sync_id,
+                sync_entry_id: entry_id,
+                connection_id,
+                file_id,
+                template_count: 1,
+            },
+        )
+        .await
+        .expect_err("background activation must reject missing models");
+        assert!(error.to_string().contains("model(s) no longer available"));
+
+        let batch_id: Option<Uuid> = sqlx::query_scalar("SELECT batch_id FROM sync_entries WHERE id = $1")
+            .bind(entry_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(batch_id, None);
     }
 }

--- a/dwctl/src/db/handlers/tariffs.rs
+++ b/dwctl/src/db/handlers/tariffs.rs
@@ -120,8 +120,9 @@ impl<'c> Tariffs<'c> {
 
     /// Get pricing with fallback support
     ///
-    /// Tries to get pricing for the preferred API key purpose, falling back to the
-    /// fallback purpose if the preferred one is not found.
+    /// Tries to get pricing for the preferred API key purpose. Background work
+    /// falls back only to the 24h batch tariff; other purposes use the supplied
+    /// fallback purpose when their preferred tariff is absent.
     ///
     /// # Arguments
     /// * `deployed_model_id` - The model to get pricing for
@@ -148,6 +149,19 @@ impl<'c> Tariffs<'c> {
                 .await?
         {
             return Ok(Some(pricing));
+        }
+
+        // Background is a distinct accounting tier, but inherits 24h batch
+        // pricing until an explicit background tariff is configured.
+        if preferred_purpose == Some(&crate::db::models::api_keys::ApiKeyPurpose::Batch) && completion_window == Some("background") {
+            return self
+                .get_pricing_at_timestamp(
+                    deployed_model_id,
+                    &crate::db::models::api_keys::ApiKeyPurpose::Batch,
+                    timestamp,
+                    Some("24h"),
+                )
+                .await;
         }
 
         // Fall back to fallback purpose (completion_window not relevant for fallback)
@@ -346,6 +360,149 @@ mod tests {
             .find(|t| t.completion_window == Some("1h".to_string()))
             .unwrap();
         assert_eq!(tariff_1h_found.name, "Batch 1h");
+    }
+
+    #[sqlx::test]
+    async fn background_pricing_prefers_explicit_tariff_then_falls_back_to_24h(pool: PgPool) {
+        let base_url = url::Url::parse("http://localhost:8080").unwrap();
+        let sources = vec![crate::config::ModelSource {
+            name: "test".to_string(),
+            url: base_url.clone(),
+            api_key: None,
+            sync_interval: std::time::Duration::from_secs(3600),
+            default_models: None,
+        }];
+        crate::seed_database(&sources, &pool).await.unwrap();
+
+        let user = crate::test::utils::create_test_user(&pool, crate::api::models::users::Role::PlatformManager).await;
+        let endpoint_id = crate::test::utils::get_test_endpoint_id(&pool).await;
+        let model_id = DeploymentId::new_v4();
+        sqlx::query!(
+            "INSERT INTO deployed_models (id, model_name, alias, hosted_on, created_by) \
+             VALUES ($1, 'background-tariff-model', 'background-tariff-model', $2, $3)",
+            model_id,
+            endpoint_id,
+            user.id
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut conn = pool.acquire().await.unwrap();
+        let mut tariffs = Tariffs::new(&mut conn);
+        tariffs
+            .create(&TariffCreateDBRequest {
+                deployed_model_id: model_id,
+                name: "24h".to_string(),
+                input_price_per_token: Decimal::from_str("0.00005").unwrap(),
+                output_price_per_token: Decimal::from_str("0.00010").unwrap(),
+                api_key_purpose: Some(ApiKeyPurpose::Batch),
+                completion_window: Some("24h".to_string()),
+                valid_from: None,
+            })
+            .await
+            .unwrap();
+
+        let fallback = tariffs
+            .get_pricing_at_timestamp_with_fallback(
+                model_id,
+                Some(&ApiKeyPurpose::Batch),
+                &ApiKeyPurpose::Realtime,
+                Utc::now(),
+                Some("background"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            fallback,
+            Some((Decimal::from_str("0.00005").unwrap(), Decimal::from_str("0.00010").unwrap()))
+        );
+
+        tariffs
+            .create(&TariffCreateDBRequest {
+                deployed_model_id: model_id,
+                name: "Background".to_string(),
+                input_price_per_token: Decimal::from_str("0.00002").unwrap(),
+                output_price_per_token: Decimal::from_str("0.00004").unwrap(),
+                api_key_purpose: Some(ApiKeyPurpose::Batch),
+                completion_window: Some("background".to_string()),
+                valid_from: None,
+            })
+            .await
+            .unwrap();
+
+        let explicit = tariffs
+            .get_pricing_at_timestamp_with_fallback(
+                model_id,
+                Some(&ApiKeyPurpose::Batch),
+                &ApiKeyPurpose::Realtime,
+                Utc::now(),
+                Some("background"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            explicit,
+            Some((Decimal::from_str("0.00002").unwrap(), Decimal::from_str("0.00004").unwrap()))
+        );
+    }
+
+    #[sqlx::test]
+    async fn background_pricing_does_not_fall_back_to_realtime(pool: PgPool) {
+        let base_url = url::Url::parse("http://localhost:8080").unwrap();
+        crate::seed_database(
+            &[crate::config::ModelSource {
+                name: "test".to_string(),
+                url: base_url,
+                api_key: None,
+                sync_interval: std::time::Duration::from_secs(3600),
+                default_models: None,
+            }],
+            &pool,
+        )
+        .await
+        .unwrap();
+
+        let user = crate::test::utils::create_test_user(&pool, crate::api::models::users::Role::PlatformManager).await;
+        let endpoint_id = crate::test::utils::get_test_endpoint_id(&pool).await;
+        let model_id = DeploymentId::new_v4();
+        sqlx::query!(
+            "INSERT INTO deployed_models (id, model_name, alias, hosted_on, created_by) \
+             VALUES ($1, 'background-no-price-model', 'background-no-price-model', $2, $3)",
+            model_id,
+            endpoint_id,
+            user.id
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut conn = pool.acquire().await.unwrap();
+        let mut tariffs = Tariffs::new(&mut conn);
+        tariffs
+            .create(&TariffCreateDBRequest {
+                deployed_model_id: model_id,
+                name: "Realtime".to_string(),
+                input_price_per_token: Decimal::from_str("0.001").unwrap(),
+                output_price_per_token: Decimal::from_str("0.002").unwrap(),
+                api_key_purpose: Some(ApiKeyPurpose::Realtime),
+                completion_window: None,
+                valid_from: None,
+            })
+            .await
+            .unwrap();
+
+        let pricing = tariffs
+            .get_pricing_at_timestamp_with_fallback(
+                model_id,
+                Some(&ApiKeyPurpose::Batch),
+                &ApiKeyPurpose::Realtime,
+                Utc::now(),
+                Some("background"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(pricing, None);
     }
 
     #[sqlx::test]

--- a/dwctl/src/db/models/credits.rs
+++ b/dwctl/src/db/models/credits.rs
@@ -59,7 +59,7 @@ pub struct CreditTransactionDBResponse {
     pub created_at: DateTime<Utc>,
     /// The API key used for this transaction
     pub api_key_id: Option<Uuid>,
-    /// Denormalized billing tier (realtime / flex / async / batch), read from
+    /// Denormalized billing tier (realtime / flex / async / batch / background), read from
     /// `credits_transactions.service_tier` (migration 112). `None` for the paths that
     /// don't select it (e.g. single-transaction lookups) or for rows written before it
     /// was backfilled.

--- a/dwctl/src/db/models/tariffs.rs
+++ b/dwctl/src/db/models/tariffs.rs
@@ -21,7 +21,7 @@ pub struct ModelTariff {
     /// If None, tariff is not automatically applied (legacy/manual pricing)
     /// If Some(purpose), tariff applies when model is accessed via that purpose
     pub api_key_purpose: Option<ApiKeyPurpose>,
-    /// Optional completion window (priority) for batch tariffs (e.g., "24h", "1h")
+    /// Optional completion window (priority) for batch tariffs (e.g., "24h", "1h", "background")
     /// Required for batch tariffs to allow multiple pricing tiers per priority
     /// Not applicable for realtime/playground tariffs
     pub completion_window: Option<String>,
@@ -36,7 +36,7 @@ pub struct TariffCreateDBRequest {
     pub output_price_per_token: Decimal,
     /// Optional API key purpose this tariff applies to
     pub api_key_purpose: Option<ApiKeyPurpose>,
-    /// Optional completion window (priority) for batch tariffs (e.g., "24h", "1h")
+    /// Optional completion window (priority) for batch tariffs (e.g., "24h", "1h", "background")
     /// Required when api_key_purpose is Batch to support multiple pricing tiers per priority
     pub completion_window: Option<String>,
     /// Optional valid_from timestamp (defaults to NOW())

--- a/dwctl/src/metrics/gen_ai.rs
+++ b/dwctl/src/metrics/gen_ai.rs
@@ -474,6 +474,7 @@ mod tests {
         let cases = [
             (None, "", "api", "realtime"),
             (None, "1h", "fusillade", "flex"),
+            (None, "background", "fusillade", "background"),
             (Some(batch_id), "1h", "fusillade", "async"),
             (Some(batch_id), "24h", "fusillade", "batch"),
         ];

--- a/dwctl/src/request_logging/batcher.rs
+++ b/dwctl/src/request_logging/batcher.rs
@@ -916,8 +916,9 @@ where
     ///
     /// Implements fallback logic:
     /// 1. Try exact match (purpose + completion_window + timestamp)
-    /// 2. Fall back to generic tariff for that purpose (completion_window = None)
-    /// 3. Fall back to realtime purpose (generic)
+    /// 2. For background work, fall back only to the 24h batch tariff
+    /// 3. For other work, fall back to a generic tariff for that purpose
+    /// 4. For other work, fall back to the generic realtime tariff
     fn find_best_tariff(
         &self,
         tariffs: &[TariffInfo],
@@ -925,43 +926,7 @@ where
         completion_window: Option<&str>,
         timestamp: DateTime<Utc>,
     ) -> (Option<Decimal>, Option<Decimal>) {
-        let purpose = api_key_purpose.unwrap_or(&ApiKeyPurpose::Realtime);
-
-        // Filter tariffs valid at timestamp:
-        // effective_from <= timestamp AND (valid_until IS NULL OR valid_until > timestamp)
-        let valid_tariffs: Vec<_> = tariffs
-            .iter()
-            .filter(|t| t.effective_from <= timestamp && t.valid_until.is_none_or(|valid_until| valid_until > timestamp))
-            .collect();
-
-        // Try exact match with completion_window (for batch tariffs with specific priority)
-        if let Some(cw) = completion_window
-            && let Some(tariff) = valid_tariffs
-                .iter()
-                .find(|t| &t.purpose == purpose && t.completion_window.as_deref() == Some(cw))
-        {
-            return (Some(tariff.input_price_per_token), Some(tariff.output_price_per_token));
-        }
-
-        // Try generic tariff for this purpose (completion_window = None)
-        // This ensures we don't accidentally match a different priority tier
-        if let Some(tariff) = valid_tariffs
-            .iter()
-            .find(|t| &t.purpose == purpose && t.completion_window.is_none())
-        {
-            return (Some(tariff.input_price_per_token), Some(tariff.output_price_per_token));
-        }
-
-        // Fall back to generic realtime tariff
-        if purpose != &ApiKeyPurpose::Realtime
-            && let Some(tariff) = valid_tariffs
-                .iter()
-                .find(|t| t.purpose == ApiKeyPurpose::Realtime && t.completion_window.is_none())
-        {
-            return (Some(tariff.input_price_per_token), Some(tariff.output_price_per_token));
-        }
-
-        (None, None)
+        resolve_tariff_prices(tariffs, api_key_purpose, completion_window, timestamp)
     }
 
     /// Write enriched records to the database in a single transaction.
@@ -1217,7 +1182,7 @@ where
         let mut served_bys: Vec<String> = Vec::new();
         let mut api_key_ids_credit: Vec<Option<Uuid>> = Vec::new();
         // Service tier, computed in memory from the fusillade metadata, so the
-        // transactions list can label each row (realtime / flex / async / batch)
+        // transactions list can label each row (realtime / flex / async / batch / background)
         // without joining http_analytics.
         let mut service_tiers: Vec<String> = Vec::new();
         // Denormalized per-request id so the responses view can read cost off the ledger
@@ -1340,7 +1305,7 @@ where
             count: i32,
             max_seq: i64,
             min_created_at: chrono::DateTime<chrono::Utc>,
-            // Constant per batch (async or batch); captured from the first folded row
+            // Constant per batch (async, batch, or background); captured from the first folded row
             // and denormalized onto batch_aggregates so the list needn't join http_analytics.
             service_tier: String,
         }
@@ -1835,6 +1800,53 @@ struct TariffInfo {
     completion_window: Option<String>,
 }
 
+fn resolve_tariff_prices(
+    tariffs: &[TariffInfo],
+    api_key_purpose: Option<&ApiKeyPurpose>,
+    completion_window: Option<&str>,
+    timestamp: DateTime<Utc>,
+) -> (Option<Decimal>, Option<Decimal>) {
+    let purpose = api_key_purpose.unwrap_or(&ApiKeyPurpose::Realtime);
+    let valid_tariffs: Vec<_> = tariffs
+        .iter()
+        .filter(|tariff| tariff.effective_from <= timestamp && tariff.valid_until.is_none_or(|valid_until| valid_until > timestamp))
+        .collect();
+
+    let prices = |tariff: &&TariffInfo| (Some(tariff.input_price_per_token), Some(tariff.output_price_per_token));
+
+    if let Some(window) = completion_window
+        && let Some(tariff) = valid_tariffs
+            .iter()
+            .find(|tariff| &tariff.purpose == purpose && tariff.completion_window.as_deref() == Some(window))
+    {
+        return prices(tariff);
+    }
+
+    if purpose == &ApiKeyPurpose::Batch && completion_window == Some("background") {
+        return valid_tariffs
+            .iter()
+            .find(|tariff| tariff.purpose == ApiKeyPurpose::Batch && tariff.completion_window.as_deref() == Some("24h"))
+            .map_or((None, None), prices);
+    }
+
+    if let Some(tariff) = valid_tariffs
+        .iter()
+        .find(|tariff| &tariff.purpose == purpose && tariff.completion_window.is_none())
+    {
+        return prices(tariff);
+    }
+
+    if purpose != &ApiKeyPurpose::Realtime
+        && let Some(tariff) = valid_tariffs
+            .iter()
+            .find(|tariff| tariff.purpose == ApiKeyPurpose::Realtime && tariff.completion_window.is_none())
+    {
+        return prices(tariff);
+    }
+
+    (None, None)
+}
+
 /// Parse API key purpose from string
 fn parse_api_key_purpose(s: &str) -> ApiKeyPurpose {
     match s {
@@ -1877,8 +1889,13 @@ fn compute_request_origin(api_key_purpose: Option<&ApiKeyPurpose>, fusillade_bat
 /// - `flex`     — 1h SLA, no batch id (async single request)
 /// - `async`    — 1h SLA with a batch id
 /// - `batch`    — 24h SLA with a batch id (the /v1/batches API)
+/// - `background` — best-effort work, with or without a batch id
 pub(crate) fn compute_billing_tier(fusillade_batch_id: Option<Uuid>, completion_window: Option<&str>) -> &'static str {
     let window = completion_window.filter(|w| !w.is_empty());
+    if window == Some("background") {
+        return "background";
+    }
+
     match (fusillade_batch_id.is_some(), window) {
         (false, None) => "realtime",
         (false, _) => "flex",
@@ -1897,8 +1914,10 @@ mod tests {
         assert_eq!(compute_billing_tier(None, None), "realtime");
         assert_eq!(compute_billing_tier(None, Some("")), "realtime");
         assert_eq!(compute_billing_tier(None, Some("1h")), "flex");
+        assert_eq!(compute_billing_tier(None, Some("background")), "background");
         assert_eq!(compute_billing_tier(Some(batch_id), Some("1h")), "async");
         assert_eq!(compute_billing_tier(Some(batch_id), Some("24h")), "batch");
+        assert_eq!(compute_billing_tier(Some(batch_id), Some("background")), "background");
     }
 
     #[test]
@@ -2201,37 +2220,7 @@ mod tests {
         completion_window: Option<&str>,
         timestamp: DateTime<Utc>,
     ) -> (Option<Decimal>, Option<Decimal>) {
-        let purpose = api_key_purpose.unwrap_or(&ApiKeyPurpose::Realtime);
-
-        let valid_tariffs: Vec<_> = tariffs
-            .iter()
-            .filter(|t| t.effective_from <= timestamp && t.valid_until.is_none_or(|valid_until| valid_until > timestamp))
-            .collect();
-
-        if let Some(cw) = completion_window
-            && let Some(tariff) = valid_tariffs
-                .iter()
-                .find(|t| &t.purpose == purpose && t.completion_window.as_deref() == Some(cw))
-        {
-            return (Some(tariff.input_price_per_token), Some(tariff.output_price_per_token));
-        }
-
-        if let Some(tariff) = valid_tariffs
-            .iter()
-            .find(|t| &t.purpose == purpose && t.completion_window.is_none())
-        {
-            return (Some(tariff.input_price_per_token), Some(tariff.output_price_per_token));
-        }
-
-        if purpose != &ApiKeyPurpose::Realtime
-            && let Some(tariff) = valid_tariffs
-                .iter()
-                .find(|t| t.purpose == ApiKeyPurpose::Realtime && t.completion_window.is_none())
-        {
-            return (Some(tariff.input_price_per_token), Some(tariff.output_price_per_token));
-        }
-
-        (None, None)
+        resolve_tariff_prices(tariffs, api_key_purpose, completion_window, timestamp)
     }
 
     #[test]
@@ -2478,9 +2467,10 @@ mod integration_tests {
     use super::*;
     use crate::api::models::transactions::TransactionFilters;
     use crate::api::models::users::Role;
-    use crate::db::handlers::Repository;
     use crate::db::handlers::credits::Credits;
+    use crate::db::handlers::{Repository, Tariffs};
     use crate::db::models::credits::CreditTransactionType;
+    use crate::db::models::tariffs::TariffCreateDBRequest;
     use crate::test::utils::create_test_user;
     use rust_decimal::prelude::FromStr;
     use sqlx::PgPool;
@@ -3024,6 +3014,123 @@ mod integration_tests {
         assert_eq!(
             final_balance, expected_balance,
             "Batch request should fall back to realtime pricing"
+        );
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn background_batcher_uses_explicit_tariff_and_ledger_tier(pool: PgPool) {
+        let model_id = create_test_model(&pool, "background-explicit-test").await;
+        let mut conn = pool.acquire().await.unwrap();
+        Tariffs::new(&mut conn)
+            .create(&TariffCreateDBRequest {
+                deployed_model_id: model_id,
+                name: "Background".to_string(),
+                input_price_per_token: Decimal::from_str("0.00002").unwrap(),
+                output_price_per_token: Decimal::from_str("0.00004").unwrap(),
+                api_key_purpose: Some(ApiKeyPurpose::Batch),
+                completion_window: Some("background".to_string()),
+                valid_from: None,
+            })
+            .await
+            .unwrap();
+        drop(conn);
+
+        let user_id = setup_user_with_balance(&pool, Decimal::from_str("100.00").unwrap()).await;
+        let batch_key = create_api_key_for_user(&pool, user_id, ApiKeyPurpose::Batch).await;
+        let mut record = create_raw_record("background-explicit-test", Some(batch_key), 1000, 500);
+        record.batch_completion_window = Some("background".to_string());
+
+        run_batcher_with_records(&pool, vec![record]).await;
+
+        let row = sqlx::query!(
+            r#"
+            SELECT amount, service_tier
+            FROM credits_transactions
+            WHERE user_id = $1 AND transaction_type = 'usage'
+            "#,
+            user_id
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.amount, Decimal::from_str("0.04").unwrap());
+        assert_eq!(row.service_tier.as_deref(), Some("background"));
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn background_batcher_falls_back_to_24h_price_but_keeps_background_tier(pool: PgPool) {
+        let model_id = create_test_model(&pool, "background-fallback-test").await;
+        setup_tariff(
+            &pool,
+            model_id,
+            Decimal::from_str("0.00005").unwrap(),
+            Decimal::from_str("0.00010").unwrap(),
+            ApiKeyPurpose::Batch,
+        )
+        .await;
+
+        let user_id = setup_user_with_balance(&pool, Decimal::from_str("100.00").unwrap()).await;
+        let batch_key = create_api_key_for_user(&pool, user_id, ApiKeyPurpose::Batch).await;
+        let batch_id = Uuid::new_v4();
+        let mut record = create_raw_record("background-fallback-test", Some(batch_key), 1000, 500);
+        record.batch_completion_window = Some("background".to_string());
+        record.fusillade_batch_id = Some(batch_id);
+
+        run_batcher_with_records(&pool, vec![record]).await;
+
+        let credit = sqlx::query!(
+            r#"
+            SELECT amount, service_tier
+            FROM credits_transactions
+            WHERE user_id = $1 AND transaction_type = 'usage'
+            "#,
+            user_id
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(credit.amount, Decimal::from_str("0.10").unwrap());
+        assert_eq!(credit.service_tier.as_deref(), Some("background"));
+
+        let aggregate_tier: Option<String> = sqlx::query_scalar("SELECT service_tier FROM batch_aggregates WHERE fusillade_batch_id = $1")
+            .bind(batch_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(aggregate_tier.as_deref(), Some("background"));
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn background_batcher_never_falls_back_to_realtime_price(pool: PgPool) {
+        let model_id = create_test_model(&pool, "background-no-price-test").await;
+        setup_tariff(
+            &pool,
+            model_id,
+            Decimal::from_str("0.00015").unwrap(),
+            Decimal::from_str("0.00030").unwrap(),
+            ApiKeyPurpose::Realtime,
+        )
+        .await;
+
+        let user_id = setup_user_with_balance(&pool, Decimal::from_str("100.00").unwrap()).await;
+        let batch_key = create_api_key_for_user(&pool, user_id, ApiKeyPurpose::Batch).await;
+        let mut record = create_raw_record("background-no-price-test", Some(batch_key), 1000, 500);
+        record.batch_completion_window = Some("background".to_string());
+
+        run_batcher_with_records(&pool, vec![record]).await;
+
+        let usage_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM credits_transactions WHERE user_id = $1 AND transaction_type = 'usage'")
+                .bind(user_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            usage_count, 0,
+            "background work without background or 24h pricing must remain unbilled"
         );
     }
 

--- a/scripts/backfill_batch_aggregates_denorm.sh
+++ b/scripts/backfill_batch_aggregates_denorm.sh
@@ -3,13 +3,11 @@
 # Backfill batch_aggregates.service_tier from fusillade.batches (COR-514, migration 113).
 #
 # batch_aggregates is one row per batch (small). Every batch has a fusillade_batch_id,
-# so its tier is `async` (1h SLA) or `batch` (24h SLA). We read the SLA from the
-# AUTHORITATIVE source, fusillade.batches.completion_window ('24h' -> batch, else ->
-# async), matching compute_service_tier in the batcher AND the credits backfill. We do
-# NOT read http_analytics.batch_sla: it was unpopulated before ~Feb 2026, so it would
-# mislabel old 24h batches as async and disagree with credits_transactions.service_tier
-# for the same batch. A deleted batch (no fusillade.batches row) has no SLA to resolve
-# and defaults to async, as in the credits backfill.
+# so its tier is `background`, `async` (1h SLA), or `batch` (24h SLA). We read
+# the scheduling tier and SLA from the AUTHORITATIVE source, fusillade.batches,
+# matching compute_service_tier in the batcher AND the credits backfill. We do
+# NOT read http_analytics.batch_sla: it was unpopulated before ~Feb 2026. A
+# deleted batch has no tier to resolve and defaults to async.
 #
 # service_tier is immutable per batch (set once), so no quiescence guard is needed and
 # there is no race with the live fold (it only writes new, non-NULL rows). This is a
@@ -30,6 +28,10 @@ psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -X <<'SQL'
 \timing on
 UPDATE batch_aggregates ba
    SET service_tier = CASE
+         WHEN (SELECT b.service_tier
+                 FROM fusillade.batches b
+                WHERE b.id = ba.fusillade_batch_id) = 'background'
+         THEN 'background'
          WHEN (SELECT b.completion_window
                  FROM fusillade.batches b
                 WHERE b.id = ba.fusillade_batch_id) = '24h'

--- a/scripts/backfill_credits_denorm.sh
+++ b/scripts/backfill_credits_denorm.sh
@@ -17,25 +17,27 @@
 # Instead we classify from cheaper, authoritative sources (validated on a prod
 # clone, see COR-507 notes):
 #
-#   * Batch vs async (rows WITH fusillade_batch_id, ~94% of usage rows):
-#     take the SLA from fusillade.batches.completion_window, NOT http_analytics.
+#   * Background/batch/async (rows WITH fusillade_batch_id, ~94% of usage rows):
+#     take the scheduling tier and SLA from fusillade.batches, NOT http_analytics.
 #     When http_analytics.batch_sla is populated it equals
 #     batches.completion_window in 100% of sampled rows; and batch_sla was simply
 #     not populated before ~Feb 2026, so batches.completion_window is both
 #     consistent with the batcher going forward AND corrects old rows that the
 #     raw analytics would mislabel `async` (real 24h batches with an empty SLA).
-#       completion_window = '24h' -> batch ;  otherwise (incl. a deleted batch
-#       row, which we can't resolve) -> async.
+#       service_tier = 'background' -> background
+#       completion_window = '24h'   -> batch
+#       otherwise (incl. a deleted batch row) -> async.
 #     fusillade.batches is small and hash-joins in memory: no http_analytics.
 #
-#   * realtime vs flex (rows WITHOUT fusillade_batch_id, ~6%):
-#     default realtime; flex is a non-batch request that carried an SLA. Its SLA
-#     lives only in http_analytics.batch_sla, so flex (~0.2% of rows) is the one
-#     case that needs http_analytics -- recovered by a SINGLE bounded scan
-#     (Phase 2), not per-row probes. Pre-cutover flex was never recorded and is
-#     correctly left realtime.
+#   * Background/realtime/flex (rows WITHOUT fusillade_batch_id, ~6%):
+#     identify batchless background work from fusillade.requests.service_tier
+#     using the denormalized request id. Default the remainder to realtime; flex
+#     is a non-batch request that carried an SLA. Its SLA lives only in
+#     http_analytics.batch_sla, so flex is recovered by a SINGLE bounded scan
+#     (Phase 2), not per-row probes.
 #
 # Tier rule (mirrors compute_service_tier in batcher.rs):
+#   service tier background  -> background
 #   batch id + '24h'      -> batch
 #   batch id + otherwise  -> async
 #   no batch id + SLA     -> flex
@@ -86,7 +88,7 @@ trap 'psql_q "DROP INDEX CONCURRENTLY IF EXISTS ${HELPER_IDX};" >/dev/null 2>&1 
 psql_q "DROP INDEX CONCURRENTLY IF EXISTS ${HELPER_IDX};"
 psql_q "CREATE INDEX CONCURRENTLY ${HELPER_IDX} ON credits_transactions (seq);"
 
-# --- Phase 1: batch/async/realtime from fusillade.batches (no http_analytics) ---
+# --- Phase 1: queued tiers from fusillade, without http_analytics ---
 CURSOR="$START_SEQ"
 total_rows=0
 batches=0
@@ -94,14 +96,30 @@ SECONDS=0
 while [ "$CURSOR" -lt "$MAX_SEQ" ]; do
   hi=$(( CURSOR + BATCH_SIZE ))
   if [ "$hi" -gt "$MAX_SEQ" ]; then hi="$MAX_SEQ"; fi
-  # Two UPDATEs + a count, one implicit transaction (atomic per chunk):
+  # Four UPDATEs + a count, one implicit transaction (atomic per chunk):
   #   1. default every usage row: batch id -> async, else -> realtime
-  #   2. upgrade to batch where the batch's window is 24h (deleted batch rows
-  #      have no batches match and stay async)
+  #   2. upgrade file-backed background work from fusillade.batches
+  #   3. upgrade batchless background work from fusillade.requests
+  #   4. upgrade remaining async rows where the batch's window is 24h
   affected=$(psql_q "
     UPDATE credits_transactions ct
        SET service_tier = CASE WHEN ct.fusillade_batch_id IS NOT NULL THEN 'async' ELSE 'realtime' END
      WHERE ct.seq > ${CURSOR} AND ct.seq <= ${hi}
+           AND ct.transaction_type = 'usage';
+    UPDATE credits_transactions ct
+       SET service_tier = 'background'
+      FROM fusillade.batches b
+     WHERE ct.fusillade_batch_id = b.id
+           AND b.service_tier = 'background'
+           AND ct.seq > ${CURSOR} AND ct.seq <= ${hi}
+           AND ct.transaction_type = 'usage';
+    UPDATE credits_transactions ct
+       SET service_tier = 'background'
+      FROM fusillade.requests r
+     WHERE ct.fusillade_batch_id IS NULL
+           AND ct.fusillade_request_id = r.id
+           AND r.service_tier = 'background'
+           AND ct.seq > ${CURSOR} AND ct.seq <= ${hi}
            AND ct.transaction_type = 'usage';
     UPDATE credits_transactions ct
        SET service_tier = 'batch'
@@ -119,17 +137,20 @@ while [ "$CURSOR" -lt "$MAX_SEQ" ]; do
   sleep "${SLEEP_SECONDS}"
 done
 
-# --- Phase 2: flex, one bounded scan of http_analytics ---
-# A non-batch request that carried an SLA. Only source is http_analytics.batch_sla.
-# Single set-based UPDATE: scan http_analytics once (bounded by FLEX_CUTOFF),
-# upgrade the matching realtime rows to flex. Not per-row probing.
+# --- Phase 2: batchless background/flex, one bounded scan of http_analytics ---
+# This recovers background rows whose fusillade request was already purged and
+# classifies the remaining non-batch requests with an SLA as flex. One UPDATE
+# scans http_analytics once (bounded by FLEX_CUTOFF) and assigns the tier by CASE.
 flex_where_cutoff=""
 if [ -n "$FLEX_CUTOFF" ]; then flex_where_cutoff="AND ha.timestamp >= '${FLEX_CUTOFF}'"; fi
-echo "backfill_credits_denorm: Phase 2 flex — scanning http_analytics ${FLEX_CUTOFF:+from ${FLEX_CUTOFF} }…"
-flex_rows=$(psql_q "
-  WITH f AS (
+echo "backfill_credits_denorm: Phase 2 batchless background/flex — scanning http_analytics ${FLEX_CUTOFF:+from ${FLEX_CUTOFF} }…"
+phase2_counts=$(psql_q "
+  WITH classified AS (
     UPDATE credits_transactions ct
-       SET service_tier = 'flex'
+       SET service_tier = CASE
+             WHEN ha.batch_sla = 'background' THEN 'background'
+             ELSE 'flex'
+           END
       FROM http_analytics ha
      WHERE ha.id::text = ct.source_id
            ${flex_where_cutoff}
@@ -137,13 +158,18 @@ flex_rows=$(psql_q "
            AND COALESCE(ha.batch_sla, '') <> ''
            AND ct.fusillade_batch_id IS NULL
            AND ct.service_tier = 'realtime'
-    RETURNING 1
+    RETURNING ct.service_tier
   )
-  SELECT count(*) FROM f;")
+  SELECT
+    count(*) FILTER (WHERE service_tier = 'background'),
+    count(*) FILTER (WHERE service_tier = 'flex')
+  FROM classified;")
+IFS='|' read -r background_rows flex_rows <<< "$phase2_counts"
 
 elapsed=$SECONDS
 echo "backfill_credits_denorm: DONE"
 printf '  usage rows classified : %s\n' "$total_rows"
+printf '  background rows (Phase 2): %s\n' "$background_rows"
 printf '  flex rows (Phase 2)   : %s\n' "$flex_rows"
 printf '  duration              : %dm %02ds (sweep only, excl. index build)\n' $(( elapsed / 60 )) $(( elapsed % 60 ))
 printf '  batches               : %s  (BATCH_SIZE=%s, SLEEP_SECONDS=%s)\n' "$batches" "$BATCH_SIZE" "$SLEEP_SECONDS"


### PR DESCRIPTION
## Summary

- add `background` as a first-class billing tier across credit transactions, batch aggregates, GenAI metrics, transaction responses, model pricing, and historical backfills
- resolve pricing as explicit background tariff → 24h batch tariff only; requests remain identified as background throughout, and stay unbilled when neither price exists
- expose background tariff configuration and effective pricing in the platform model dashboard independently of foreground SLA windows
- allow authorized connection syncs, including S3, to submit native background batches while preserving model validation and bypassing foreground SLA capacity and unverified-volume admission
- add an atomic, low-cost constraint migration that avoids scanning the large credits ledger

## Why

Background dispatch is a distinct inference class, but billing and connector ingestion still treated it as an ordinary SLA batch in several paths. That could report the wrong tier, select realtime pricing, or reject/fail connector-created background work through foreground admission and completion-window parsing.

## Impact

Platform managers can configure a dedicated background tariff per model. Without one, background work charges the model's 24h batch price without changing its accounting identity. Connection sync callers need the `BackgroundInferenceUser` role to select `completion_window: "background"`; accepted files become real background batches and do not consume foreground admission capacity.

Historical backfill scripts now classify file-backed and batchless background usage, including purged request rows recovered from analytics, without adding an extra analytics-table scan.

## Validation

- `cargo test -p dwctl background_ --lib` (31 passed)
- `cargo test -p dwctl test_compute_billing_tier --lib`
- `cargo test -p dwctl test_billing_tier_label_maps_each_case --lib`
- `just lint rust -- -D warnings`
- `just lint ts`
- `pnpm build`
- focused dashboard tests (75 passed, including the previously flaky user-management test in isolation)
- live PostgreSQL migration and backfill SQL syntax checks
- independent code review with no remaining findings