### PR TITLE
feat: expose cache pricing in admin model responses

### DIFF
--- a/dwctl/src/api/handlers/deployments.rs
+++ b/dwctl/src/api/handlers/deployments.rs
@@ -186,7 +186,7 @@ fn db_component_to_response(c: DeploymentComponentDBResponse) -> ModelComponentR
         ("endpoint" = Option<i32>, Query, description = "Filter by inference endpoint ID"),
         ("group" = Option<String>, Query, description = "Filter by group IDs (comma-separated UUIDs)"),
         ("accessible" = Option<bool>, Query, description = "Filter to only models the current user can access (defaults to false for admins, true for users)"),
-        ("include" = Option<String>, Query, description = "Include additional data (comma-separated: 'groups', 'metrics', 'status', 'pricing', 'endpoints', 'facets', 'reasoning_capabilities'). Only platform managers can include groups. Status shows probe monitoring information. Pricing shows simple customer rates for regular users, full pricing structure including current active tariffs for users with Pricing::ReadAll permission. Endpoints includes full inference endpoint details. Facets returns distinct providers, capabilities, and model types for filter dropdowns. Reasoning capabilities shows efforts supported by every provider behind each model."),
+        ("include" = Option<String>, Query, description = "Include additional data (comma-separated: 'groups', 'metrics', 'status', 'pricing', 'endpoints', 'facets', 'reasoning_capabilities'). Only platform managers can include groups. Status shows probe monitoring information. Pricing includes active customer tariffs and prompt-cache pricing; provider pricing remains restricted to users with Pricing::ReadAll permission. Endpoints includes full inference endpoint details. Facets returns distinct providers, capabilities, and model types for filter dropdowns. Reasoning capabilities shows efforts supported by every provider behind each model."),
         ("provider" = Option<String>, Query, description = "Filter by provider name (case-insensitive exact match against metadata.provider)"),
         ("model_type" = Option<String>, Query, description = "Filter by model type (CHAT, EMBEDDINGS, RERANKER)"),
         ("capability" = Option<String>, Query, description = "Filter by capability (returns models that have this capability)"),
@@ -907,7 +907,7 @@ pub async fn update_deployed_model<P: PoolProvider>(
     path = "/models/{id}",
     tag = "models",
     summary = "Get deployed model",
-    description = "Get a specific deployed model",
+    description = "Get a specific deployed model. include=pricing includes active customer tariffs and prompt-cache pricing.",
     params(
         ("id" = uuid::Uuid, Path, description = "Deployment ID to retrieve"),
         GetModelQuery
@@ -1381,7 +1381,7 @@ mod tests {
             models::{pagination::PaginatedResponse, users::Role},
         },
         db::{
-            handlers::{Deployments, Groups, Repository},
+            handlers::{CacheTariffOverrides, CacheTariffs, Deployments, Groups, Repository},
             models::{api_keys::ApiKeyPurpose, deployments::TrafficRuleAction, groups::GroupCreateDBRequest},
         },
         test::utils::*,
@@ -1412,6 +1412,89 @@ mod tests {
         let response_body: PaginatedResponse<DeployedModelResponse> = response.json();
         // Should be empty initially, but test that it returns proper structure
         assert!(response_body.data.is_empty() || !response_body.data.is_empty());
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn admin_models_include_pricing_exposes_cache_tariffs(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let admin = create_test_admin_user(&pool, Role::PlatformManager).await;
+        let priced = create_test_deployment(&pool, admin.id, "priced-model", "priced-model").await;
+        let unpriced = create_test_deployment(&pool, admin.id, "unpriced-model", "unpriced-model").await;
+
+        let mut conn = pool.acquire().await.unwrap();
+        CacheTariffs::new(&mut conn)
+            .enable(
+                priced.id,
+                &crate::config::CachePricingConfig::default(),
+                CacheTariffOverrides {
+                    write_multiplier_5m: Some(rust_decimal::Decimal::new(125, 2)),
+                    write_multiplier_1h: Some(rust_decimal::Decimal::new(2, 0)),
+                    write_multiplier_24h: Some(rust_decimal::Decimal::new(25, 1)),
+                    read_multiplier: Some(rust_decimal::Decimal::new(1, 1)),
+                    min_prefix_tokens: Some(2048),
+                },
+            )
+            .await
+            .unwrap();
+
+        let response = app
+            .get("/admin/api/v1/models?include=pricing")
+            .add_header(&add_auth_headers(&admin)[0].0, &add_auth_headers(&admin)[0].1)
+            .add_header(&add_auth_headers(&admin)[1].0, &add_auth_headers(&admin)[1].1)
+            .await;
+        response.assert_status_ok();
+        let body: serde_json::Value = response.json();
+        let models = body["data"].as_array().expect("list response should contain data");
+        let priced_model = models
+            .iter()
+            .find(|model| model["id"] == priced.id.to_string())
+            .expect("priced model should be listed");
+        let unpriced_model = models
+            .iter()
+            .find(|model| model["id"] == unpriced.id.to_string())
+            .expect("unpriced model should be listed");
+        let cache_pricing = &priced_model["cache_pricing"];
+        assert_eq!(cache_pricing["enabled"], true);
+        assert_eq!(cache_pricing["write_multiplier_5m"], "1.25");
+        assert_eq!(cache_pricing["write_multiplier_1h"], "2.0");
+        assert_eq!(cache_pricing["write_multiplier_24h"], "2.5");
+        assert_eq!(cache_pricing["read_multiplier"], "0.1");
+        assert_eq!(cache_pricing["min_prefix_tokens"], 2048);
+        assert!(cache_pricing["valid_from"].is_string());
+        assert_eq!(cache_pricing["valid_until"], serde_json::Value::Null);
+        assert_eq!(
+            unpriced_model["cache_pricing"],
+            json!({
+                "enabled": false,
+                "write_multiplier_5m": null,
+                "write_multiplier_1h": null,
+                "write_multiplier_24h": null,
+                "read_multiplier": null,
+                "min_prefix_tokens": null,
+                "valid_from": null,
+                "valid_until": null,
+            })
+        );
+
+        let response = app
+            .get(&format!("/admin/api/v1/models/{}?include=pricing", priced.id))
+            .add_header(&add_auth_headers(&admin)[0].0, &add_auth_headers(&admin)[0].1)
+            .add_header(&add_auth_headers(&admin)[1].0, &add_auth_headers(&admin)[1].1)
+            .await;
+        response.assert_status_ok();
+        let model: serde_json::Value = response.json();
+        assert_eq!(model["cache_pricing"]["enabled"], true);
+        assert_eq!(model["cache_pricing"]["min_prefix_tokens"], 2048);
+
+        let response = app
+            .get(&format!("/admin/api/v1/models/{}", priced.id))
+            .add_header(&add_auth_headers(&admin)[0].0, &add_auth_headers(&admin)[0].1)
+            .add_header(&add_auth_headers(&admin)[1].0, &add_auth_headers(&admin)[1].1)
+            .await;
+        response.assert_status_ok();
+        let model: serde_json::Value = response.json();
+        assert!(model.get("cache_pricing").is_none());
     }
 
     #[sqlx::test]

--- a/dwctl/src/api/handlers/deployments.rs
+++ b/dwctl/src/api/handlers/deployments.rs
@@ -1456,10 +1456,10 @@ mod tests {
             .expect("unpriced model should be listed");
         let cache_pricing = &priced_model["cache_pricing"];
         assert_eq!(cache_pricing["enabled"], true);
-        assert_eq!(cache_pricing["write_multiplier_5m"], "1.25");
-        assert_eq!(cache_pricing["write_multiplier_1h"], "2.0");
-        assert_eq!(cache_pricing["write_multiplier_24h"], "2.5");
-        assert_eq!(cache_pricing["read_multiplier"], "0.1");
+        assert_eq!(cache_pricing["write_multiplier_5m"], "1.2500");
+        assert_eq!(cache_pricing["write_multiplier_1h"], "2.0000");
+        assert_eq!(cache_pricing["write_multiplier_24h"], "2.5000");
+        assert_eq!(cache_pricing["read_multiplier"], "0.1000");
         assert_eq!(cache_pricing["min_prefix_tokens"], 2048);
         assert!(cache_pricing["valid_from"].is_string());
         assert_eq!(cache_pricing["valid_until"], serde_json::Value::Null);

--- a/dwctl/src/api/models/deployments/enrichment.rs
+++ b/dwctl/src/api/models/deployments/enrichment.rs
@@ -6,6 +6,7 @@
 
 use crate::{
     api::models::{
+        cache_pricing::CachePricingResponse,
         deployments::{
             ComponentEndpointSummary, ComponentModelSummary, DeployedModelResponse, ModelComponentResponse, ModelMetrics, ModelProbeStatus,
             ModelType,
@@ -13,7 +14,7 @@ use crate::{
         inference_endpoints::InferenceEndpointResponse,
     },
     db::{
-        handlers::{Groups, InferenceEndpoints, Repository, analytics::get_model_metrics},
+        handlers::{CacheTariffs, Groups, InferenceEndpoints, Repository, analytics::get_model_metrics},
         models::{deployments::DeploymentComponentDBResponse, groups::GroupDBResponse},
     },
     errors::{Error, Result},
@@ -76,7 +77,7 @@ impl<'a> DeployedModelEnricher<'a> {
         let model_aliases: Vec<String> = models.iter().map(|m| m.alias.clone()).collect();
 
         // Fetch all includes in parallel for maximum performance
-        let (groups_result, status_map, metrics_map, endpoints_map, pricing_tariffs_map, components_map) = tokio::join!(
+        let (groups_result, status_map, metrics_map, endpoints_map, pricing_tariffs_map, cache_tariffs_map, components_map) = tokio::join!(
             // Groups query
             async {
                 if self.include_groups {
@@ -170,6 +171,15 @@ impl<'a> DeployedModelEnricher<'a> {
                     None
                 }
             },
+            // Active prompt-cache tariffs query
+            async {
+                if self.include_pricing {
+                    let mut conn = self.db.acquire().await.map_err(|e| Error::Database(e.into()))?;
+                    Ok::<_, Error>(Some(CacheTariffs::new(&mut conn).get_active_bulk(&model_ids).await?))
+                } else {
+                    Ok(None)
+                }
+            },
             // Components query (for composite models)
             async {
                 if self.include_components && self.can_read_composite_info {
@@ -195,6 +205,7 @@ impl<'a> DeployedModelEnricher<'a> {
             Some((model_groups_map, groups_map)) => (Some(model_groups_map), Some(groups_map)),
             None => (None, None),
         };
+        let cache_tariffs_map = cache_tariffs_map?;
 
         // Build enriched responses
         let mut enriched_models = Vec::with_capacity(models.len());
@@ -223,6 +234,7 @@ impl<'a> DeployedModelEnricher<'a> {
             // Add tariffs if pricing is requested and available
             if self.include_pricing {
                 model_response = Self::apply_tariffs(model_response, &pricing_tariffs_map);
+                model_response = Self::apply_cache_pricing(model_response, &cache_tariffs_map);
                 // Hide pricing for purposes that the model denies via a
                 // traffic-routing rule. Run after `apply_tariffs` so it
                 // operates on the freshly-attached set; no-op if no tariffs.
@@ -378,6 +390,21 @@ impl<'a> DeployedModelEnricher<'a> {
         model
     }
 
+    /// Apply active prompt-cache pricing to a model response. Pricing is explicitly
+    /// disabled when no active cache-tariff row exists for the model.
+    fn apply_cache_pricing(
+        model: DeployedModelResponse,
+        cache_tariffs_map: &Option<HashMap<DeploymentId, crate::db::handlers::ActiveTariff>>,
+    ) -> DeployedModelResponse {
+        let cache_pricing = cache_tariffs_map
+            .as_ref()
+            .and_then(|tariffs| tariffs.get(&model.id))
+            .cloned()
+            .map(CachePricingResponse::from)
+            .unwrap_or_else(CachePricingResponse::disabled);
+        model.with_cache_pricing(cache_pricing)
+    }
+
     /// Apply components to a model response (for composite models)
     fn apply_components(
         mut model: DeployedModelResponse,
@@ -455,6 +482,7 @@ mod tests {
             metrics: None,
             status: None,
             provider_pricing: None,
+            cache_pricing: None,
             endpoint: None,
             tariffs: None,
             // Composite model fields (regular model = not composite)

--- a/dwctl/src/api/models/deployments/mod.rs
+++ b/dwctl/src/api/models/deployments/mod.rs
@@ -3,6 +3,7 @@
 pub mod enrichment;
 
 use super::pagination::Pagination;
+use crate::api::models::cache_pricing::CachePricingResponse;
 use crate::api::models::groups::GroupResponse;
 use crate::db::models::api_keys::ApiKeyPurpose;
 use crate::db::models::deployments::{
@@ -118,7 +119,8 @@ pub struct GetModelQuery {
     pub deleted: Option<bool>,
     /// Show inactive model when true, 404 when false/unspecified if model is inactive
     pub inactive: Option<bool>,
-    /// Include related data (comma-separated: "groups", "metrics", "status", "pricing", "endpoints")
+    /// Include related data (comma-separated: "groups", "metrics", "status", "pricing", "endpoints").
+    /// Pricing includes active customer tariffs and prompt-cache pricing.
     pub include: Option<String>,
 }
 
@@ -544,6 +546,9 @@ pub struct DeployedModelResponse {
     /// Provider/downstream pricing details (only included if requested and user has Pricing::ReadAll)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_pricing: Option<ProviderPricing>,
+    /// Active customer prompt-cache pricing (only included when include=pricing)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_pricing: Option<CachePricingResponse>,
     /// Inference endpoint information (only included if requested)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<super::inference_endpoints::InferenceEndpointResponse>,
@@ -635,6 +640,7 @@ impl From<DeploymentDBResponse> for DeployedModelResponse {
             metrics: None,          // By default, metrics are not included
             status: None,           // By default, probe status is not included
             provider_pricing: None, // By default, provider pricing is not included
+            cache_pricing: None,    // By default, cache pricing is not included
             endpoint: None,         // By default, endpoint is not included
             tariffs: None,          // By default, tariffs are not included
             // Composite model fields
@@ -683,6 +689,12 @@ impl DeployedModelResponse {
     /// Create a response with provider pricing included (admin only)
     pub fn with_provider_pricing(mut self, provider_pricing: Option<ProviderPricing>) -> Self {
         self.provider_pricing = provider_pricing;
+        self
+    }
+
+    /// Create a response with cache pricing included.
+    pub fn with_cache_pricing(mut self, cache_pricing: CachePricingResponse) -> Self {
+        self.cache_pricing = Some(cache_pricing);
         self
     }
 

--- a/dwctl/src/db/handlers/cache_tariffs.rs
+++ b/dwctl/src/db/handlers/cache_tariffs.rs
@@ -14,6 +14,7 @@ use crate::types::DeploymentId;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use sqlx::{Connection, PgConnection};
+use std::collections::HashMap;
 use tracing::instrument;
 
 /// Optional per-tier overrides for [`CacheTariffs::enable`]. Any `None` field is filled
@@ -38,6 +39,18 @@ pub struct ActiveTariff {
     pub min_prefix_tokens: i32,
     pub valid_from: DateTime<Utc>,
     pub valid_until: Option<DateTime<Utc>>,
+}
+
+#[derive(sqlx::FromRow)]
+struct ActiveTariffRow {
+    deployed_model_id: DeploymentId,
+    write_multiplier_5m: Decimal,
+    write_multiplier_1h: Decimal,
+    write_multiplier_24h: Decimal,
+    read_multiplier: Decimal,
+    min_prefix_tokens: i32,
+    valid_from: DateTime<Utc>,
+    valid_until: Option<DateTime<Utc>>,
 }
 
 pub struct CacheTariffs<'c> {
@@ -130,6 +143,47 @@ impl<'c> CacheTariffs<'c> {
         .fetch_optional(&mut *self.db)
         .await?;
         Ok(row)
+    }
+
+    /// Active tariff versions effective now, keyed by deployment ID. Models without an
+    /// active row are omitted from the map.
+    #[instrument(skip(self, model_ids), fields(model_count = model_ids.len()), err)]
+    pub async fn get_active_bulk(&mut self, model_ids: &[DeploymentId]) -> Result<HashMap<DeploymentId, ActiveTariff>> {
+        if model_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let rows = sqlx::query_as::<_, ActiveTariffRow>(
+            r#"SELECT DISTINCT ON (deployed_model_id)
+                      deployed_model_id, write_multiplier_5m, write_multiplier_1h, write_multiplier_24h,
+                      read_multiplier, min_prefix_tokens, valid_from, valid_until
+               FROM model_cache_tariffs
+               WHERE deployed_model_id = ANY($1)
+                 AND valid_from <= now()
+                 AND (valid_until IS NULL OR valid_until > now())
+               ORDER BY deployed_model_id, valid_from DESC"#,
+        )
+        .bind(model_ids)
+        .fetch_all(&mut *self.db)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                (
+                    row.deployed_model_id,
+                    ActiveTariff {
+                        write_multiplier_5m: row.write_multiplier_5m,
+                        write_multiplier_1h: row.write_multiplier_1h,
+                        write_multiplier_24h: row.write_multiplier_24h,
+                        read_multiplier: row.read_multiplier,
+                        min_prefix_tokens: row.min_prefix_tokens,
+                        valid_from: row.valid_from,
+                        valid_until: row.valid_until,
+                    },
+                )
+            })
+            .collect())
     }
 }
 


### PR DESCRIPTION
## Summary
- expose active prompt-cache tariffs in Admin Model responses when include=pricing is requested
- add a single bulk active-tariff lookup shared by model list and single-model enrichment
- document cache pricing in the Admin Models OpenAPI response/query descriptions

## Verification
- cargo fmt --all --check
- SQLX_OFFLINE=true cargo check -p dwctl --lib
- SQLX_OFFLINE=true cargo clippy -p dwctl --lib --no-deps -- -D warnings
- cargo sqlx prepare --check --workspace

## Verification gap
The focused #[sqlx::test] Admin API test could not run locally because Docker is unavailable at /Users/peter/.docker/run/docker.sock, so the PostgreSQL test database could not be started. The new bulk lookup uses SQLx typed runtime query API and does not add a .sqlx metadata entry.