### PR TITLE
feat(organizations): replace silent domain auto-join with join requests

### DIFF
--- a/dwctl/src/request_logging/utils.rs
+++ b/dwctl/src/request_logging/utils.rs
@@ -330,7 +330,7 @@ pub(crate) fn extract_header_as_string(request_data: &outlet::RequestData, heade
         .map(|s| s.to_string())
 }
 
-// Mylena & Sebastien 2026 <3 :^)
+// Mylena & Sebastien 2026 <3 :^) <3
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Re-records #1430 so the release tooling can see it. **No code change** — the work is already on main in cfa5c384. This PR contains a single empty commit.

Deliberately written without fenced code blocks: that is the bug being worked around, and this body becomes the squash commit message.

## Why this is needed

cfa5c384 is invisible to release-please. The repo squashes with squash_merge_commit_message=PR_BODY, so the PR description became the commit body, and it contained a fenced code block. The conventional-commits parser rejected the whole message, logging "commit could not be parsed", so the root package counted zero commits and cut no release.

Markdown alone is not the problem — #1421 had four tables and released normally in 10.3.0. It is the code fence specifically.

Because this is a parse failure rather than a filtered commit, it would never have healed on its own. #1430 would have stayed out of every future changelog while its code shipped silently under some later version, and the deploy would have waited on whatever merged next.

Verified by re-running the release-please workflow: same result 26 minutes later, so it is deterministic rather than API lag.

## What cfa5c384 actually did

Restating it here because this is the message that reaches the changelog.

First login with a company email domain used to add the user straight into that domain's organization as a member, with no approval and no notice to either party. Anyone who could receive mail at a domain landed inside the organization that owns its billing account. They now land in a queue and an owner or admin decides.

Join requests reuse the invite lifecycle rather than adding a table: user_organizations.status gains 'requested' alongside 'active' and 'pending', so the unique constraint, membership-type trigger and existing indexes all still apply. Adds list, approve and decline endpoints plus invite resend, all gated on managing the organization rather than merely belonging to it. Auto-creation of an org for an unclaimed domain is unchanged — gating that needs DNS ownership proof, which is separate work.

Unblocks the Requests and Invitations tabs of doublewordai/app-doubleword-private#134, which cannot go live until this is released and deployed.

## Test plan

Nothing to test — the commit is empty and the code it describes was verified on #1430 (1947 tests passing, just lint rust clean). CI runs here only to satisfy the required checks.