### PR TITLE
feat(organizations): expose the verified flag on org membership summaries

### DIFF
--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -1486,6 +1486,7 @@ pub async fn list_user_organizations<P: PoolProvider>(
                     can_manage_keys: matches!(m.role.as_str(), "owner" | "admin") || manage_keys_orgs.contains(&o.id),
                     role: m.role.clone(),
                     zero_data_retention: o.zero_data_retention,
+                    verified: o.verified,
                 })
         })
         .collect();
@@ -2182,6 +2183,66 @@ mod tests {
         assert_eq!(members.len(), 1);
         assert_eq!(members[0]["role"].as_str().unwrap(), "owner");
         assert_eq!(members[0]["user"]["id"].as_str().unwrap(), user.id.to_string());
+    }
+
+    /// The org's verification is its own, not the member's.
+    ///
+    /// Paying as an org admin verifies the organization rather than the human
+    /// who clicked, so a client asking "can this workspace pay" has to read the
+    /// summary. This pins that the two never get conflated.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_user_organizations_summary_reflects_org_verification(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+        let user_headers = add_auth_headers(&user);
+
+        let resp = server
+            .post("/admin/api/v1/organizations")
+            .add_header(&user_headers[0].0, &user_headers[0].1)
+            .add_header(&user_headers[1].0, &user_headers[1].1)
+            .json(&json!({ "name": "verify-org", "email": "contact@verify-org.com" }))
+            .await;
+        resp.assert_status(axum::http::StatusCode::CREATED);
+        let org_id: uuid::Uuid = resp.json::<serde_json::Value>()["id"].as_str().unwrap().parse().unwrap();
+
+        let orgs_url = format!("/admin/api/v1/users/{}/organizations", user.id);
+        let fetch_summary = async |server: &axum_test::TestServer| -> serde_json::Value {
+            let resp = server
+                .get(&orgs_url)
+                .add_header(&user_headers[0].0, &user_headers[0].1)
+                .add_header(&user_headers[1].0, &user_headers[1].1)
+                .await;
+            resp.assert_status(axum::http::StatusCode::OK);
+            resp.json::<Vec<serde_json::Value>>().into_iter().next().expect("one org")
+        };
+
+        // A newly created org has never paid for anything.
+        assert_eq!(fetch_summary(&server).await["verified"].as_bool(), Some(false));
+
+        // The same call the payment and card-verification paths make.
+        let mut conn = pool.acquire().await.unwrap();
+        crate::db::handlers::users::Users::new(&mut conn)
+            .set_verified(org_id)
+            .await
+            .unwrap();
+        drop(conn);
+
+        assert_eq!(fetch_summary(&server).await["verified"].as_bool(), Some(true));
+
+        // Verifying the organization must not have verified the member, or the
+        // topbar would clear its badge for the wrong entity.
+        let resp = server
+            .get("/admin/api/v1/users/current")
+            .add_header(&user_headers[0].0, &user_headers[0].1)
+            .add_header(&user_headers[1].0, &user_headers[1].1)
+            .await;
+        resp.assert_status(axum::http::StatusCode::OK);
+        assert_eq!(
+            resp.json::<serde_json::Value>()["verified"].as_bool(),
+            Some(false),
+            "the member is still unverified in their own right"
+        );
     }
 
     #[sqlx::test]

--- a/dwctl/src/api/handlers/users.rs
+++ b/dwctl/src/api/handlers/users.rs
@@ -288,6 +288,7 @@ pub async fn get_user<P: PoolProvider>(
                             can_manage_keys: matches!(m.role.as_str(), "owner" | "admin") || manage_keys_orgs.contains(&m.organization_id),
                             role: m.role.clone(),
                             zero_data_retention: org.zero_data_retention,
+                            verified: org.verified,
                         })
                 })
                 .collect();

--- a/dwctl/src/api/models/organizations.rs
+++ b/dwctl/src/api/models/organizations.rs
@@ -256,4 +256,13 @@ pub struct OrganizationSummary {
     /// Drives the dashboard's create/edit affordances and the batch key
     /// selection requirement.
     pub can_manage_keys: bool,
+    /// Whether the organization has proven a payment method - a completed
+    /// purchase or a setup-mode card verification. Surfaced alongside the
+    /// other org-wide flags so a member can see their organization's status
+    /// without a second request per organization.
+    ///
+    /// Distinct from the same field on the *user*: paying as an org admin
+    /// verifies the organization, not you, so a client showing "is this
+    /// workspace able to pay" must read it from here when acting as an org.
+    pub verified: bool,
 }


### PR DESCRIPTION
Unblocks the org half of the "Verification pending" badge in app-doubleword-private#178. No fenced code blocks in this body, since squash uses PR_BODY and a code fence is what stopped release-please cutting a release for #1430.

## Why

The topbar badges an account as pending verification until its billing entity has proven a payment method. In org context that entity is the **organization**, and its status wasn't reachable: `OrganizationSummary` carried `zero_data_retention` and `can_manage_keys` but not `verified`, so a client would have had to fetch each organization separately just to render a badge.

Reading the user's own flag instead is wrong, and quietly so. Paying as an org admin verifies the organization, not the human who clicked — so `user.verified` stays false while the workspace is perfectly able to pay. Without this the SPA cannot tell "this workspace can pay" from "I can pay".

Today #178 handles that by treating an absent field as verified and showing no badge, which is the safe degradation but means the org case simply doesn't work.

## What

One field on `OrganizationSummary`, sourced from the same `users` row the neighbouring flags already come from. Both construction sites are covered: `/users/current?include=organizations` and `/users/{id}/organizations`.

Purely additive — a new field on a response body, no behaviour change.

## Test plan

- `cargo test -p dwctl` — **1948 passed, 0 failed**
- `just lint rust` — clean
- New test walks the transition rather than asserting an end state: a fresh org reports false, `set_verified` (the same call the payment and card-verification paths make) flips it to true, and the member's own `/users/current` still reports false afterwards. That last assertion is the one that matters — conflating the two would clear the badge for the wrong entity.

## After this ships

#178 needs no change to start working in org context: it already reads `verified` off the membership summary and treats absent as verified. Once this is deployed the field arrives and the badge appears for genuinely unverified organizations.