### PR TITLE
feat(payments): add setup-mode checkout for onboarding card verification

### DIFF
--- a/.sqlx/query-2646d7eb84cc72318cfb02cae8003d737ed88062dde5752dc18a653647dff89e.json
+++ b/.sqlx/query-2646d7eb84cc72318cfb02cae8003d737ed88062dde5752dc18a653647dff89e.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT EXISTS (\n                SELECT 1 FROM credits_transactions\n                WHERE user_id = $1\n                  AND transaction_type = 'admin_grant'\n                  AND source_id LIKE '%:verification-credits'\n            ) AS \"already_granted!\"\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "already_granted!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "2646d7eb84cc72318cfb02cae8003d737ed88062dde5752dc18a653647dff89e"
+}

--- a/config.yaml
+++ b/config.yaml
@@ -256,6 +256,17 @@ credits:
   # is derived from whether they have any prior purchase).
   # Example: 50 matches a new user's first $50 of credits.
   first_payment_match_up_to: 0
+  # Signup credits granted the first time a billing target verifies a payment
+  # method through setup-mode checkout (POST /payments/setup) — the onboarding
+  # "Add Payment Method" step, which saves and verifies a card without charging
+  # it. Set to 0 to disable.
+  #
+  # Unlike initial_credits_for_standard_users (granted to everyone at account
+  # creation), this only pays out once a real card has been verified, so it
+  # can't be farmed by signing up repeatedly. Granted at most once per billing
+  # target, and idempotent across the webhook/front-channel race.
+  # Example: 25 gives a newly verified user 25 credits.
+  verification_credits: 0
 
 # Optional feature toggles
 enable_metrics: true # Enable Prometheus metrics endpoint

--- a/dwctl/src/api/handlers/payments.rs
+++ b/dwctl/src/api/handlers/payments.rs
@@ -238,6 +238,85 @@ pub async fn create_payment<P: PoolProvider>(
     .into_response())
 }
 
+/// Create a setup-mode checkout session for card verification.
+///
+/// Onboarding needs the user to prove a real payment method before we hand out
+/// signup credits and unlock the verified rate-limit tier, but making them buy
+/// credits to do it is a conversion killer. This creates a hosted checkout in
+/// setup mode: the card is verified and saved, nothing is charged.
+///
+/// The return trip is the same one top-ups take (`payment=success&session_id=...`
+/// → `PATCH /payments/{id}`); `process_payment_session` dispatches on the
+/// session's mode, so the SPA doesn't need a second confirmation endpoint.
+#[utoipa::path(
+    post,
+    path = "/payments/setup",
+    tag = "payments",
+    summary = "Create card verification session",
+    description = "Creates a setup-mode checkout session that verifies and saves a payment method without charging it. Returns a JSON object with the checkout URL for the client to navigate to. Confirm the result with PATCH /payments/{id}, as for a normal payment.",
+    responses(
+        (status = 200, description = "Setup session created successfully. Returns JSON with checkout URL.", body = inline(Object)),
+        (status = 403, description = "Caller cannot manage billing for the active organization"),
+        (status = 503, description = "No payment provider configured"),
+    ),
+    security(
+        ("BearerAuth" = []),
+        ("CookieAuth" = []),
+        ("X-Doubleword-User" = [])
+    )
+)]
+#[tracing::instrument(skip_all)]
+pub async fn create_payment_setup<P: PoolProvider>(State(state): State<AppState<P>>, user: CurrentUser) -> Result<Response, StatusCode> {
+    let config = state.current_config();
+    let payment_config = match config.payment.clone() {
+        Some(config) => config,
+        None => {
+            tracing::warn!("Card verification requested but no payment provider is configured");
+            let error_response = Json(json!({
+                "message": "Payment processing is currently unavailable. Please contact support."
+            }));
+            return Ok((StatusCode::SERVICE_UNAVAILABLE, error_response).into_response());
+        }
+    };
+
+    // Same return path as `create_payment`, so the SPA's existing
+    // `payment=success&session_id=...` handling covers verification too.
+    let origin = config.dashboard_url.clone();
+    let success_url = format!("{}/cost-management?payment=success&session_id={{CHECKOUT_SESSION_ID}}", origin);
+    let cancel_url = format!("{}/cost-management?payment=cancelled&session_id={{CHECKOUT_SESSION_ID}}", origin);
+
+    // Verification applies to the billing entity, not the human clicking the
+    // button: verifying as an org admin verifies the org, matching where the
+    // credits and the rate-limit tier actually live.
+    let mut conn = state.db.write().acquire().await.map_err(|e| {
+        tracing::error!("Failed to acquire database connection: {:?}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let target = resolve_billing_target(&user, &mut conn).await?;
+    drop(conn);
+
+    let payer = payment_providers::CheckoutPayer {
+        id: target.id,
+        email: target.email,
+        payment_provider_id: target.payment_provider_id,
+    };
+
+    let provider = payment_providers::create_provider(payment_config);
+
+    let checkout_url = provider
+        .create_setup_checkout_session(&payer, &cancel_url, &success_url)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to create setup checkout session: {:?}", e);
+            StatusCode::from(e)
+        })?;
+
+    Ok(Json(json!({
+        "url": checkout_url
+    }))
+    .into_response())
+}
+
 /// Process a payment
 /// This endpoint allows the frontend to trigger payment processing for a specific payment ID.
 /// Useful as a fallback when webhooks fail or for immediate payment confirmation.
@@ -1675,5 +1754,212 @@ mod tests {
             .unwrap();
         assert_eq!(user_row.auto_topup_amount, None);
         assert_eq!(user_row.auto_topup_threshold, None);
+    }
+
+    /// Build an app exposing the two endpoints the onboarding verification round
+    /// trip uses, and a config granting `verification_credits` on success.
+    fn setup_flow_config(verification_credits: Decimal) -> crate::config::Config {
+        let mut config = create_test_config();
+        config.payment = Some(PaymentConfig::Dummy(DummyConfig {
+            amount: Decimal::new(100, 0),
+        }));
+        config.credits.verification_credits = verification_credits;
+        config
+    }
+
+    /// Pull the session id back out of the checkout URL, the way Stripe hands it
+    /// to the SPA via `?session_id=`.
+    fn session_id_from(checkout_url: &str) -> String {
+        let url = url::Url::parse(checkout_url).unwrap();
+        let query_pairs: std::collections::HashMap<_, _> = url.query_pairs().collect();
+        query_pairs.get("session_id").expect("session_id in return URL").to_string()
+    }
+
+    #[sqlx::test]
+    async fn test_payment_setup_returns_checkout_url(pool: PgPool) {
+        let state = crate::test::utils::create_test_app_state_with_config(pool.clone(), setup_flow_config(Decimal::ZERO)).await;
+        let user = crate::test::utils::create_test_user(&pool, crate::api::models::users::Role::StandardUser).await;
+        let auth_headers = crate::test::utils::add_auth_headers(&user);
+
+        let app = Router::new().route("/payments/setup", post(create_payment_setup)).with_state(state);
+        let server = TestServer::new(app).unwrap();
+
+        let mut request = server.post("/payments/setup");
+        for (key, value) in &auth_headers {
+            request = request.add_header(key.as_str(), value.as_str());
+        }
+        let response = request.await;
+
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        let url = body["url"].as_str().expect("Should contain checkout URL");
+
+        // The SPA's existing top-up return handling keys off these two params,
+        // which is why setup mode reuses them rather than inventing new ones.
+        assert!(url.contains("payment=success"), "URL should reuse the payment return marker");
+        assert!(url.contains("session_id="), "URL should carry the session id back");
+    }
+
+    #[sqlx::test]
+    async fn test_payment_setup_no_provider(pool: PgPool) {
+        let state = crate::test::utils::create_test_app_state_with_config(pool.clone(), create_test_config()).await;
+        let user = crate::test::utils::create_test_user(&pool, crate::api::models::users::Role::StandardUser).await;
+        let auth_headers = crate::test::utils::add_auth_headers(&user);
+
+        let app = Router::new().route("/payments/setup", post(create_payment_setup)).with_state(state);
+        let server = TestServer::new(app).unwrap();
+
+        let mut request = server.post("/payments/setup");
+        for (key, value) in &auth_headers {
+            request = request.add_header(key.as_str(), value.as_str());
+        }
+        request.await.assert_status(StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// The whole onboarding round trip: create the setup session, come back
+    /// through the same `PATCH /payments/{id}` a top-up uses, and end up
+    /// verified with signup credits but *no* purchase on the ledger.
+    #[sqlx::test]
+    async fn test_payment_setup_verifies_user_and_grants_signup_credits(pool: PgPool) {
+        let state = crate::test::utils::create_test_app_state_with_config(pool.clone(), setup_flow_config(Decimal::new(25, 0))).await;
+        let user = crate::test::utils::create_test_user(&pool, crate::api::models::users::Role::StandardUser).await;
+        let auth_headers = crate::test::utils::add_auth_headers(&user);
+
+        let app = Router::new()
+            .route("/payments/setup", post(create_payment_setup))
+            .route("/payments/{id}", patch(process_payment))
+            .with_state(state);
+        let server = TestServer::new(app).unwrap();
+
+        // Assert the "before" state so the test covers the transition, not just
+        // the end state.
+        let before = sqlx::query!("SELECT verified, payment_provider_id FROM users WHERE id = $1", user.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(!before.verified, "user starts unverified");
+        assert!(before.payment_provider_id.is_none());
+
+        let mut request = server.post("/payments/setup");
+        for (key, value) in &auth_headers {
+            request = request.add_header(key.as_str(), value.as_str());
+        }
+        let response = request.await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        let session_id = session_id_from(body["url"].as_str().unwrap());
+
+        let mut request = server.patch(&format!("/payments/{}", session_id));
+        for (key, value) in &auth_headers {
+            request = request.add_header(key.as_str(), value.as_str());
+        }
+        request.await.assert_status(StatusCode::OK);
+
+        let after = sqlx::query!("SELECT verified, payment_provider_id FROM users WHERE id = $1", user.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(after.verified, "verifying a card should clear the unverified tier");
+        assert!(after.payment_provider_id.is_some(), "customer ID should be persisted");
+
+        let grant: Option<Decimal> = sqlx::query_scalar!(
+            "SELECT amount FROM credits_transactions WHERE user_id = $1 AND source_id LIKE '%:verification-credits'",
+            user.id
+        )
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        assert_eq!(grant, Some(Decimal::new(25, 0)), "signup credits should be granted");
+
+        // Nothing was charged, so nothing may look like a purchase.
+        let purchases: Option<i64> = sqlx::query_scalar!(
+            "SELECT COUNT(*) FROM credits_transactions WHERE user_id = $1 AND transaction_type = 'purchase'",
+            user.id
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(purchases, Some(0), "setup mode must not record a purchase");
+    }
+
+    /// The SPA's front-channel PATCH races the provider webhook; both call the
+    /// same code path, so replaying it must not pay out twice.
+    #[sqlx::test]
+    async fn test_payment_setup_processing_is_idempotent(pool: PgPool) {
+        let state = crate::test::utils::create_test_app_state_with_config(pool.clone(), setup_flow_config(Decimal::new(25, 0))).await;
+        let user = crate::test::utils::create_test_user(&pool, crate::api::models::users::Role::StandardUser).await;
+        let auth_headers = crate::test::utils::add_auth_headers(&user);
+
+        let app = Router::new()
+            .route("/payments/setup", post(create_payment_setup))
+            .route("/payments/{id}", patch(process_payment))
+            .with_state(state);
+        let server = TestServer::new(app).unwrap();
+
+        let mut request = server.post("/payments/setup");
+        for (key, value) in &auth_headers {
+            request = request.add_header(key.as_str(), value.as_str());
+        }
+        let response = request.await;
+        let body: serde_json::Value = response.json();
+        let session_id = session_id_from(body["url"].as_str().unwrap());
+
+        for _ in 0..3 {
+            let mut request = server.patch(&format!("/payments/{}", session_id));
+            for (key, value) in &auth_headers {
+                request = request.add_header(key.as_str(), value.as_str());
+            }
+            request.await.assert_status(StatusCode::OK);
+        }
+
+        let count: Option<i64> = sqlx::query_scalar!(
+            "SELECT COUNT(*) FROM credits_transactions WHERE user_id = $1 AND source_id LIKE '%:verification-credits'",
+            user.id
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, Some(1), "replaying the return must not double-grant");
+    }
+
+    #[sqlx::test]
+    async fn test_payment_setup_without_verification_credits_still_verifies(pool: PgPool) {
+        let state = crate::test::utils::create_test_app_state_with_config(pool.clone(), setup_flow_config(Decimal::ZERO)).await;
+        let user = crate::test::utils::create_test_user(&pool, crate::api::models::users::Role::StandardUser).await;
+        let auth_headers = crate::test::utils::add_auth_headers(&user);
+
+        let app = Router::new()
+            .route("/payments/setup", post(create_payment_setup))
+            .route("/payments/{id}", patch(process_payment))
+            .with_state(state);
+        let server = TestServer::new(app).unwrap();
+
+        let mut request = server.post("/payments/setup");
+        for (key, value) in &auth_headers {
+            request = request.add_header(key.as_str(), value.as_str());
+        }
+        let body: serde_json::Value = request.await.json();
+        let session_id = session_id_from(body["url"].as_str().unwrap());
+
+        let mut request = server.patch(&format!("/payments/{}", session_id));
+        for (key, value) in &auth_headers {
+            request = request.add_header(key.as_str(), value.as_str());
+        }
+        request.await.assert_status(StatusCode::OK);
+
+        let verified = sqlx::query_scalar!("SELECT verified FROM users WHERE id = $1", user.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(verified, "verification is independent of the credits promotion");
+
+        let count: Option<i64> = sqlx::query_scalar!(
+            "SELECT COUNT(*) FROM credits_transactions WHERE user_id = $1 AND source_id LIKE '%:verification-credits'",
+            user.id
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, Some(0), "zero credits configured means no grant row");
     }
 }

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -604,6 +604,12 @@ pub struct StripeConfig {
     /// Custom text displayed for terms of service acceptance during auto top-up setup.
     /// If not set, no terms of service acceptance text is shown.
     pub auto_topup_terms_of_service_text: Option<String>,
+    /// Custom text displayed for terms of service acceptance during onboarding
+    /// card verification (`POST /payments/setup`). Falls back to
+    /// `auto_topup_terms_of_service_text` when unset, since both are setup-mode
+    /// checkouts saving a card for later off-session use.
+    #[serde(default)]
+    pub setup_terms_of_service_text: Option<String>,
     /// Stripe tax code for auto top-up tax calculations (e.g. "txcd_10000000").
     /// If not set, falls back to the account-level default tax code in Stripe Tax settings.
     pub tax_code: Option<String>,
@@ -2293,6 +2299,17 @@ pub struct CreditsConfig {
     /// `purchase`), so existing paying customers are never matched.
     #[serde(default)]
     pub first_payment_match_up_to: rust_decimal::Decimal,
+    /// Signup credits granted the first time a billing target verifies a payment
+    /// method through setup-mode checkout (`POST /payments/setup`), in dollars.
+    /// 0 disables the grant.
+    ///
+    /// Distinct from `initial_credits_for_standard_users`, which lands at account
+    /// creation for everyone. This one is the onboarding carrot that only pays out
+    /// once a real card has been verified, so it is not farmable by signing up
+    /// repeatedly. Idempotent per checkout session, and granted at most once per
+    /// billing target (see `Credits::grant_verification_credits`).
+    #[serde(default)]
+    pub verification_credits: rust_decimal::Decimal,
 }
 
 impl Default for CreditsConfig {
@@ -2302,6 +2319,8 @@ impl Default for CreditsConfig {
             initial_credits_for_standard_users: rust_decimal::Decimal::ZERO,
             // Default to 0 (first-payment match promotion disabled)
             first_payment_match_up_to: rust_decimal::Decimal::ZERO,
+            // Default to 0 (no signup credits on card verification)
+            verification_credits: rust_decimal::Decimal::ZERO,
         }
     }
 }

--- a/dwctl/src/db/handlers/credits.rs
+++ b/dwctl/src/db/handlers/credits.rs
@@ -297,6 +297,77 @@ impl<'c> Credits<'c> {
         }
     }
 
+    /// Grant one-off signup credits to `payee` for verifying a payment method.
+    ///
+    /// `amount <= 0` disables the grant. Called from the setup-mode checkout
+    /// (`POST /payments/setup`) return path, where the user proved a real card
+    /// without being charged.
+    ///
+    /// Guarded twice, because both guards catch a different failure:
+    ///
+    /// * `source_id` is derived from the checkout session, so the front-channel
+    ///   `PATCH /payments/{id}` racing the Stripe webhook cannot double-grant -
+    ///   the second insert hits the `source_id` unique constraint and no-ops.
+    /// * The ledger scan rejects a payee who already has *any* verification
+    ///   grant, so re-running setup checkout with a second card (a new session
+    ///   id, therefore a new `source_id`) doesn't pay out again.
+    ///
+    /// Recorded as an `admin_grant` via `create_transaction`, so it fires the
+    /// balance-restored notify like any other credit.
+    #[instrument(skip(self), fields(payee = %abbrev_uuid(&payee), amount = %amount), err)]
+    pub async fn grant_verification_credits(&mut self, amount: Decimal, payee: UserId, setup_source_id: &str) -> Result<()> {
+        if amount <= Decimal::ZERO {
+            return Ok(());
+        }
+
+        let source_id = format!("{setup_source_id}:verification-credits");
+
+        // Already granted for a previous verification? The LIKE anchors on the
+        // suffix this method owns, so it only ever matches its own grants.
+        let already_granted = sqlx::query_scalar!(
+            r#"
+            SELECT EXISTS (
+                SELECT 1 FROM credits_transactions
+                WHERE user_id = $1
+                  AND transaction_type = 'admin_grant'
+                  AND source_id LIKE '%:verification-credits'
+            ) AS "already_granted!"
+            "#,
+            payee
+        )
+        .fetch_one(&mut *self.db)
+        .await?;
+
+        if already_granted {
+            trace!("Payee {} already received verification credits, skipping", payee);
+            return Ok(());
+        }
+
+        let request = CreditTransactionCreateDBRequest {
+            user_id: payee,
+            transaction_type: CreditTransactionType::AdminGrant,
+            amount,
+            source_id,
+            description: Some("Signup credits for verifying a payment method".to_string()),
+            fusillade_batch_id: None,
+            api_key_id: None,
+        };
+
+        match self.create_transaction(&request).await {
+            Ok(_) => {
+                trace!("Granted {} verification credits to payee {}", amount, payee);
+                Ok(())
+            }
+            // The webhook and the front-channel PATCH both landed: idempotent no-op.
+            Err(crate::db::errors::DbError::UniqueViolation { constraint, .. })
+                if constraint.as_deref() == Some("credits_transactions_source_id_unique") =>
+            {
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
     /// Send a pg_notify so the onwards config sync re-evaluates key
     /// eligibility. Only called on zero crossings (edge-triggered), so the
     /// resulting full reloads are rare.
@@ -2158,5 +2229,116 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(count, Some(1));
+    }
+
+    /// Amount granted as verification credits for a given setup session, if any.
+    async fn verification_grant_amount(pool: &PgPool, setup_source_id: &str) -> Option<Decimal> {
+        sqlx::query_scalar!(
+            "SELECT amount FROM credits_transactions WHERE source_id = $1",
+            format!("{setup_source_id}:verification-credits")
+        )
+        .fetch_optional(pool)
+        .await
+        .expect("query verification grant")
+    }
+
+    async fn verification_grant_count(pool: &PgPool, user: UserId) -> i64 {
+        sqlx::query_scalar!(
+            "SELECT COUNT(*) FROM credits_transactions WHERE user_id = $1 AND source_id LIKE '%:verification-credits'",
+            user
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .unwrap_or(0)
+    }
+
+    #[sqlx::test]
+    async fn test_verification_credits_granted_on_first_verification(pool: PgPool) {
+        let user = create_test_user(&pool).await;
+        let mut conn = pool.acquire().await.unwrap();
+        let mut credits = Credits::new(&mut conn);
+
+        assert_eq!(verification_grant_amount(&pool, "cs_setup_1").await, None);
+
+        credits
+            .grant_verification_credits(Decimal::from_str("25.0").unwrap(), user, "cs_setup_1")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            verification_grant_amount(&pool, "cs_setup_1").await,
+            Some(Decimal::from_str("25.0").unwrap())
+        );
+    }
+
+    #[sqlx::test]
+    async fn test_verification_credits_disabled_at_zero(pool: PgPool) {
+        let user = create_test_user(&pool).await;
+        let mut conn = pool.acquire().await.unwrap();
+        let mut credits = Credits::new(&mut conn);
+
+        credits.grant_verification_credits(Decimal::ZERO, user, "cs_setup_1").await.unwrap();
+
+        assert_eq!(verification_grant_amount(&pool, "cs_setup_1").await, None);
+    }
+
+    /// The webhook and the front-channel `PATCH /payments/{id}` both fulfil the
+    /// same session; the derived source_id must make the second one a no-op.
+    #[sqlx::test]
+    async fn test_verification_credits_idempotent_for_one_session(pool: PgPool) {
+        let user = create_test_user(&pool).await;
+        let mut conn = pool.acquire().await.unwrap();
+        let mut credits = Credits::new(&mut conn);
+
+        for _ in 0..3 {
+            credits
+                .grant_verification_credits(Decimal::from_str("25.0").unwrap(), user, "cs_setup_1")
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(verification_grant_count(&pool, user).await, 1);
+    }
+
+    /// Verifying a *second* card produces a different session id, so the
+    /// source_id constraint can't catch it - the ledger scan has to.
+    #[sqlx::test]
+    async fn test_verification_credits_granted_only_once_per_user(pool: PgPool) {
+        let user = create_test_user(&pool).await;
+        let mut conn = pool.acquire().await.unwrap();
+        let mut credits = Credits::new(&mut conn);
+
+        credits
+            .grant_verification_credits(Decimal::from_str("25.0").unwrap(), user, "cs_setup_1")
+            .await
+            .unwrap();
+        credits
+            .grant_verification_credits(Decimal::from_str("25.0").unwrap(), user, "cs_setup_2")
+            .await
+            .unwrap();
+
+        assert_eq!(verification_grant_count(&pool, user).await, 1);
+        assert_eq!(verification_grant_amount(&pool, "cs_setup_2").await, None);
+    }
+
+    #[sqlx::test]
+    async fn test_verification_credits_are_per_user(pool: PgPool) {
+        let first = create_test_user(&pool).await;
+        let second = create_test_user(&pool).await;
+        let mut conn = pool.acquire().await.unwrap();
+        let mut credits = Credits::new(&mut conn);
+
+        credits
+            .grant_verification_credits(Decimal::from_str("25.0").unwrap(), first, "cs_setup_1")
+            .await
+            .unwrap();
+        credits
+            .grant_verification_credits(Decimal::from_str("25.0").unwrap(), second, "cs_setup_2")
+            .await
+            .unwrap();
+
+        assert_eq!(verification_grant_count(&pool, first).await, 1);
+        assert_eq!(verification_grant_count(&pool, second).await, 1);
     }
 }

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1288,6 +1288,9 @@ pub async fn build_router(
         .route("/transactions", get(api::handlers::transactions::list_transactions))
         // Payment processing
         .route("/payments", post(api::handlers::payments::create_payment))
+        // Registered before `/payments/{id}` for clarity; axum matches the
+        // static segment first regardless, and the methods differ anyway.
+        .route("/payments/setup", post(api::handlers::payments::create_payment_setup))
         .route("/payments/{id}", patch(api::handlers::payments::process_payment))
         .route("/billing-portal", post(api::handlers::payments::create_billing_portal_session))
         .route("/auto-topup/enable", post(api::handlers::payments::enable_auto_topup))

--- a/dwctl/src/notifications.rs
+++ b/dwctl/src/notifications.rs
@@ -1483,6 +1483,14 @@ mod tests {
         async fn create_billing_portal_session(&self, _: &str, _: &str) -> crate::payment_providers::Result<String> {
             unimplemented!("not called by process_auto_topups")
         }
+        async fn create_setup_checkout_session(
+            &self,
+            _: &crate::payment_providers::CheckoutPayer,
+            _: &str,
+            _: &str,
+        ) -> crate::payment_providers::Result<String> {
+            unimplemented!("not called by process_auto_topups")
+        }
         async fn create_auto_topup_checkout_session(
             &self,
             _: &crate::payment_providers::CheckoutPayer,

--- a/dwctl/src/payment_providers/dummy.rs
+++ b/dwctl/src/payment_providers/dummy.rs
@@ -18,6 +18,10 @@ use crate::{
 #[cfg(test)]
 use crate::payment_providers::AutoTopupDeclineKind;
 
+/// Marks a dummy session as setup-mode (card verification, no charge), standing
+/// in for Stripe's `CheckoutSessionMode::Setup`.
+const DUMMY_SETUP_SESSION_PREFIX: &str = "dummy_setup_";
+
 /// Dummy payment provider that adds credits automatically
 pub struct DummyProvider {
     config: crate::config::DummyConfig,
@@ -107,6 +111,38 @@ impl PaymentProvider for DummyProvider {
             }
         }
 
+        // Setup-mode sessions carry their own prefix, mirroring the Stripe
+        // provider's dispatch on `CheckoutSessionMode`.
+        if let Some(rest) = session_id.strip_prefix(DUMMY_SETUP_SESSION_PREFIX) {
+            let target_id: crate::types::UserId = rest
+                .split('_')
+                .next()
+                .unwrap_or_default()
+                .parse()
+                .map_err(|e| PaymentError::InvalidData(format!("Invalid dummy setup target user ID: {}", e)))?;
+
+            {
+                let mut users = crate::db::handlers::users::Users::new(&mut conn);
+                if users.get_by_id(target_id).await?.is_none() {
+                    return Err(PaymentError::InvalidData("Setup session target user not found".to_string()));
+                }
+                users
+                    .set_payment_provider_id_if_empty(target_id, &format!("dummy_cus_{}", target_id))
+                    .await?;
+                users.set_verified(target_id).await?;
+            }
+
+            if let Err(e) = Credits::new(&mut conn)
+                .grant_verification_credits(credits_config.verification_credits, target_id, session_id)
+                .await
+            {
+                tracing::error!(session_id, target_id = %target_id, error = %e, "Verification credits grant failed");
+            }
+
+            tracing::info!("Successfully fulfilled dummy setup session {} for user {}", session_id, target_id);
+            return Ok(());
+        }
+
         // Get payment session details to extract user_id
         let payment_session = self.get_payment_session(session_id).await?;
 
@@ -185,6 +221,13 @@ impl PaymentProvider for DummyProvider {
     async fn process_webhook_event(&self, _db_pool: &PgPool, _event: &WebhookEvent, _credits_config: &CreditsConfig) -> Result<()> {
         // Dummy provider doesn't use webhooks
         Ok(())
+    }
+
+    async fn create_setup_checkout_session(&self, payer: &CheckoutPayer, _cancel_url: &str, success_url: &str) -> Result<String> {
+        // Distinct prefix from the payment/auto-topup sessions so
+        // `process_payment_session` can dispatch on it.
+        let session_id = format!("{}{}_{}", DUMMY_SETUP_SESSION_PREFIX, payer.id, uuid::Uuid::new_v4());
+        Ok(success_url.replace("{CHECKOUT_SESSION_ID}", &session_id))
     }
 
     async fn create_auto_topup_checkout_session(&self, payer: &CheckoutPayer, _cancel_url: &str, success_url: &str) -> Result<String> {

--- a/dwctl/src/payment_providers/mod.rs
+++ b/dwctl/src/payment_providers/mod.rs
@@ -166,10 +166,33 @@ pub trait PaymentProvider: Send + Sync {
     /// Fetches the payment session from the provider and returns validated details.
     async fn get_payment_session(&self, session_id: &str) -> Result<PaymentSession>;
 
-    /// Process a completed payment session
+    /// Create a setup-mode checkout session that verifies and saves a payment
+    /// method without charging it.
+    ///
+    /// Used by onboarding's "Add Payment Method" step: the user proves a real
+    /// card (and clears the unverified rate-limit tier) without having to buy
+    /// credits first. Returns the hosted checkout URL.
+    ///
+    /// Distinct from `create_auto_topup_checkout_session`, which is also
+    /// setup-mode but carries auto-top-up-specific consent copy and is only
+    /// reachable from the auto-top-up flow.
+    ///
+    /// # Arguments
+    /// * `payer` - The billing target being verified (individual or org)
+    /// * `cancel_url` - URL to redirect to if the user cancels
+    /// * `success_url` - URL to redirect to on success
+    async fn create_setup_checkout_session(&self, payer: &CheckoutPayer, cancel_url: &str, success_url: &str) -> Result<String>;
+
+    /// Process a completed checkout session
     ///
     /// This is idempotent - calling multiple times with the same session_id
     /// should not create duplicate transactions.
+    ///
+    /// Handles both checkout modes, dispatching on the session the provider
+    /// fetches: `payment` sessions credit the account, `setup` sessions save the
+    /// verified payment method and grant signup credits. The caller (the
+    /// `PATCH /payments/{id}` front channel and the webhook path alike) does not
+    /// know which mode a session id belongs to, so the dispatch lives here.
     ///
     /// `credits_config` carries credit-system settings (e.g. the first-payment
     /// match promotion) applied as part of processing, so the provider can act on

--- a/dwctl/src/payment_providers/stripe.rs
+++ b/dwctl/src/payment_providers/stripe.rs
@@ -176,6 +176,196 @@ impl StripeProvider {
                 PaymentError::ProviderApi(e.to_string())
             })
     }
+
+    /// Retrieve a session with the expansions both checkout modes need.
+    ///
+    /// `process_payment_session` doesn't know the mode until it has the session,
+    /// so it fetches once with the union of the expansions rather than paying a
+    /// second Stripe round trip after dispatching. Stripe ignores expansions that
+    /// don't apply to the session's mode.
+    async fn get_session_for_processing(&self, session_id: &str) -> Result<stripe_checkout::CheckoutSession> {
+        let session_id: CheckoutSessionId = session_id
+            .parse()
+            .map_err(|_| PaymentError::InvalidData("Invalid Stripe session ID".to_string()))?;
+
+        RetrieveCheckoutSession::new(session_id)
+            .expand(vec![
+                "line_items".to_string(),
+                "setup_intent".to_string(),
+                "setup_intent.payment_method".to_string(),
+            ])
+            .send(&self.client)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to retrieve Stripe checkout session: {:?}", e);
+                PaymentError::ProviderApi(e.to_string())
+            })
+    }
+
+    /// Fulfil a completed `setup`-mode session: save the verified card, mark the
+    /// billing target verified, and pay out signup credits.
+    ///
+    /// No money moved, so there is no purchase to record - the only ledger entry
+    /// is the (optional, once-per-target) verification grant.
+    async fn fulfil_setup_session(
+        &self,
+        conn: &mut sqlx::PgConnection,
+        session: &stripe_checkout::CheckoutSession,
+        session_id: &str,
+        credits_config: &crate::config::CreditsConfig,
+    ) -> Result<()> {
+        if session.status != Some(CheckoutSessionStatus::Complete) {
+            tracing::trace!("Setup session {} is not complete yet, skipping", session_id);
+            return Err(PaymentError::PaymentNotCompleted);
+        }
+
+        // Who was being verified. Set from `payer.id` at creation, i.e. the
+        // resolved billing target (the org when acting as an org, else self).
+        let target_id: UserId = session
+            .client_reference_id
+            .as_deref()
+            .ok_or_else(|| {
+                tracing::error!("Setup session {} missing client_reference_id", session_id);
+                PaymentError::InvalidData("Missing client_reference_id".to_string())
+            })?
+            .parse()
+            .map_err(|e| {
+                tracing::error!("Failed to parse setup session target ID: {:?}", e);
+                PaymentError::InvalidData(format!("Invalid target user ID: {}", e))
+            })?;
+
+        let customer_id = match &session.customer {
+            Some(stripe_types::Expandable::Id(id)) => Some(id.to_string()),
+            Some(stripe_types::Expandable::Object(c)) => Some(c.id.to_string()),
+            None => None,
+        };
+
+        let setup_intent = match &session.setup_intent {
+            Some(stripe_types::Expandable::Object(si)) => si.as_ref(),
+            _ => {
+                tracing::error!("Setup session {} has no expanded setup_intent", session_id);
+                return Err(PaymentError::InvalidData("Setup intent not found or not expanded".to_string()));
+            }
+        };
+
+        // A complete session whose SetupIntent didn't succeed means the card was
+        // not actually verified - never treat that as proof of payment ability.
+        if setup_intent.status.as_str() != "succeeded" {
+            tracing::warn!(
+                session_id,
+                status = setup_intent.status.as_str(),
+                "Setup session completed but the SetupIntent did not succeed"
+            );
+            return Err(PaymentError::InvalidData("Payment method setup failed".to_string()));
+        }
+
+        // Checkout attaches the payment method but doesn't make it the default;
+        // auto top-up charges look it up via invoice_settings, so set it here.
+        // Best-effort: the card is verified either way, and
+        // `get_default_payment_method` falls back to listing attached methods.
+        if let (Some(cust_id), Some(pm)) = (&customer_id, &setup_intent.payment_method) {
+            let pm_id = pm.id().to_string();
+            let mut invoice_settings = stripe_core::customer::UpdateCustomerInvoiceSettings::new();
+            invoice_settings.default_payment_method = Some(pm_id.clone());
+
+            if let Err(e) = stripe_core::customer::UpdateCustomer::new(cust_id.as_str())
+                .invoice_settings(invoice_settings)
+                .send(&self.client)
+                .await
+            {
+                tracing::warn!("Failed to set default payment method {} on customer {}: {:?}", pm_id, cust_id, e);
+            }
+        }
+
+        {
+            let mut users = crate::db::handlers::users::Users::new(&mut *conn);
+
+            if users.get_by_id(target_id).await?.is_none() {
+                tracing::error!(
+                    "Target user {} not found for setup session {}. This indicates a data integrity issue.",
+                    target_id,
+                    session_id
+                );
+                return Err(PaymentError::InvalidData("Setup session target user not found".to_string()));
+            }
+
+            // Stripe may have created the customer during checkout; persist it so
+            // the billing portal and auto top-up can find it later.
+            if let Some(ref provider_id) = customer_id
+                && users.set_payment_provider_id_if_empty(target_id, provider_id).await?
+            {
+                tracing::debug!("Saved newly created stripe ID {} for user ID {}", provider_id, target_id);
+            }
+
+            // A verified card clears the unverified rate-limit tier in onwards,
+            // same as a completed purchase does.
+            users.set_verified(target_id).await?;
+        }
+
+        // Signup credits. Best-effort by the same reasoning as the first-payment
+        // match: verification is the thing that must stick, and a failed freebie
+        // is not worth undoing it. This path isn't retried once verification has
+        // landed, so the error log is the signal to grant manually.
+        if let Err(e) = Credits::new(&mut *conn)
+            .grant_verification_credits(credits_config.verification_credits, target_id, session_id)
+            .await
+        {
+            tracing::error!(
+                session_id,
+                target_id = %target_id,
+                error = %e,
+                "Verification credits grant failed; card verification unaffected, grant manually if needed"
+            );
+        }
+
+        tracing::debug!("Successfully fulfilled setup session {} for user {}", session_id, target_id);
+        Ok(())
+    }
+}
+
+/// Parse a retrieved `payment`-mode checkout session into a `PaymentSession`.
+///
+/// Expects `line_items` expanded (falls back to the session-level subtotal).
+fn parse_payment_session(checkout_session: &stripe_checkout::CheckoutSession) -> Result<PaymentSession> {
+    // Parse creditor ID from client_reference_id
+    let creditor_id: UserId = checkout_session
+        .client_reference_id
+        .as_deref()
+        .ok_or_else(|| {
+            tracing::error!("Checkout session missing client_reference_id");
+            PaymentError::InvalidData("Missing client_reference_id".to_string())
+        })?
+        .parse()
+        .map_err(|e| {
+            tracing::error!("Failed to parse creditor ID: {:?}", e);
+            PaymentError::InvalidData(format!("Invalid creditor user ID: {}", e))
+        })?;
+
+    // Parse creditee ID from metadata, or use creditor_id if not present (self-payment)
+    let creditee_id: UserId = checkout_session
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("creditee_id"))
+        .map(|s| s.parse())
+        .transpose()
+        .map_err(|e| {
+            tracing::error!("Failed to parse creditee ID: {:?}", e);
+            PaymentError::InvalidData(format!("Invalid creditee user ID: {}", e))
+        })?
+        .unwrap_or(creditor_id);
+
+    let price = pretax_credit_cents(checkout_session).ok_or_else(|| {
+        tracing::error!("Checkout session missing both line_items and amount_subtotal");
+        PaymentError::InvalidData("Missing payment amount".to_string())
+    })? / 100; // Convert cents to dollars
+
+    Ok(PaymentSession {
+        creditee_id,
+        amount: Decimal::from(price),
+        is_paid: checkout_session.payment_status == CheckoutSessionPaymentStatus::Paid,
+        creditor_id,
+        payment_provider_id: checkout_session.customer.as_ref().map(|c| c.id().to_string()),
+    })
 }
 
 /// Pre-tax amount (in cents) to credit for a completed checkout session.
@@ -291,45 +481,7 @@ impl PaymentProvider for StripeProvider {
                 PaymentError::ProviderApi(e.to_string())
             })?;
 
-        // Parse creditor ID from client_reference_id
-        let creditor_id: UserId = checkout_session
-            .client_reference_id
-            .as_deref()
-            .ok_or_else(|| {
-                tracing::error!("Checkout session missing client_reference_id");
-                PaymentError::InvalidData("Missing client_reference_id".to_string())
-            })?
-            .parse()
-            .map_err(|e| {
-                tracing::error!("Failed to parse creditor ID: {:?}", e);
-                PaymentError::InvalidData(format!("Invalid creditor user ID: {}", e))
-            })?;
-
-        // Parse creditee ID from metadata, or use creditor_id if not present (self-payment)
-        let creditee_id: UserId = checkout_session
-            .metadata
-            .as_ref()
-            .and_then(|m| m.get("creditee_id"))
-            .map(|s| s.parse())
-            .transpose()
-            .map_err(|e| {
-                tracing::error!("Failed to parse creditee ID: {:?}", e);
-                PaymentError::InvalidData(format!("Invalid creditee user ID: {}", e))
-            })?
-            .unwrap_or(creditor_id);
-
-        let price = pretax_credit_cents(&checkout_session).ok_or_else(|| {
-            tracing::error!("Checkout session missing both line_items and amount_subtotal");
-            PaymentError::InvalidData("Missing payment amount".to_string())
-        })? / 100; // Convert cents to dollars
-
-        Ok(PaymentSession {
-            creditee_id,
-            amount: Decimal::from(price),
-            is_paid: checkout_session.payment_status == CheckoutSessionPaymentStatus::Paid,
-            creditor_id,
-            payment_provider_id: checkout_session.customer.as_ref().map(|c| c.id().to_string()),
-        })
+        parse_payment_session(&checkout_session)
     }
 
     async fn process_payment_session(
@@ -352,8 +504,17 @@ impl PaymentProvider for StripeProvider {
             }
         }
 
-        // Get payment session details
-        let payment_session = self.get_payment_session(session_id).await?;
+        // One retrieve, then dispatch on mode. Callers hand us a bare session id
+        // (the front-channel `PATCH /payments/{id}` and `checkout.session.completed`
+        // webhooks alike) and cannot tell a top-up from a card verification, so the
+        // mode has to be read off the session itself.
+        let session = self.get_session_for_processing(session_id).await?;
+
+        if session.mode == CheckoutSessionMode::Setup {
+            return self.fulfil_setup_session(&mut conn, &session, session_id, credits_config).await;
+        }
+
+        let payment_session = parse_payment_session(&session)?;
 
         // Verify payment status
         if !payment_session.is_paid {
@@ -521,6 +682,80 @@ impl PaymentProvider for StripeProvider {
 
         // Use the existing process_payment_session method
         self.process_payment_session(db_pool, session_id, credits_config).await
+    }
+
+    async fn create_setup_checkout_session(&self, payer: &CheckoutPayer, cancel_url: &str, success_url: &str) -> Result<String> {
+        let mut checkout_params = CreateCheckoutSession::new()
+            .cancel_url(cancel_url)
+            .success_url(success_url)
+            // Read back as the billing target in `fulfil_setup_session`.
+            .client_reference_id(payer.id.to_string())
+            .mode(CheckoutSessionMode::Setup)
+            .ui_mode(CheckoutSessionUiMode::HostedPage)
+            // Collected here rather than later: automatic tax on the first real
+            // top-up needs an address on the customer, and the billing portal
+            // detour to add one is exactly the onboarding friction this removes.
+            .tax_id_collection(CreateCheckoutSessionTaxIdCollection::new(true))
+            .name_collection(CreateCheckoutSessionNameCollection {
+                business: Some(CreateCheckoutSessionNameCollectionBusiness::new(true)),
+                individual: None,
+            })
+            .consent_collection(CreateCheckoutSessionConsentCollection {
+                terms_of_service: Some(CreateCheckoutSessionConsentCollectionTermsOfService::Required),
+                payment_method_reuse_agreement: Some(CreateCheckoutSessionConsentCollectionPaymentMethodReuseAgreement::new(
+                    CreateCheckoutSessionConsentCollectionPaymentMethodReuseAgreementPosition::Auto,
+                )),
+                promotions: None,
+            })
+            .custom_text(CreateCheckoutSessionCustomText {
+                terms_of_service_acceptance: self
+                    .config
+                    .setup_terms_of_service_text
+                    .as_ref()
+                    .or(self.config.auto_topup_terms_of_service_text.as_ref())
+                    .map(CustomTextPositionParam::new),
+                submit: Some(CustomTextPositionParam::new("Verify payment method")),
+                after_submit: None,
+                shipping_address: None,
+            })
+            .payment_method_types(vec![
+                CreateCheckoutSessionPaymentMethodTypes::Card,
+                CreateCheckoutSessionPaymentMethodTypes::Link,
+                CreateCheckoutSessionPaymentMethodTypes::SepaDebit,
+            ])
+            .setup_intent_data(CreateCheckoutSessionSetupIntentData {
+                description: Some("Payment method verification".to_string()),
+                metadata: None,
+                on_behalf_of: None,
+            });
+
+        if let Some(existing_id) = &payer.payment_provider_id {
+            tracing::debug!("Using existing Stripe customer ID {} for payer {}", existing_id, payer.id);
+            checkout_params = checkout_params
+                .customer(existing_id)
+                .customer_update(CreateCheckoutSessionCustomerUpdate {
+                    address: Some(CreateCheckoutSessionCustomerUpdateAddress::Auto),
+                    name: Some(CreateCheckoutSessionCustomerUpdateName::Auto),
+                    shipping: None,
+                })
+        } else {
+            tracing::debug!("No customer ID found for payer {}, Stripe will create one", payer.id);
+            checkout_params = checkout_params
+                .customer_email(&payer.email)
+                .customer_creation(CreateCheckoutSessionCustomerCreation::Always);
+        }
+
+        let checkout_session = checkout_params.send(&self.client).await.map_err(|e| {
+            tracing::error!("Failed to create Stripe setup checkout session: {:?}", e);
+            PaymentError::ProviderApi(e.to_string())
+        })?;
+
+        tracing::debug!("Created setup checkout session {} for payer {}", checkout_session.id, payer.id);
+
+        checkout_session.url.ok_or_else(|| {
+            tracing::error!("Setup checkout session missing URL");
+            PaymentError::ProviderApi("Checkout session missing URL".to_string())
+        })
     }
 
     async fn create_auto_topup_checkout_session(&self, payer: &CheckoutPayer, cancel_url: &str, success_url: &str) -> Result<String> {
@@ -824,6 +1059,7 @@ mod tests {
             webhook_secret: "whsec_fake".to_string(),
             enable_invoice_creation: false,
             auto_topup_terms_of_service_text: None,
+            setup_terms_of_service_text: None,
             tax_code: None,
         };
         let provider = StripeProvider::from(config);
@@ -842,6 +1078,7 @@ mod tests {
             webhook_secret: "whsec_fake".to_string(),
             enable_invoice_creation: true,
             auto_topup_terms_of_service_text: None,
+            setup_terms_of_service_text: None,
             tax_code: None,
         };
         let provider = StripeProvider::from(config);
@@ -907,6 +1144,7 @@ mod tests {
             webhook_secret: "whsec_fake".to_string(),
             enable_invoice_creation: false,
             auto_topup_terms_of_service_text: None,
+            setup_terms_of_service_text: None,
             tax_code: None,
         };
         let provider = StripeProvider::from(config);


### PR DESCRIPTION
## Why

Onboarding wants a **verified payment method** before it hands out signup credits and unlocks the verified rate-limit tier — but the only route to `users.verified` today is actually buying credits. Asking users to pay before they've sent a single request is a conversion killer, and it's the blocker under the onboarding ZDR flow (which gates on verification).

Stripe already supports exactly this: a **setup-mode** Checkout Session verifies and saves a card without charging it. We build one of these for auto top-up, but that path carries auto-top-up consent copy, hardcodes its own return URL, and isn't reachable from onboarding.

Unblocks doublewordai/app-doubleword-private#162, which is otherwise complete and green but calls a `POST /admin/api/v1/payments/setup` that didn't exist.

## What

**`POST /admin/api/v1/payments/setup`** — creates a setup-mode hosted Checkout Session for the resolved billing target (the org when acting as an org admin, else self, via the existing `resolve_billing_target`). Returns `{ "url": ... }` on the same `?payment=success&session_id=...` return URL a top-up uses, so the SPA's existing return handling covers it.

**`process_payment_session` now dispatches on checkout mode.** The return trip hands us a bare session id — the SPA can't tell a top-up from a verification, and Stripe fires `checkout.session.completed` for both. Rather than add a second confirmation endpoint, the provider reads the mode off the session it already has to fetch. One retrieve, expanded for both modes.

> Side effect: this fixes existing noise. A completed **auto top-up** setup session already reached this code path via webhook and failed on `"Missing payment amount"`.

**Setup sessions** save the verified card as the customer default, persist the Stripe customer id, `set_verified` the target, and grant the new `credits.verification_credits`. No purchase row is written — no money moved.

## The double guard on signup credits

`grant_verification_credits` is guarded twice, because each guard catches something the other can't:

| Guard | Catches |
|---|---|
| session-derived `source_id` | webhook racing the front-channel `PATCH /payments/{id}` on the **same** session |
| ledger scan for a prior grant | verifying a **second** card — new session, new `source_id`, so the constraint can't see it |

## Config

Both new settings default to `0`/`None`, so **this is inert until configured**:

- `credits.verification_credits` — signup credits on first verification. Distinct from `initial_credits_for_standard_users`, which lands at account creation for everyone; this one only pays out behind a real card, so it isn't farmable by signing up repeatedly.
- `payment.stripe.setup_terms_of_service_text` — ToS copy for the verification checkout; falls back to `auto_topup_terms_of_service_text`.

## Test plan

- [x] `cargo test -p dwctl` — **1935 passed, 0 failed**
- [x] `just lint rust` — clean (fmt, clippy, ZDR payload guard, `sqlx prepare --check`)
- [x] 9 new tests: full round trip (create → `PATCH` → verified + credits + **no** purchase row), idempotent replay, zero-credits still verifies, no-provider 503, and 5 unit tests on the grant's two guards
- [ ] End-to-end against real Stripe test mode alongside app-doubleword-private#162

## Note for review

`create_auto_topup_checkout` and `process_auto_topup` (`/auto-topup/checkout`, `/auto-topup/{id}`) are handlers that exist and are tested but are **not registered in `lib.rs`** — they're unreachable in production. Pre-existing, untouched here, but worth a follow-up decision: wire them up or delete them.