### PR TITLE
feat(organizations): replace silent domain auto-join with join requests

### DIFF
--- a/.sqlx/query-16161654b04e7faa5eacd3f40e6a4fad922fc28f8d87cbdb8b124414446ed6d5.json
+++ b/.sqlx/query-16161654b04e7faa5eacd3f40e6a4fad922fc28f8d87cbdb8b124414446ed6d5.json
@@ -1,0 +1,71 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO user_organizations (user_id, organization_id, role, status)\n            VALUES ($1, $2, 'member', 'requested')\n            RETURNING id, user_id, organization_id, role, status, created_at,\n                      invite_email, invited_by, expires_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "organization_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "role",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "invite_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "invited_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "16161654b04e7faa5eacd3f40e6a4fad922fc28f8d87cbdb8b124414446ed6d5"
+}

--- a/.sqlx/query-18d928222d0edea2620a5a5dc410655c1b64473af944437a291f4f59521a5193.json
+++ b/.sqlx/query-18d928222d0edea2620a5a5dc410655c1b64473af944437a291f4f59521a5193.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT uo.id, uo.user_id, uo.organization_id, uo.role, uo.status,\n                   uo.created_at, uo.invite_email, uo.invited_by, uo.expires_at\n            FROM user_organizations uo\n            INNER JOIN users u ON u.id = uo.user_id\n            WHERE uo.organization_id = $1\n              AND uo.status = 'requested'\n              AND u.is_deleted = false\n            ORDER BY uo.created_at ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "organization_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "role",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "invite_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "invited_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "18d928222d0edea2620a5a5dc410655c1b64473af944437a291f4f59521a5193"
+}

--- a/.sqlx/query-265b64ac28b648dc6e84527336163727d9f85a2ecc006f4f2ad5f0611f6f5604.json
+++ b/.sqlx/query-265b64ac28b648dc6e84527336163727d9f85a2ecc006f4f2ad5f0611f6f5604.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT uo.id, uo.user_id, uo.organization_id, uo.role, uo.status,\n                   uo.created_at, uo.invite_email, uo.invited_by, uo.expires_at\n            FROM user_organizations uo\n            LEFT JOIN users u ON u.id = uo.user_id\n            WHERE uo.organization_id = $1\n              AND uo.status <> 'requested'\n              AND (uo.user_id IS NULL OR u.is_deleted = false)\n            ORDER BY uo.status ASC, uo.created_at ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "organization_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "role",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "invite_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "invited_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "265b64ac28b648dc6e84527336163727d9f85a2ecc006f4f2ad5f0611f6f5604"
+}

--- a/.sqlx/query-35b903d04e51d26dd5b3fb186e7535374f93b8936ee03173e1b2977cd189b0dd.json
+++ b/.sqlx/query-35b903d04e51d26dd5b3fb186e7535374f93b8936ee03173e1b2977cd189b0dd.json
@@ -1,0 +1,31 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE user_organizations\n            SET invite_token_hash = $3, expires_at = $4\n            WHERE id = $1 AND organization_id = $2 AND status = 'pending'\n            RETURNING invite_email, role\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "invite_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "role",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      true,
+      false
+    ]
+  },
+  "hash": "35b903d04e51d26dd5b3fb186e7535374f93b8936ee03173e1b2977cd189b0dd"
+}

--- a/.sqlx/query-b1de8f7dfc6265775d22bb2810b24031530336534f762c1720577348da9a5111.json
+++ b/.sqlx/query-b1de8f7dfc6265775d22bb2810b24031530336534f762c1720577348da9a5111.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM user_organizations WHERE id = $1 AND organization_id = $2 AND status = 'requested'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b1de8f7dfc6265775d22bb2810b24031530336534f762c1720577348da9a5111"
+}

--- a/.sqlx/query-ce80db92f8e68afc56b9e69d9960f5683eacd808e3383836330019147a9f2831.json
+++ b/.sqlx/query-ce80db92f8e68afc56b9e69d9960f5683eacd808e3383836330019147a9f2831.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE user_organizations\n            SET status = 'active', role = $3\n            WHERE id = $1 AND organization_id = $2 AND status = 'requested'\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ce80db92f8e68afc56b9e69d9960f5683eacd808e3383836330019147a9f2831"
+}

--- a/dwctl/migrations/130_add_org_join_requests.sql
+++ b/dwctl/migrations/130_add_org_join_requests.sql
@@ -1,0 +1,36 @@
+-- Join requests: a user asking to join an organization, awaiting approval.
+--
+-- The mirror image of an invite, so it reuses the same membership lifecycle
+-- rather than getting its own table. `pending` already means "the org invited
+-- someone who hasn't accepted"; `requested` means "someone asked to join and
+-- the org hasn't decided". Both become `active` on acceptance, and both are
+-- already covered by the UNIQUE (user_id, organization_id) constraint, the
+-- membership-type trigger and the existing indexes.
+--
+-- This replaces silent auto-join. Until now, first login with a company email
+-- domain added the user straight into that domain's organization as a member
+-- (see auth::current_user), with no approval and no notice to either party.
+-- Anyone who could receive mail at the domain landed inside the org that owns
+-- the billing account. They now land in this table instead, and an owner or
+-- admin decides.
+--
+-- Auto-*creation* of an org for an unclaimed domain is unchanged and still
+-- happens; gating that needs domain ownership proof (DNS TXT), which is a
+-- separate piece of work.
+ALTER TABLE user_organizations
+    DROP CONSTRAINT IF EXISTS user_organizations_status_check;
+
+ALTER TABLE user_organizations
+    ADD CONSTRAINT user_organizations_status_check
+        CHECK (status IN ('active', 'pending', 'requested'));
+
+-- Owners/admins list these per organization; the existing
+-- idx_user_organizations_organization_id covers the whole table, so this
+-- partial index keeps the common "show me the queue" read cheap as membership
+-- grows.
+CREATE INDEX idx_user_organizations_requested
+    ON user_organizations(organization_id, created_at)
+    WHERE status = 'requested';
+
+COMMENT ON COLUMN user_organizations.status IS
+    'active = current member; pending = invited by the org, not yet accepted; requested = asked to join, awaiting approval.';

--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -984,7 +984,7 @@ pub async fn list_join_requests<P: PoolProvider>(
     ),
     request_body(content = ApproveJoinRequestRequest, description = "Optional role to grant; defaults to 'member'"),
     responses(
-        (status = 200, description = "Request approved"),
+        (status = 204, description = "Request approved"),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Join request not found"),
     ),

--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -4,9 +4,9 @@ use crate::{
     AppState,
     api::models::{
         organizations::{
-            AddMemberRequest, InviteDetailsResponse, InviteMemberRequest, InviteMemberResponse, ListOrganizationsQuery, OrganizationCreate,
-            OrganizationMemberResponse, OrganizationResponse, OrganizationUpdate, PendingEmailChangeResponse, SetActiveOrganizationRequest,
-            SetActiveOrganizationResponse, UpdateMemberRoleRequest,
+            AddMemberRequest, ApproveJoinRequestRequest, InviteDetailsResponse, InviteMemberRequest, InviteMemberResponse,
+            ListOrganizationsQuery, OrganizationCreate, OrganizationMemberResponse, OrganizationResponse, OrganizationUpdate,
+            PendingEmailChangeResponse, SetActiveOrganizationRequest, SetActiveOrganizationResponse, UpdateMemberRoleRequest,
         },
         pagination::PaginatedResponse,
         users::{CurrentUser, UserResponse},
@@ -819,6 +819,266 @@ pub async fn list_members<P: PoolProvider>(
         .collect();
 
     Ok(Json(members))
+}
+
+/// Re-send a pending organization invite
+#[utoipa::path(
+    post,
+    path = "/organizations/{id}/invites/{invite_id}/resend",
+    tag = "organizations",
+    summary = "Resend invite",
+    description = "Issue a fresh token for a pending invite and email it again. The previous link stops working. Requires owner/admin role or platform manager access.",
+    params(
+        ("id" = String, Path, description = "Organization ID"),
+        ("invite_id" = String, Path, description = "Invite (membership row) ID"),
+    ),
+    responses(
+        (status = 204, description = "Invite re-sent"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Pending invite not found"),
+    ),
+    security(("BearerAuth" = []), ("CookieAuth" = []), ("X-Doubleword-User" = [])),
+)]
+#[tracing::instrument(skip_all)]
+pub async fn resend_invite<P: PoolProvider>(
+    State(state): State<AppState<P>>,
+    Path((id, invite_id)): Path<(UserId, uuid::Uuid)>,
+    current_user: CurrentUser,
+) -> Result<StatusCode> {
+    let can_all = crate::auth::permissions::has_permission(&current_user, Resource::Organizations, Operation::UpdateAll);
+
+    let mut pool_conn = state.db.write().acquire().await.map_err(|e| Error::Database(e.into()))?;
+
+    if !can_all {
+        let can_org = can_manage_org_resource(&current_user, id, &mut pool_conn).await?;
+        if !can_org {
+            return Err(Error::InsufficientPermissions {
+                required: Permission::Allow(Resource::Organizations, Operation::UpdateOwn),
+                action: Operation::UpdateOwn,
+                resource: format!("Organization {id} invites"),
+            });
+        }
+    }
+
+    // A resend necessarily mints a new token: the original is only stored as a
+    // hash, so it can't be recovered to send again.
+    let token = crate::auth::password::generate_reset_token();
+    let token_hash = hash_invite_token(&token);
+    let expires_at = chrono::Utc::now() + Duration::days(7);
+
+    let mut org_repo = Organizations::new(&mut pool_conn);
+    let Some((email, role)) = org_repo.refresh_invite_token(id, invite_id, &token_hash, expires_at).await? else {
+        return Err(Error::NotFound {
+            resource: "Pending invite".to_string(),
+            id: format!("{invite_id} in organization {id}"),
+        });
+    };
+
+    let mut users_repo = Users::new(&mut pool_conn);
+    let org_user = users_repo.get_by_id(id).await?;
+    let org_name = org_user
+        .as_ref()
+        .and_then(|u| u.display_name.clone())
+        .unwrap_or_else(|| org_user.as_ref().map(|u| u.username.clone()).unwrap_or_default());
+
+    let sender = users_repo.get_by_id(current_user.id).await?;
+    let sender_name = sender
+        .as_ref()
+        .and_then(|u| u.display_name.clone())
+        .unwrap_or_else(|| sender.as_ref().map(|u| u.username.clone()).unwrap_or_default());
+
+    // The token is already rotated in the database. Treat a send failure as a
+    // warning rather than an error, matching `invite_member`: failing the
+    // request would imply nothing happened, when in fact the old link is now
+    // dead and the admin would need to resend anyway.
+    let config = state.current_config();
+    let invite_link = format!("{}/org-invite?token={}", config.dashboard_url.trim_end_matches('/'), token);
+    let email_service = EmailService::new(&config)?;
+    if let Err(e) = email_service
+        .send_org_invite_email(&email, &org_name, &sender_name, &role, &invite_link)
+        .await
+    {
+        tracing::warn!("Failed to re-send invite email to {email}: {e}");
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// List outstanding join requests for an organization
+#[utoipa::path(
+    get,
+    path = "/organizations/{id}/join-requests",
+    tag = "organizations",
+    summary = "List join requests",
+    description = "List users who have asked to join this organization and are awaiting a decision. Requires owner/admin role or platform manager access.",
+    params(("id" = String, Path, description = "Organization ID")),
+    responses(
+        (status = 200, description = "Outstanding join requests", body = [OrganizationMemberResponse]),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Organization not found"),
+    ),
+    security(("BearerAuth" = []), ("CookieAuth" = []), ("X-Doubleword-User" = [])),
+)]
+#[tracing::instrument(skip_all)]
+pub async fn list_join_requests<P: PoolProvider>(
+    State(state): State<AppState<P>>,
+    Path(id): Path<UserId>,
+    current_user: CurrentUser,
+) -> Result<Json<Vec<OrganizationMemberResponse>>> {
+    let can_all = crate::auth::permissions::has_permission(&current_user, Resource::Organizations, Operation::UpdateAll);
+
+    // Primary pool: a user's first login records their request, and an admin
+    // may well be looking at this queue moments later.
+    let mut pool_conn = state.db.write().acquire().await.map_err(|e| Error::Database(e.into()))?;
+
+    // Deliberately gated on *manage*, not read: the queue exposes the identities
+    // of people who share your email domain, which ordinary members shouldn't see.
+    if !can_all {
+        let can_org = can_manage_org_resource(&current_user, id, &mut pool_conn).await?;
+        if !can_org {
+            return Err(Error::InsufficientPermissions {
+                required: Permission::Allow(Resource::Organizations, Operation::UpdateOwn),
+                action: Operation::UpdateOwn,
+                resource: format!("Organization {id} join requests"),
+            });
+        }
+    }
+
+    let mut repo = Organizations::new(&mut pool_conn);
+    let requests = repo.list_join_requests(id).await?;
+
+    let user_ids: Vec<UserId> = requests.iter().filter_map(|m| m.user_id).collect();
+    let mut users_repo = Users::new(&mut pool_conn);
+    let user_map = users_repo.get_bulk(user_ids).await?;
+
+    let responses: Vec<OrganizationMemberResponse> = requests
+        .iter()
+        .filter_map(|m| {
+            let uid = m.user_id?;
+            user_map.get(&uid).map(|u| OrganizationMemberResponse {
+                id: m.id,
+                user: Some(UserResponse::from(u.clone())),
+                role: m.role.clone(),
+                status: m.status.clone(),
+                created_at: m.created_at,
+                invite_email: m.invite_email.clone(),
+                // A request carries no capability until it's approved.
+                can_manage_keys: false,
+            })
+        })
+        .collect();
+
+    Ok(Json(responses))
+}
+
+/// Approve a join request
+#[utoipa::path(
+    post,
+    path = "/organizations/{id}/join-requests/{request_id}/approve",
+    tag = "organizations",
+    summary = "Approve join request",
+    description = "Approve a pending join request, making the requester an active member. Requires owner/admin role or platform manager access.",
+    params(
+        ("id" = String, Path, description = "Organization ID"),
+        ("request_id" = String, Path, description = "Join request ID"),
+    ),
+    request_body(content = ApproveJoinRequestRequest, description = "Optional role to grant; defaults to 'member'"),
+    responses(
+        (status = 200, description = "Request approved"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Join request not found"),
+    ),
+    security(("BearerAuth" = []), ("CookieAuth" = []), ("X-Doubleword-User" = [])),
+)]
+#[tracing::instrument(skip_all)]
+pub async fn approve_join_request<P: PoolProvider>(
+    State(state): State<AppState<P>>,
+    Path((id, request_id)): Path<(UserId, uuid::Uuid)>,
+    current_user: CurrentUser,
+    body: Option<Json<ApproveJoinRequestRequest>>,
+) -> Result<StatusCode> {
+    let can_all = crate::auth::permissions::has_permission(&current_user, Resource::Organizations, Operation::UpdateAll);
+
+    let mut pool_conn = state.db.write().acquire().await.map_err(|e| Error::Database(e.into()))?;
+
+    if !can_all {
+        let can_org = can_manage_org_resource(&current_user, id, &mut pool_conn).await?;
+        if !can_org {
+            return Err(Error::InsufficientPermissions {
+                required: Permission::Allow(Resource::Organizations, Operation::UpdateOwn),
+                action: Operation::UpdateOwn,
+                resource: format!("Organization {id} join requests"),
+            });
+        }
+    }
+
+    let role = body.and_then(|b| b.0.role).unwrap_or_else(|| "member".to_string());
+    validate_role(&role)?;
+    // Approving straight to owner would let an admin promote past themselves,
+    // so the same guard as invites applies.
+    check_role_assignment_privilege(&current_user, id, &role, can_all, &mut pool_conn).await?;
+
+    let mut repo = Organizations::new(&mut pool_conn);
+    let approved = repo.approve_join_request(id, request_id, &role).await?;
+    if !approved {
+        return Err(Error::NotFound {
+            resource: "Join request".to_string(),
+            id: format!("{request_id} in organization {id}"),
+        });
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Decline a join request
+#[utoipa::path(
+    post,
+    path = "/organizations/{id}/join-requests/{request_id}/decline",
+    tag = "organizations",
+    summary = "Decline join request",
+    description = "Decline a pending join request. The requester may ask again later. Requires owner/admin role or platform manager access.",
+    params(
+        ("id" = String, Path, description = "Organization ID"),
+        ("request_id" = String, Path, description = "Join request ID"),
+    ),
+    responses(
+        (status = 204, description = "Request declined"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Join request not found"),
+    ),
+    security(("BearerAuth" = []), ("CookieAuth" = []), ("X-Doubleword-User" = [])),
+)]
+#[tracing::instrument(skip_all)]
+pub async fn decline_join_request<P: PoolProvider>(
+    State(state): State<AppState<P>>,
+    Path((id, request_id)): Path<(UserId, uuid::Uuid)>,
+    current_user: CurrentUser,
+) -> Result<StatusCode> {
+    let can_all = crate::auth::permissions::has_permission(&current_user, Resource::Organizations, Operation::UpdateAll);
+
+    let mut pool_conn = state.db.write().acquire().await.map_err(|e| Error::Database(e.into()))?;
+
+    if !can_all {
+        let can_org = can_manage_org_resource(&current_user, id, &mut pool_conn).await?;
+        if !can_org {
+            return Err(Error::InsufficientPermissions {
+                required: Permission::Allow(Resource::Organizations, Operation::UpdateOwn),
+                action: Operation::UpdateOwn,
+                resource: format!("Organization {id} join requests"),
+            });
+        }
+    }
+
+    let mut repo = Organizations::new(&mut pool_conn);
+    let declined = repo.decline_join_request(id, request_id).await?;
+    if !declined {
+        return Err(Error::NotFound {
+            resource: "Join request".to_string(),
+            id: format!("{request_id} in organization {id}"),
+        });
+    }
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Add a member to an organization
@@ -2115,6 +2375,218 @@ mod tests {
     }
 
     // ── Leave organization ────────────────────────────────────────────────
+
+    /// Resending necessarily rotates the token: the original is only stored as
+    /// a hash and can't be recovered, so the old link must stop working.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_resend_invite_rotates_the_token(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let owner = create_test_user(&pool, Role::StandardUser).await;
+        let owner_headers = add_auth_headers(&owner);
+
+        let resp = server
+            .post("/admin/api/v1/organizations")
+            .add_header(&owner_headers[0].0, &owner_headers[0].1)
+            .add_header(&owner_headers[1].0, &owner_headers[1].1)
+            .json(&json!({ "name": "resend-org", "email": "resend@example.com" }))
+            .await;
+        resp.assert_status(axum::http::StatusCode::CREATED);
+        let org_id = resp.json::<serde_json::Value>()["id"].as_str().unwrap().to_string();
+
+        let resp = server
+            .post(&format!("/admin/api/v1/organizations/{org_id}/invites"))
+            .add_header(&owner_headers[0].0, &owner_headers[0].1)
+            .add_header(&owner_headers[1].0, &owner_headers[1].1)
+            .json(&json!({ "email": "invitee@example.com", "role": "member" }))
+            .await;
+        resp.assert_status(axum::http::StatusCode::CREATED);
+        let invite_id = resp.json::<serde_json::Value>()["id"].as_str().unwrap().to_string();
+
+        let hash_before: Option<String> = sqlx::query_scalar!(
+            "SELECT invite_token_hash FROM user_organizations WHERE id = $1",
+            uuid::Uuid::parse_str(&invite_id).unwrap()
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let resp = server
+            .post(&format!("/admin/api/v1/organizations/{org_id}/invites/{invite_id}/resend"))
+            .add_header(&owner_headers[0].0, &owner_headers[0].1)
+            .add_header(&owner_headers[1].0, &owner_headers[1].1)
+            .await;
+        resp.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+        let hash_after: Option<String> = sqlx::query_scalar!(
+            "SELECT invite_token_hash FROM user_organizations WHERE id = $1",
+            uuid::Uuid::parse_str(&invite_id).unwrap()
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert!(hash_before.is_some() && hash_after.is_some());
+        assert_ne!(hash_before, hash_after, "the old invite link must stop working");
+    }
+
+    // ── Join requests ──────────────────────────────────────────────────────
+
+    /// Create an org owned by `owner` and park a join request from `joiner`.
+    async fn org_with_join_request(pool: &PgPool, owner_id: uuid::Uuid, joiner_id: uuid::Uuid) -> (uuid::Uuid, uuid::Uuid) {
+        let mut conn = pool.acquire().await.unwrap();
+        let mut repo = crate::db::handlers::Organizations::new(&mut conn);
+        let org = repo
+            .create(
+                &crate::db::models::organizations::OrganizationCreateDBRequest {
+                    name: format!("jr-{}", &owner_id.to_string()[..8]),
+                    email: format!("org-{}@example.com", &owner_id.to_string()[..8]),
+                    display_name: None,
+                    avatar_url: None,
+                    created_by: owner_id,
+                },
+                &[Role::StandardUser],
+            )
+            .await
+            .unwrap();
+        let request = repo.create_join_request(org.id, joiner_id).await.unwrap();
+        (org.id, request.id)
+    }
+
+    /// The queue names people who share your email domain, so it's gated on
+    /// managing the org — being a member of it isn't enough.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_join_requests_hidden_from_ordinary_members(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let owner = create_test_user(&pool, Role::StandardUser).await;
+        let joiner = create_test_user(&pool, Role::StandardUser).await;
+        let (org_id, _) = org_with_join_request(&pool, owner.id, joiner.id).await;
+
+        let member = create_test_user(&pool, Role::StandardUser).await;
+        {
+            let mut conn = pool.acquire().await.unwrap();
+            crate::db::handlers::Organizations::new(&mut conn)
+                .add_member(org_id, member.id, "member")
+                .await
+                .unwrap();
+        }
+        let member_headers = add_auth_headers(&member);
+
+        let resp = server
+            .get(&format!("/admin/api/v1/organizations/{org_id}/join-requests"))
+            .add_header(&member_headers[0].0, &member_headers[0].1)
+            .add_header(&member_headers[1].0, &member_headers[1].1)
+            .await;
+        resp.assert_status(axum::http::StatusCode::FORBIDDEN);
+
+        let owner_headers = add_auth_headers(&owner);
+        let resp = server
+            .get(&format!("/admin/api/v1/organizations/{org_id}/join-requests"))
+            .add_header(&owner_headers[0].0, &owner_headers[0].1)
+            .add_header(&owner_headers[1].0, &owner_headers[1].1)
+            .await;
+        resp.assert_status_ok();
+        assert_eq!(resp.json::<serde_json::Value>().as_array().unwrap().len(), 1);
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_approve_join_request_makes_an_active_member(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let owner = create_test_user(&pool, Role::StandardUser).await;
+        let joiner = create_test_user(&pool, Role::StandardUser).await;
+        let (org_id, request_id) = org_with_join_request(&pool, owner.id, joiner.id).await;
+        let owner_headers = add_auth_headers(&owner);
+
+        // Not a member while the request is outstanding.
+        {
+            let mut conn = pool.acquire().await.unwrap();
+            let role = crate::db::handlers::Organizations::new(&mut conn)
+                .get_user_org_role(joiner.id, org_id)
+                .await
+                .unwrap();
+            assert_eq!(role, None);
+        }
+
+        let resp = server
+            .post(&format!("/admin/api/v1/organizations/{org_id}/join-requests/{request_id}/approve"))
+            .add_header(&owner_headers[0].0, &owner_headers[0].1)
+            .add_header(&owner_headers[1].0, &owner_headers[1].1)
+            .await;
+        resp.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+        let mut conn = pool.acquire().await.unwrap();
+        let mut repo = crate::db::handlers::Organizations::new(&mut conn);
+        assert_eq!(repo.get_user_org_role(joiner.id, org_id).await.unwrap(), Some("member".to_string()));
+        assert!(repo.list_join_requests(org_id).await.unwrap().is_empty(), "queue is cleared");
+
+        // Approving twice must not double-add.
+        let resp = server
+            .post(&format!("/admin/api/v1/organizations/{org_id}/join-requests/{request_id}/approve"))
+            .add_header(&owner_headers[0].0, &owner_headers[0].1)
+            .add_header(&owner_headers[1].0, &owner_headers[1].1)
+            .await;
+        resp.assert_status(axum::http::StatusCode::NOT_FOUND);
+    }
+
+    /// Declining removes the row rather than tombstoning it, so the user can
+    /// ask again - a permanent record would silently block them forever via
+    /// the unique constraint on (user_id, organization_id).
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_decline_join_request_allows_asking_again(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let owner = create_test_user(&pool, Role::StandardUser).await;
+        let joiner = create_test_user(&pool, Role::StandardUser).await;
+        let (org_id, request_id) = org_with_join_request(&pool, owner.id, joiner.id).await;
+        let owner_headers = add_auth_headers(&owner);
+
+        let resp = server
+            .post(&format!("/admin/api/v1/organizations/{org_id}/join-requests/{request_id}/decline"))
+            .add_header(&owner_headers[0].0, &owner_headers[0].1)
+            .add_header(&owner_headers[1].0, &owner_headers[1].1)
+            .await;
+        resp.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+        let mut conn = pool.acquire().await.unwrap();
+        let mut repo = crate::db::handlers::Organizations::new(&mut conn);
+        assert!(repo.list_join_requests(org_id).await.unwrap().is_empty());
+        assert_eq!(repo.get_user_org_role(joiner.id, org_id).await.unwrap(), None);
+
+        // The door isn't bolted: they can request again.
+        repo.create_join_request(org_id, joiner.id).await.expect("can ask again");
+    }
+
+    /// Managing one org must not grant authority over another's queue.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_join_request_decisions_are_scoped_to_their_org(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let owner_a = create_test_user(&pool, Role::StandardUser).await;
+        let owner_b = create_test_user(&pool, Role::StandardUser).await;
+        let joiner = create_test_user(&pool, Role::StandardUser).await;
+
+        let (_org_a, _) = org_with_join_request(&pool, owner_a.id, joiner.id).await;
+        let other = create_test_user(&pool, Role::StandardUser).await;
+        let (org_b, request_b) = org_with_join_request(&pool, owner_b.id, other.id).await;
+
+        // Owner A tries to approve a request belonging to org B, via org B's path.
+        let a_headers = add_auth_headers(&owner_a);
+        let resp = server
+            .post(&format!("/admin/api/v1/organizations/{org_b}/join-requests/{request_b}/approve"))
+            .add_header(&a_headers[0].0, &a_headers[0].1)
+            .add_header(&a_headers[1].0, &a_headers[1].1)
+            .await;
+        resp.assert_status(axum::http::StatusCode::FORBIDDEN);
+
+        let mut conn = pool.acquire().await.unwrap();
+        let role = crate::db::handlers::Organizations::new(&mut conn)
+            .get_user_org_role(other.id, org_b)
+            .await
+            .unwrap();
+        assert_eq!(role, None, "the request must still be outstanding");
+    }
 
     #[sqlx::test]
     #[test_log::test]

--- a/dwctl/src/api/models/organizations.rs
+++ b/dwctl/src/api/models/organizations.rs
@@ -105,7 +105,6 @@ impl From<crate::db::models::organizations::PendingOrgEmailChangeDBResponse> for
     }
 }
 
-/// Organization member details
 /// Optional body for approving a join request.
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema, Default)]
 pub struct ApproveJoinRequestRequest {
@@ -114,6 +113,7 @@ pub struct ApproveJoinRequestRequest {
     pub role: Option<String>,
 }
 
+/// Organization member details
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct OrganizationMemberResponse {
     /// Membership row ID
@@ -124,7 +124,9 @@ pub struct OrganizationMemberResponse {
     pub user: Option<UserResponse>,
     /// Role in the organization: 'owner', 'admin', or 'member'
     pub role: String,
-    /// Membership status: 'active' or 'pending'
+    /// Membership status: 'active' for current members, 'pending' for an
+    /// invite the organization sent, or 'requested' for someone asking to
+    /// join and awaiting a decision.
     pub status: String,
     /// When the membership was created
     pub created_at: DateTime<Utc>,

--- a/dwctl/src/api/models/organizations.rs
+++ b/dwctl/src/api/models/organizations.rs
@@ -106,6 +106,14 @@ impl From<crate::db::models::organizations::PendingOrgEmailChangeDBResponse> for
 }
 
 /// Organization member details
+/// Optional body for approving a join request.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema, Default)]
+pub struct ApproveJoinRequestRequest {
+    /// Role to grant on approval. Defaults to 'member'.
+    #[serde(default)]
+    pub role: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct OrganizationMemberResponse {
     /// Membership row ID

--- a/dwctl/src/auth/current_user.rs
+++ b/dwctl/src/auth/current_user.rs
@@ -199,9 +199,16 @@ async fn try_proxy_header_auth<P: sqlx_pool_router::PoolProvider + Clone + Send 
                         let mut org_repo = Organizations::new(&mut tx);
                         match org_repo.find_by_domain(domain).await {
                             Ok(Some(org)) => {
-                                // Org exists — add user as member
-                                if let Err(e) = org_repo.add_member(org.id, user.id, "member").await {
-                                    tracing::warn!("Failed to auto-add user to org {}: {e}", domain);
+                                // Org exists — ask to join rather than joining.
+                                //
+                                // This used to call `add_member` directly, so anyone who
+                                // could receive mail at a company's domain landed inside
+                                // the organization that owns its billing account, with no
+                                // approval and no notice to either side. Now an owner or
+                                // admin decides. Sharing an email domain is evidence that
+                                // someone probably belongs, not that they do.
+                                if let Err(e) = org_repo.create_join_request(org.id, user.id).await {
+                                    tracing::warn!("Failed to record join request for org {}: {e}", domain);
                                 }
                             }
                             Ok(None) => {
@@ -1771,18 +1778,22 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_proxy_header_signup_joins_existing_org(pool: PgPool) {
+    /// Sharing an email domain gets you a request, not a membership.
+    ///
+    /// This used to add the second user straight in as a member. Anyone who
+    /// could receive mail at a company's domain landed inside the organization
+    /// that owns its billing account, with nobody asked and nobody told.
+    async fn test_proxy_header_signup_requests_to_join_existing_org(pool: PgPool) {
         let mut config = create_test_config();
         config.auth.proxy_header.enabled = true;
         config.auth.proxy_header.auto_create_users = true;
 
         let state = crate::test::utils::create_test_app_state_with_config(pool.clone(), config).await;
 
-        // First user creates the org
+        // First user still claims the unclaimed domain and owns the org.
         let mut parts1 = create_test_parts_with_auth("auth0|first", "first@widgets.io");
         let first = CurrentUser::from_request_parts(&mut parts1, &state).await.unwrap();
 
-        // Second user from same domain should auto-join
         let mut parts2 = create_test_parts_with_auth("auth0|second", "second@widgets.io");
         let second = CurrentUser::from_request_parts(&mut parts2, &state).await.unwrap();
 
@@ -1790,12 +1801,55 @@ mod tests {
         let mut org_repo = Organizations::new(&mut conn);
         let org = org_repo.find_by_domain("widgets.io").await.unwrap().unwrap();
 
-        // First user is owner, second is member
-        let first_role = org_repo.get_user_org_role(first.id, org.id).await.unwrap();
-        assert_eq!(first_role, Some("owner".to_string()));
+        assert_eq!(
+            org_repo.get_user_org_role(first.id, org.id).await.unwrap(),
+            Some("owner".to_string())
+        );
 
-        let second_role = org_repo.get_user_org_role(second.id, org.id).await.unwrap();
-        assert_eq!(second_role, Some("member".to_string()));
+        // The second user is NOT a member - `get_user_org_role` only counts
+        // active memberships, so this is the check that would have failed
+        // before the change.
+        assert_eq!(
+            org_repo.get_user_org_role(second.id, org.id).await.unwrap(),
+            None,
+            "sharing a domain must not grant membership"
+        );
+
+        // They're waiting in the queue instead.
+        let requests = org_repo.list_join_requests(org.id).await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].user_id, Some(second.id));
+        assert_eq!(requests[0].status, "requested");
+
+        // And the queue doesn't leak into the members list.
+        let members = org_repo.list_members(org.id).await.unwrap();
+        assert_eq!(members.len(), 1, "only the owner is a member");
+        assert_eq!(members[0].user_id, Some(first.id));
+    }
+
+    /// Logging in repeatedly must not pile up duplicate requests.
+    #[sqlx::test]
+    async fn test_proxy_header_repeat_login_does_not_duplicate_join_request(pool: PgPool) {
+        let mut config = create_test_config();
+        config.auth.proxy_header.enabled = true;
+        config.auth.proxy_header.auto_create_users = true;
+
+        let state = crate::test::utils::create_test_app_state_with_config(pool.clone(), config).await;
+
+        let mut owner_parts = create_test_parts_with_auth("auth0|owner", "owner@widgets.io");
+        CurrentUser::from_request_parts(&mut owner_parts, &state).await.unwrap();
+
+        for i in 0..3 {
+            let mut parts = create_test_parts_with_auth("auth0|joiner", "joiner@widgets.io");
+            CurrentUser::from_request_parts(&mut parts, &state)
+                .await
+                .unwrap_or_else(|_| panic!("login {i} should succeed"));
+        }
+
+        let mut conn = pool.acquire().await.unwrap();
+        let mut org_repo = Organizations::new(&mut conn);
+        let org = org_repo.find_by_domain("widgets.io").await.unwrap().unwrap();
+        assert_eq!(org_repo.list_join_requests(org.id).await.unwrap().len(), 1);
     }
 
     #[sqlx::test]

--- a/dwctl/src/db/handlers/organizations.rs
+++ b/dwctl/src/db/handlers/organizations.rs
@@ -731,8 +731,6 @@ impl<'c> Organizations<'c> {
         Ok(row.into())
     }
 
-    /// Cancel (delete) a pending invite by row ID
-    #[instrument(skip(self), fields(org_id = %abbrev_uuid(&org_id), invite_id = %abbrev_uuid(&invite_id)), err)]
     /// Re-issue a pending invite: new token, fresh expiry.
     ///
     /// The original token is only stored as a hash, so it can't be recovered to
@@ -768,6 +766,8 @@ impl<'c> Organizations<'c> {
         Ok(row.and_then(|r| r.invite_email.map(|email| (email, r.role))))
     }
 
+    /// Cancel (delete) a pending invite by row ID
+    #[instrument(skip(self), fields(org_id = %abbrev_uuid(&org_id), invite_id = %abbrev_uuid(&invite_id)), err)]
     pub async fn cancel_invite(&mut self, org_id: UserId, invite_id: UserId) -> Result<bool> {
         let result = sqlx::query!(
             "DELETE FROM user_organizations WHERE id = $1 AND organization_id = $2 AND status = 'pending'",

--- a/dwctl/src/db/handlers/organizations.rs
+++ b/dwctl/src/db/handlers/organizations.rs
@@ -495,6 +495,7 @@ impl<'c> Organizations<'c> {
             FROM user_organizations uo
             LEFT JOIN users u ON u.id = uo.user_id
             WHERE uo.organization_id = $1
+              AND uo.status <> 'requested'
               AND (uo.user_id IS NULL OR u.is_deleted = false)
             ORDER BY uo.status ASC, uo.created_at ASC
             "#,
@@ -504,6 +505,97 @@ impl<'c> Organizations<'c> {
         .await?;
 
         Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    /// Record a request to join an organization, awaiting owner/admin approval.
+    ///
+    /// The mirror of an invite: same table, same lifecycle, opposite direction.
+    /// `UNIQUE (user_id, organization_id)` means a second request while one is
+    /// outstanding - or while the user is already a member - conflicts rather
+    /// than creating a duplicate, so callers should treat that as "already
+    /// requested" rather than an error.
+    #[instrument(skip(self), fields(org_id = %abbrev_uuid(&org_id), user_id = %abbrev_uuid(&user_id)), err)]
+    pub async fn create_join_request(&mut self, org_id: UserId, user_id: UserId) -> Result<OrganizationMemberDBResponse> {
+        let row = sqlx::query_as!(
+            MemberRow,
+            r#"
+            INSERT INTO user_organizations (user_id, organization_id, role, status)
+            VALUES ($1, $2, 'member', 'requested')
+            RETURNING id, user_id, organization_id, role, status, created_at,
+                      invite_email, invited_by, expires_at
+            "#,
+            user_id,
+            org_id,
+        )
+        .fetch_one(&mut *self.db)
+        .await?;
+
+        Ok(row.into())
+    }
+
+    /// Outstanding join requests for an organization, oldest first.
+    #[instrument(skip(self), fields(org_id = %abbrev_uuid(&org_id)), err)]
+    pub async fn list_join_requests(&mut self, org_id: UserId) -> Result<Vec<OrganizationMemberDBResponse>> {
+        let rows = sqlx::query_as!(
+            MemberRow,
+            r#"
+            SELECT uo.id, uo.user_id, uo.organization_id, uo.role, uo.status,
+                   uo.created_at, uo.invite_email, uo.invited_by, uo.expires_at
+            FROM user_organizations uo
+            INNER JOIN users u ON u.id = uo.user_id
+            WHERE uo.organization_id = $1
+              AND uo.status = 'requested'
+              AND u.is_deleted = false
+            ORDER BY uo.created_at ASC
+            "#,
+            org_id
+        )
+        .fetch_all(&mut *self.db)
+        .await?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    /// Approve a join request: the requester becomes an active member.
+    ///
+    /// Scoped to `org_id` as well as the request id so a caller who can manage
+    /// one organization can't approve a request belonging to another. Returns
+    /// false if the request no longer exists or was already decided, which
+    /// makes concurrent approvals a no-op rather than a double-add.
+    #[instrument(skip(self), fields(org_id = %abbrev_uuid(&org_id), request_id = %abbrev_uuid(&request_id)), err)]
+    pub async fn approve_join_request(&mut self, org_id: UserId, request_id: Uuid, role: &str) -> Result<bool> {
+        let result = sqlx::query!(
+            r#"
+            UPDATE user_organizations
+            SET status = 'active', role = $3
+            WHERE id = $1 AND organization_id = $2 AND status = 'requested'
+            "#,
+            request_id,
+            org_id,
+            role,
+        )
+        .execute(&mut *self.db)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Decline a join request, removing the row.
+    ///
+    /// Deleted rather than kept in a `declined` state so the user can ask again
+    /// later - a permanent tombstone would silently block them forever via the
+    /// unique constraint.
+    #[instrument(skip(self), fields(org_id = %abbrev_uuid(&org_id), request_id = %abbrev_uuid(&request_id)), err)]
+    pub async fn decline_join_request(&mut self, org_id: UserId, request_id: Uuid) -> Result<bool> {
+        let result = sqlx::query!(
+            "DELETE FROM user_organizations WHERE id = $1 AND organization_id = $2 AND status = 'requested'",
+            request_id,
+            org_id,
+        )
+        .execute(&mut *self.db)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
     }
 
     /// List organizations a user belongs to (active memberships only)
@@ -641,6 +733,41 @@ impl<'c> Organizations<'c> {
 
     /// Cancel (delete) a pending invite by row ID
     #[instrument(skip(self), fields(org_id = %abbrev_uuid(&org_id), invite_id = %abbrev_uuid(&invite_id)), err)]
+    /// Re-issue a pending invite: new token, fresh expiry.
+    ///
+    /// The original token is only stored as a hash, so it can't be recovered to
+    /// re-send - a resend necessarily mints a new one. That also invalidates
+    /// the old link, which is the behaviour you want if the first was sent to
+    /// the wrong place or has leaked.
+    ///
+    /// Returns the invite's email and role so the caller can send the mail,
+    /// or None if there's no pending invite by that id in this organization.
+    #[instrument(skip(self, token_hash), fields(org_id = %abbrev_uuid(&org_id), invite_id = %abbrev_uuid(&invite_id)), err)]
+    pub async fn refresh_invite_token(
+        &mut self,
+        org_id: UserId,
+        invite_id: Uuid,
+        token_hash: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<Option<(String, String)>> {
+        let row = sqlx::query!(
+            r#"
+            UPDATE user_organizations
+            SET invite_token_hash = $3, expires_at = $4
+            WHERE id = $1 AND organization_id = $2 AND status = 'pending'
+            RETURNING invite_email, role
+            "#,
+            invite_id,
+            org_id,
+            token_hash,
+            expires_at,
+        )
+        .fetch_optional(&mut *self.db)
+        .await?;
+
+        Ok(row.and_then(|r| r.invite_email.map(|email| (email, r.role))))
+    }
+
     pub async fn cancel_invite(&mut self, org_id: UserId, invite_id: UserId) -> Result<bool> {
         let result = sqlx::query!(
             "DELETE FROM user_organizations WHERE id = $1 AND organization_id = $2 AND status = 'pending'",

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1422,6 +1422,24 @@ pub async fn build_router(
             delete(api::handlers::organizations::cancel_invite),
         )
         .route(
+            "/organizations/{id}/invites/{invite_id}/resend",
+            post(api::handlers::organizations::resend_invite),
+        )
+        // Join requests: the mirror of invites, for users asking to join an
+        // organization that matches their email domain.
+        .route(
+            "/organizations/{id}/join-requests",
+            get(api::handlers::organizations::list_join_requests),
+        )
+        .route(
+            "/organizations/{id}/join-requests/{request_id}/approve",
+            post(api::handlers::organizations::approve_join_request),
+        )
+        .route(
+            "/organizations/{id}/join-requests/{request_id}/decline",
+            post(api::handlers::organizations::decline_join_request),
+        )
+        .route(
             "/organizations/invites/{token}",
             get(api::handlers::organizations::get_invite_details),
         )


### PR DESCRIPTION
Phase 1 of making domain-based org membership deliberate. Unblocks the **Requests** and **Invitations** tabs of doublewordai/app-doubleword-private#134.

## The behaviour this replaces

Until now, `auth::current_user` did this on first login with a company email domain:

```rust
Ok(Some(org)) => {
    // Org exists — add user as member
    org_repo.add_member(org.id, user.id, "member")
}
```

**No approval, no notice to either party.** Anyone who could receive mail at a domain landed inside the organization that owns its billing account, and the org found out by noticing a new name in the members list.

Sharing an email domain is evidence that someone *probably* belongs — not proof that they do. They now land in a queue and an owner or admin decides.

## Why no new table

Join requests are the mirror image of invites, so they reuse the same membership lifecycle:

| status | meaning |
|---|---|
| `active` | current member |
| `pending` | **org invited someone**, not yet accepted |
| `requested` | **someone asked**, org hasn't decided |

Both non-active states become `active` on acceptance. Both are already covered by `UNIQUE (user_id, organization_id)`, the membership-type trigger and the existing indexes — so repeat logins can't pile up duplicates, and that's tested.

The migration is one CHECK constraint plus a partial index. No new table, no new trigger, no second lifecycle to keep in sync.

## Decisions worth reviewing

**Gated on *managing* the org, not belonging to it.** The queue names people who share your email domain; ordinary members have no business seeing it. There's a test asserting a plain member gets `403` where the owner gets the list.

**Declining deletes the row rather than tombstoning it.** A permanent `declined` record would silently block that user forever via the unique constraint. Tested by declining and then asking again.

**Resending mints a new token.** The original is only stored as a hash, so it *can't* be recovered to send again — a resend necessarily rotates it. That also kills the old link, which is what you want if the first went astray. Tested by asserting the stored hash changes.

**`list_members` now excludes `requested`** so the new status can't leak into the members or invitations views.

## Deliberately not in scope

Auto-**creation** of an org for an unclaimed domain is unchanged — first signup from a new domain still creates and owns it. Gating that needs domain ownership proof (DNS TXT), which is phase 2.

Worth flagging the residual risk that leaves: someone who claims `acme.com` first could approve real Acme staff into *their* org. That risk exists today and is strictly worse today, since it's currently auto-join with no prompt at all — but it's the reason phase 2 matters.

## Test plan

- [x] `cargo test -p dwctl` — **1947 passed, 0 failed**
- [x] `just lint rust` — clean
- [x] The old `test_proxy_header_signup_joins_existing_org` is rewritten to assert the *new* contract: `get_user_org_role` returns `None` (the assertion that would have failed before), the request is queued, and the members list is unaffected
- [x] New: repeat logins don't duplicate; approve makes an active member and is a no-op the second time; decline lets the user re-request; decisions are scoped to their own org (owner of A gets `403` on B's queue and B's request stays outstanding); resend rotates the token