### PR TITLE
fix(keystore): enable TLS for Redis connections

### DIFF
--- a/.github/scripts/test-local-rust-workspace.sh
+++ b/.github/scripts/test-local-rust-workspace.sh
@@ -74,6 +74,34 @@ local_dependencies = {
     "fusillade-arsenal/Cargo.toml": {"fusillade-core": "../fusillade-core"},
 }
 
+dwctl_dependencies = tomllib.loads((root / "dwctl/Cargo.toml").read_text())[
+    "dependencies"
+]
+redis_dependency = dwctl_dependencies.get("redis")
+if not isinstance(redis_dependency, dict):
+    raise SystemExit(
+        "dwctl must declare redis directly so TLS support is explicit"
+    )
+if redis_dependency.get("default-features") is not False:
+    raise SystemExit("dwctl's redis dependency must disable unused default features")
+if "tokio-rustls-comp" not in redis_dependency.get("features", []):
+    raise SystemExit(
+        "dwctl's redis dependency must enable tokio-rustls-comp for rediss URLs"
+    )
+
+lockfile = tomllib.loads((root / "Cargo.lock").read_text())
+resolved_redis_packages = [
+    package for package in lockfile["package"] if package["name"] == "redis"
+]
+if len(resolved_redis_packages) != 1:
+    resolved_versions = sorted(
+        package["version"] for package in resolved_redis_packages
+    )
+    raise SystemExit(
+        "workspace must resolve exactly one redis package so deadpool-redis "
+        f"inherits TLS support; resolved versions: {resolved_versions}"
+    )
+
 onwards_manifest = tomllib.loads((root / "onwards/Cargo.toml").read_text())
 if "fusillade" in onwards_manifest.get("dependencies", {}):
     raise SystemExit("published Onwards must not depend on Fusillade")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1948,6 +1948,7 @@ dependencies = [
  "postgresql_embedded",
  "prometheus",
  "rand 0.10.1",
+ "redis",
  "reqwest 0.13.3",
  "rust-embed",
  "rust_decimal",
@@ -3234,7 +3235,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -4073,10 +4074,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4377,6 +4378,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -5257,8 +5264,13 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "ryu",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "url",
 ]
@@ -5374,7 +5386,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5729,14 +5741,36 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5761,10 +5795,10 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -5887,6 +5921,19 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -6877,7 +6924,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -114,6 +114,9 @@ hickory-resolver = { version = "0.26", default-features = false, features = [
 aes-gcm = "0.10.3"
 # Redis-backed keystore for zero-data-retention flex request keys.
 deadpool-redis = "0.18"
+redis = { version = "0.27", default-features = false, features = [
+  "tokio-rustls-comp",
+] }
 paste = "1.0"
 serde_with = "3.14.1"
 rust_decimal = { version = "1.38.0", features = ["serde"] }


### PR DESCRIPTION
## Summary

- enable the Redis Tokio/Rustls transport required by `rediss://` connection URLs
- keep the client dependency minimal by disabling unrelated default features
- add a workspace contract check so Redis TLS cannot be removed accidentally

## Why

The keystore accepts secure Redis URLs, but the application binary was built without the corresponding TLS transport feature and rejected them during pool creation.

## Verification

- `cargo check -p dwctl` against an isolated, fully migrated PostgreSQL database
- `cargo test -p dwctl keystore::tests --lib` (6 passed)
- `bash .github/scripts/test-local-rust-workspace.sh`
- `cargo fmt --check --package dwctl`
- `cargo metadata --format-version 1 --locked`