### PR TITLE
feat(organizations): claim the owner's domain, several workspaces allowed

### DIFF
--- a/.sqlx/query-fc0c19f29df0353c465fac938996e8c3bd98319f117ab46ce5b7cc501b678100.json
+++ b/.sqlx/query-fc0c19f29df0353c465fac938996e8c3bd98319f117ab46ce5b7cc501b678100.json
@@ -1,0 +1,160 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, username, email, display_name, avatar_url, auth_source, created_at, updated_at,\n                   is_admin, password_hash, external_user_id, payment_provider_id,\n                   is_deleted, is_internal, batch_notifications_enabled, first_batch_email_sent,\n                   low_balance_notification_sent, low_balance_threshold,\n                   auto_topup_amount, auto_topup_threshold, auto_topup_monthly_limit, user_type, verified, zero_data_retention\n            FROM users\n            WHERE (username = $1 OR username LIKE $1 || '~%')\n              AND user_type = 'organization'\n              -- A soft-deleted workspace must never receive join requests:\n              -- nobody is left to approve them, so the requester would sit on a\n              -- queue no one can see.\n              AND is_deleted = false\n            ORDER BY created_at ASC\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "avatar_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_source",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "password_hash",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "external_user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "payment_provider_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "is_deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "is_internal",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "batch_notifications_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 15,
+        "name": "first_batch_email_sent",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 16,
+        "name": "low_balance_notification_sent",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "low_balance_threshold",
+        "type_info": "Float4"
+      },
+      {
+        "ordinal": 18,
+        "name": "auto_topup_amount",
+        "type_info": "Float4"
+      },
+      {
+        "ordinal": 19,
+        "name": "auto_topup_threshold",
+        "type_info": "Float4"
+      },
+      {
+        "ordinal": 20,
+        "name": "auto_topup_monthly_limit",
+        "type_info": "Float4"
+      },
+      {
+        "ordinal": 21,
+        "name": "user_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 22,
+        "name": "verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 23,
+        "name": "zero_data_retention",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fc0c19f29df0353c465fac938996e8c3bd98319f117ab46ce5b7cc501b678100"
+}

--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -261,8 +261,7 @@ pub async fn create_organization<P: PoolProvider>(
             })?
             .email
     };
-    let claimable_domain =
-        crate::auth::utils::email_domain(&owner_email).filter(|d| !crate::auth::utils::is_personal_email_domain(d));
+    let claimable_domain = crate::auth::utils::email_domain(&owner_email).filter(|d| !crate::auth::utils::is_personal_email_domain(d));
 
     // `{domain}~{suffix}`: the domain is what a colleague's signup matches on,
     // and the suffix keeps `users.username` unique so one company can hold
@@ -2231,7 +2230,10 @@ mod tests {
             .await;
         resp.assert_status(axum::http::StatusCode::CREATED);
         let username = resp.json::<serde_json::Value>()["username"].as_str().unwrap().to_string();
-        assert!(username.starts_with("mixedcase.test~"), "claim should be lowercased, got {username}");
+        assert!(
+            username.starts_with("mixedcase.test~"),
+            "claim should be lowercased, got {username}"
+        );
 
         // A colleague whose address is cased differently still finds it.
         let mut conn = pool.acquire().await.unwrap();

--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -235,10 +235,41 @@ pub async fn create_organization<P: PoolProvider>(
         current_user.id
     };
 
+    // The organization's username IS its email domain, which is what makes an
+    // organization findable by the people who belong to it: a later signup from
+    // the same domain is offered a join request instead of a second workspace.
+    // `users.username` is already UNIQUE, so that also enforces one
+    // organization per domain without a separate claim table.
+    //
+    // Derived from the owner's own address rather than the submitted name, so a
+    // caller can't claim a domain they don't have mail at. The name the user
+    // typed becomes the display name.
+    //
+    // Falls back to the submitted name when the owner is on a personal email
+    // domain (gmail and friends) - there's no meaningful domain to claim, and
+    // claiming "gmail.com" would swallow every consumer signup into one org.
+    let owner_email = if owner_id == current_user.id {
+        current_user.email.clone()
+    } else {
+        let mut conn = state.db.write().acquire().await.map_err(|e| Error::Database(e.into()))?;
+        Users::new(&mut conn)
+            .get_by_id(owner_id)
+            .await?
+            .ok_or(Error::NotFound {
+                resource: "User".to_string(),
+                id: owner_id.to_string(),
+            })?
+            .email
+    };
+    let claimable_domain = crate::auth::utils::email_domain(&owner_email)
+        .filter(|d| !crate::auth::utils::is_personal_email_domain(d))
+        .map(str::to_string);
+
+    let display_name = data.display_name.clone().or_else(|| Some(data.name.clone()));
     let db_request = OrganizationCreateDBRequest {
-        name: data.name,
+        name: claimable_domain.clone().unwrap_or_else(|| data.name.clone()),
         email,
-        display_name: data.display_name,
+        display_name,
         avatar_url: None,
         created_by: owner_id,
     };
@@ -246,6 +277,19 @@ pub async fn create_organization<P: PoolProvider>(
     let config = state.current_config();
     let mut pool_conn = state.db.write().acquire().await.map_err(|e| Error::Database(e.into()))?;
     let mut repo = Organizations::new(&mut pool_conn);
+
+    // One workspace per domain. Checked explicitly so the caller gets a reason
+    // and the name of the organization to ask for, rather than a bare unique
+    // violation on `users.username` - the constraint still backstops races.
+    if let Some(domain) = claimable_domain.as_deref()
+        && let Some(existing) = repo.find_by_domain(domain).await?
+    {
+        let existing_name = existing.display_name.unwrap_or(existing.username);
+        return Err(Error::Conflict {
+            message: format!("{domain} already has a workspace ({existing_name}). Request to join it instead of creating another."),
+            conflicts: None,
+        });
+    }
 
     // Check org membership limit for the owner
     let org_count = repo.count_user_organizations(owner_id).await?;
@@ -2132,6 +2176,7 @@ mod tests {
     use crate::api::models::users::Role;
     use crate::test::utils::{
         add_auth_headers, create_test_admin_user, create_test_app, create_test_app_with_config, create_test_config, create_test_user,
+        create_test_user_on_domain,
     };
     use serde_json::json;
     use sqlx::PgPool;
@@ -2153,7 +2198,44 @@ mod tests {
             .await;
         resp.assert_status(axum::http::StatusCode::CREATED);
         let body = resp.json::<serde_json::Value>();
-        assert_eq!(body["username"].as_str().unwrap(), "my-org");
+        // The username is the owner's email domain, not the submitted name:
+        // that's what makes the workspace findable by colleagues. The submitted
+        // name becomes the display name.
+        assert_eq!(body["username"].as_str().unwrap(), "example.com");
+        assert_eq!(body["display_name"].as_str().unwrap(), "my-org");
+    }
+
+    /// One workspace per domain, with a reason the caller can act on.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_second_org_for_the_same_domain_is_refused(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let first = create_test_user(&pool, Role::StandardUser).await;
+        let first_headers = add_auth_headers(&first);
+
+        let resp = server
+            .post("/admin/api/v1/organizations")
+            .add_header(&first_headers[0].0, &first_headers[0].1)
+            .add_header(&first_headers[1].0, &first_headers[1].1)
+            .json(&json!({ "name": "Acme Engineering", "email": "eng@acme.test" }))
+            .await;
+        resp.assert_status(axum::http::StatusCode::CREATED);
+
+        // A colleague - same email domain - can't stand up a second one.
+        let second = create_test_user(&pool, Role::StandardUser).await;
+        let second_headers = add_auth_headers(&second);
+        let resp = server
+            .post("/admin/api/v1/organizations")
+            .add_header(&second_headers[0].0, &second_headers[0].1)
+            .add_header(&second_headers[1].0, &second_headers[1].1)
+            .json(&json!({ "name": "Acme Sales", "email": "sales@acme.test" }))
+            .await;
+        resp.assert_status(axum::http::StatusCode::CONFLICT);
+        let text = resp.text();
+        assert!(
+            text.contains("already has a workspace") && text.contains("Acme Engineering"),
+            "the refusal should name the workspace to ask for, got: {text}"
+        );
     }
 
     #[sqlx::test]
@@ -2332,7 +2414,7 @@ mod tests {
         let owner = create_test_user(&pool, Role::StandardUser).await;
         let org_admin = create_test_user(&pool, Role::StandardUser).await;
         let member = create_test_user(&pool, Role::StandardUser).await;
-        let other_owner = create_test_user(&pool, Role::StandardUser).await;
+        let other_owner = create_test_user_on_domain(&pool, Role::StandardUser, "other-tenant.test").await;
         let other_owner_headers = add_auth_headers(&other_owner);
 
         let resp = server
@@ -2405,25 +2487,37 @@ mod tests {
 
     // ── Org membership limit ──────────────────────────────────────────────
 
+    /// The cap counts *memberships*, not authorship.
+    ///
+    /// This used to have one user create MAX_ORGS_PER_USER organizations back
+    /// to back, which is no longer possible: an organization claims its owner's
+    /// email domain, so a user can self-serve at most one. The cap still bites
+    /// via invitations, so that's the route it's exercised through now.
     #[sqlx::test]
     #[test_log::test]
     async fn test_cannot_create_org_when_at_limit(pool: PgPool) {
         let (server, _bg) = create_test_app(pool.clone(), false).await;
-        let user = create_test_user(&pool, Role::StandardUser).await;
+        let pm = create_test_admin_user(&pool, Role::PlatformManager).await;
+        let pm_headers = add_auth_headers(&pm);
+
+        // The user is on a domain nobody has claimed, so nothing but the cap
+        // stands between them and their own workspace.
+        let user = create_test_user_on_domain(&pool, Role::StandardUser, "at-limit.test").await;
         let user_headers = add_auth_headers(&user);
 
-        // Create MAX_ORGS_PER_USER orgs
         for i in 0..super::MAX_ORGS_PER_USER {
+            let owner = create_test_user_on_domain(&pool, Role::StandardUser, &format!("host-{i}.test")).await;
+            let org_id = create_org_for(&server, &pm_headers, &format!("org-{i}"), &format!("org{i}@example.com"), owner.id).await;
+
             let resp = server
-                .post("/admin/api/v1/organizations")
-                .add_header(&user_headers[0].0, &user_headers[0].1)
-                .add_header(&user_headers[1].0, &user_headers[1].1)
-                .json(&json!({ "name": format!("org-{i}"), "email": format!("org{i}@example.com") }))
+                .post(&format!("/admin/api/v1/organizations/{org_id}/members"))
+                .add_header(&pm_headers[0].0, &pm_headers[0].1)
+                .add_header(&pm_headers[1].0, &pm_headers[1].1)
+                .json(&json!({ "user_id": user.id, "role": "member" }))
                 .await;
             resp.assert_status(axum::http::StatusCode::CREATED);
         }
 
-        // Next one should fail
         let resp = server
             .post("/admin/api/v1/organizations")
             .add_header(&user_headers[0].0, &user_headers[0].1)
@@ -2431,8 +2525,7 @@ mod tests {
             .json(&json!({ "name": "one-too-many", "email": "extra@example.com" }))
             .await;
         resp.assert_status(axum::http::StatusCode::BAD_REQUEST);
-        let body = resp.text();
-        assert!(body.contains("maximum"));
+        assert!(resp.text().contains("maximum"));
     }
 
     // ── Leave organization ────────────────────────────────────────────────
@@ -3399,10 +3492,10 @@ mod tests {
             let (server, _bg) = create_test_app(pool.clone(), false).await;
             let pm = create_test_admin_user(&pool, Role::PlatformManager).await;
             let pm_headers = add_auth_headers(&pm);
-            let owner = create_test_user(&pool, Role::StandardUser).await;
-            let owner_headers = add_auth_headers(&owner);
-
             let label = if new_first { "new-first" } else { "old-first" };
+            // Each iteration needs its own domain; the organization claims it.
+            let owner = create_test_user_on_domain(&pool, Role::StandardUser, &format!("{label}.test")).await;
+            let owner_headers = add_auth_headers(&owner);
             let org_id = create_org_for(&server, &pm_headers, &format!("apply-{label}-org"), "billing@example.com", owner.id).await;
             let org_uuid = uuid::Uuid::parse_str(&org_id).unwrap();
 
@@ -3717,9 +3810,11 @@ mod tests {
         let (server, _bg) = create_test_app(pool.clone(), false).await;
         let pm = create_test_admin_user(&pool, Role::PlatformManager).await;
         let pm_headers = add_auth_headers(&pm);
-        let owner_a = create_test_user(&pool, Role::StandardUser).await;
+        // Distinct domains: an organization claims its owner's domain, so two
+        // owners on one domain can't hold two organizations.
+        let owner_a = create_test_user_on_domain(&pool, Role::StandardUser, "tenant-a.test").await;
         let owner_a_headers = add_auth_headers(&owner_a);
-        let owner_b = create_test_user(&pool, Role::StandardUser).await;
+        let owner_b = create_test_user_on_domain(&pool, Role::StandardUser, "tenant-b.test").await;
         let owner_b_headers = add_auth_headers(&owner_b);
 
         let org_a_id = create_org_for(&server, &pm_headers, "tenancy-org-a", "a@example.com", owner_a.id).await;

--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -265,9 +265,22 @@ pub async fn create_organization<P: PoolProvider>(
         .filter(|d| !crate::auth::utils::is_personal_email_domain(d))
         .map(str::to_string);
 
+    // `{domain}~{suffix}`: the domain is what a colleague's signup matches on,
+    // and the suffix keeps `users.username` unique so one company can hold
+    // several workspaces - prod and dev being the obvious pair. `~` can't occur
+    // in a domain, which is what makes the match exact on the way back out.
+    //
+    // Falls back to the submitted name when the owner is on a personal email
+    // domain: there's nothing worth matching on, and an organization claiming
+    // "gmail.com" would catch every consumer signup.
+    let username = match claimable_domain.as_deref() {
+        Some(domain) => format!("{domain}~{}", &uuid::Uuid::new_v4().simple().to_string()[..8]),
+        None => data.name.clone(),
+    };
+
     let display_name = data.display_name.clone().or_else(|| Some(data.name.clone()));
     let db_request = OrganizationCreateDBRequest {
-        name: claimable_domain.clone().unwrap_or_else(|| data.name.clone()),
+        name: username,
         email,
         display_name,
         avatar_url: None,
@@ -277,19 +290,6 @@ pub async fn create_organization<P: PoolProvider>(
     let config = state.current_config();
     let mut pool_conn = state.db.write().acquire().await.map_err(|e| Error::Database(e.into()))?;
     let mut repo = Organizations::new(&mut pool_conn);
-
-    // One workspace per domain. Checked explicitly so the caller gets a reason
-    // and the name of the organization to ask for, rather than a bare unique
-    // violation on `users.username` - the constraint still backstops races.
-    if let Some(domain) = claimable_domain.as_deref()
-        && let Some(existing) = repo.find_by_domain(domain).await?
-    {
-        let existing_name = existing.display_name.unwrap_or(existing.username);
-        return Err(Error::Conflict {
-            message: format!("{domain} already has a workspace ({existing_name}). Request to join it instead of creating another."),
-            conflicts: None,
-        });
-    }
 
     // Check org membership limit for the owner
     let org_count = repo.count_user_organizations(owner_id).await?;
@@ -1509,7 +1509,14 @@ pub async fn list_user_organizations<P: PoolProvider>(
         });
     }
 
-    let mut pool_conn = state.db.read().acquire().await.map_err(|e| Error::Database(e.into()))?;
+    // Primary, not the replica: these summaries carry `verified`, and clients
+    // read it straight after a write that sets it - the card-verification
+    // return path marks the organization verified, then the UI re-reads to drop
+    // its "Verification pending" badge. Off the replica that read can land
+    // before the flag has propagated, so the badge stays up on an account that
+    // has just paid. Same inter-endpoint consistency trap `get_user` already
+    // avoids for the equivalent reason (see CLAUDE.md).
+    let mut pool_conn = state.db.write().acquire().await.map_err(|e| Error::Database(e.into()))?;
     let mut repo = Organizations::new(&mut pool_conn);
     let memberships = repo.list_user_organizations(target_user_id).await?;
     let manage_keys_orgs = repo.user_manage_keys_org_ids(target_user_id).await?;
@@ -2198,43 +2205,96 @@ mod tests {
             .await;
         resp.assert_status(axum::http::StatusCode::CREATED);
         let body = resp.json::<serde_json::Value>();
-        // The username is the owner's email domain, not the submitted name:
-        // that's what makes the workspace findable by colleagues. The submitted
-        // name becomes the display name.
-        assert_eq!(body["username"].as_str().unwrap(), "example.com");
+        // The username is the owner's email domain plus a suffix - the domain
+        // is what makes the workspace findable by colleagues, the suffix keeps
+        // it unique so they can have more than one. The submitted name becomes
+        // the display name.
+        let username = body["username"].as_str().unwrap();
+        assert!(username.starts_with("example.com~"), "got {username}");
         assert_eq!(body["display_name"].as_str().unwrap(), "my-org");
     }
 
-    /// One workspace per domain, with a reason the caller can act on.
+    /// A domain can hold several workspaces - prod and dev, say - and a join
+    /// request goes to the oldest surviving one.
     #[sqlx::test]
     #[test_log::test]
-    async fn test_second_org_for_the_same_domain_is_refused(pool: PgPool) {
+    async fn test_domain_can_hold_several_workspaces(pool: PgPool) {
         let (server, _bg) = create_test_app(pool.clone(), false).await;
-        let first = create_test_user(&pool, Role::StandardUser).await;
-        let first_headers = add_auth_headers(&first);
+        let user = create_test_user_on_domain(&pool, Role::StandardUser, "acme.test").await;
+        let headers = add_auth_headers(&user);
+
+        let mut ids = Vec::new();
+        for name in ["Acme Prod", "Acme Dev"] {
+            let resp = server
+                .post("/admin/api/v1/organizations")
+                .add_header(&headers[0].0, &headers[0].1)
+                .add_header(&headers[1].0, &headers[1].1)
+                .json(&json!({ "name": name, "email": "billing@acme.test" }))
+                .await;
+            resp.assert_status(axum::http::StatusCode::CREATED);
+            let body = resp.json::<serde_json::Value>();
+            assert!(body["username"].as_str().unwrap().starts_with("acme.test~"));
+            ids.push(body["id"].as_str().unwrap().to_string());
+        }
+        assert_ne!(ids[0], ids[1], "both workspaces exist independently");
+
+        // A colleague's join request goes to the first one created.
+        let mut conn = pool.acquire().await.unwrap();
+        let matched = crate::db::handlers::Organizations::new(&mut conn)
+            .find_by_domain("acme.test")
+            .await
+            .unwrap()
+            .expect("a workspace matches the domain");
+        assert_eq!(matched.id.to_string(), ids[0], "the oldest surviving workspace wins");
+    }
+
+    /// A soft-deleted workspace must never receive join requests - nobody is
+    /// left to approve them.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_deleted_workspace_is_not_matched_by_domain(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let pm = create_test_admin_user(&pool, Role::PlatformManager).await;
+        let pm_headers = add_auth_headers(&pm);
+        let user = create_test_user_on_domain(&pool, Role::StandardUser, "gone.test").await;
+        let headers = add_auth_headers(&user);
 
         let resp = server
             .post("/admin/api/v1/organizations")
-            .add_header(&first_headers[0].0, &first_headers[0].1)
-            .add_header(&first_headers[1].0, &first_headers[1].1)
-            .json(&json!({ "name": "Acme Engineering", "email": "eng@acme.test" }))
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .json(&json!({ "name": "Gone Ltd", "email": "billing@gone.test" }))
             .await;
         resp.assert_status(axum::http::StatusCode::CREATED);
+        let org_id = resp.json::<serde_json::Value>()["id"].as_str().unwrap().to_string();
 
-        // A colleague - same email domain - can't stand up a second one.
-        let second = create_test_user(&pool, Role::StandardUser).await;
-        let second_headers = add_auth_headers(&second);
+        {
+            let mut conn = pool.acquire().await.unwrap();
+            assert!(
+                crate::db::handlers::Organizations::new(&mut conn)
+                    .find_by_domain("gone.test")
+                    .await
+                    .unwrap()
+                    .is_some(),
+                "matches while it exists"
+            );
+        }
+
         let resp = server
-            .post("/admin/api/v1/organizations")
-            .add_header(&second_headers[0].0, &second_headers[0].1)
-            .add_header(&second_headers[1].0, &second_headers[1].1)
-            .json(&json!({ "name": "Acme Sales", "email": "sales@acme.test" }))
+            .delete(&format!("/admin/api/v1/organizations/{org_id}"))
+            .add_header(&pm_headers[0].0, &pm_headers[0].1)
+            .add_header(&pm_headers[1].0, &pm_headers[1].1)
             .await;
-        resp.assert_status(axum::http::StatusCode::CONFLICT);
-        let text = resp.text();
+        assert!(resp.status_code().is_success(), "delete failed: {}", resp.text());
+
+        let mut conn = pool.acquire().await.unwrap();
         assert!(
-            text.contains("already has a workspace") && text.contains("Acme Engineering"),
-            "the refusal should name the workspace to ask for, got: {text}"
+            crate::db::handlers::Organizations::new(&mut conn)
+                .find_by_domain("gone.test")
+                .await
+                .unwrap()
+                .is_none(),
+            "a deleted workspace must not collect join requests"
         );
     }
 
@@ -2414,7 +2474,7 @@ mod tests {
         let owner = create_test_user(&pool, Role::StandardUser).await;
         let org_admin = create_test_user(&pool, Role::StandardUser).await;
         let member = create_test_user(&pool, Role::StandardUser).await;
-        let other_owner = create_test_user_on_domain(&pool, Role::StandardUser, "other-tenant.test").await;
+        let other_owner = create_test_user(&pool, Role::StandardUser).await;
         let other_owner_headers = add_auth_headers(&other_owner);
 
         let resp = server
@@ -2487,37 +2547,25 @@ mod tests {
 
     // ── Org membership limit ──────────────────────────────────────────────
 
-    /// The cap counts *memberships*, not authorship.
-    ///
-    /// This used to have one user create MAX_ORGS_PER_USER organizations back
-    /// to back, which is no longer possible: an organization claims its owner's
-    /// email domain, so a user can self-serve at most one. The cap still bites
-    /// via invitations, so that's the route it's exercised through now.
     #[sqlx::test]
     #[test_log::test]
     async fn test_cannot_create_org_when_at_limit(pool: PgPool) {
         let (server, _bg) = create_test_app(pool.clone(), false).await;
-        let pm = create_test_admin_user(&pool, Role::PlatformManager).await;
-        let pm_headers = add_auth_headers(&pm);
-
-        // The user is on a domain nobody has claimed, so nothing but the cap
-        // stands between them and their own workspace.
-        let user = create_test_user_on_domain(&pool, Role::StandardUser, "at-limit.test").await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
         let user_headers = add_auth_headers(&user);
 
+        // Create MAX_ORGS_PER_USER orgs
         for i in 0..super::MAX_ORGS_PER_USER {
-            let owner = create_test_user_on_domain(&pool, Role::StandardUser, &format!("host-{i}.test")).await;
-            let org_id = create_org_for(&server, &pm_headers, &format!("org-{i}"), &format!("org{i}@example.com"), owner.id).await;
-
             let resp = server
-                .post(&format!("/admin/api/v1/organizations/{org_id}/members"))
-                .add_header(&pm_headers[0].0, &pm_headers[0].1)
-                .add_header(&pm_headers[1].0, &pm_headers[1].1)
-                .json(&json!({ "user_id": user.id, "role": "member" }))
+                .post("/admin/api/v1/organizations")
+                .add_header(&user_headers[0].0, &user_headers[0].1)
+                .add_header(&user_headers[1].0, &user_headers[1].1)
+                .json(&json!({ "name": format!("org-{i}"), "email": format!("org{i}@example.com") }))
                 .await;
             resp.assert_status(axum::http::StatusCode::CREATED);
         }
 
+        // Next one should fail
         let resp = server
             .post("/admin/api/v1/organizations")
             .add_header(&user_headers[0].0, &user_headers[0].1)
@@ -2525,13 +2573,10 @@ mod tests {
             .json(&json!({ "name": "one-too-many", "email": "extra@example.com" }))
             .await;
         resp.assert_status(axum::http::StatusCode::BAD_REQUEST);
-        assert!(resp.text().contains("maximum"));
+        let body = resp.text();
+        assert!(body.contains("maximum"));
     }
 
-    // ── Leave organization ────────────────────────────────────────────────
-
-    /// Resending necessarily rotates the token: the original is only stored as
-    /// a hash and can't be recovered, so the old link must stop working.
     #[sqlx::test]
     #[test_log::test]
     async fn test_resend_invite_rotates_the_token(pool: PgPool) {
@@ -3492,10 +3537,10 @@ mod tests {
             let (server, _bg) = create_test_app(pool.clone(), false).await;
             let pm = create_test_admin_user(&pool, Role::PlatformManager).await;
             let pm_headers = add_auth_headers(&pm);
-            let label = if new_first { "new-first" } else { "old-first" };
-            // Each iteration needs its own domain; the organization claims it.
-            let owner = create_test_user_on_domain(&pool, Role::StandardUser, &format!("{label}.test")).await;
+            let owner = create_test_user(&pool, Role::StandardUser).await;
             let owner_headers = add_auth_headers(&owner);
+
+            let label = if new_first { "new-first" } else { "old-first" };
             let org_id = create_org_for(&server, &pm_headers, &format!("apply-{label}-org"), "billing@example.com", owner.id).await;
             let org_uuid = uuid::Uuid::parse_str(&org_id).unwrap();
 
@@ -3810,11 +3855,9 @@ mod tests {
         let (server, _bg) = create_test_app(pool.clone(), false).await;
         let pm = create_test_admin_user(&pool, Role::PlatformManager).await;
         let pm_headers = add_auth_headers(&pm);
-        // Distinct domains: an organization claims its owner's domain, so two
-        // owners on one domain can't hold two organizations.
-        let owner_a = create_test_user_on_domain(&pool, Role::StandardUser, "tenant-a.test").await;
+        let owner_a = create_test_user(&pool, Role::StandardUser).await;
         let owner_a_headers = add_auth_headers(&owner_a);
-        let owner_b = create_test_user_on_domain(&pool, Role::StandardUser, "tenant-b.test").await;
+        let owner_b = create_test_user(&pool, Role::StandardUser).await;
         let owner_b_headers = add_auth_headers(&owner_b);
 
         let org_a_id = create_org_for(&server, &pm_headers, "tenancy-org-a", "a@example.com", owner_a.id).await;

--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -261,9 +261,8 @@ pub async fn create_organization<P: PoolProvider>(
             })?
             .email
     };
-    let claimable_domain = crate::auth::utils::email_domain(&owner_email)
-        .filter(|d| !crate::auth::utils::is_personal_email_domain(d))
-        .map(str::to_string);
+    let claimable_domain =
+        crate::auth::utils::email_domain(&owner_email).filter(|d| !crate::auth::utils::is_personal_email_domain(d));
 
     // `{domain}~{suffix}`: the domain is what a colleague's signup matches on,
     // and the suffix keeps `users.username` unique so one company can hold
@@ -2212,6 +2211,38 @@ mod tests {
         let username = body["username"].as_str().unwrap();
         assert!(username.starts_with("example.com~"), "got {username}");
         assert_eq!(body["display_name"].as_str().unwrap(), "my-org");
+    }
+
+    /// Domains are case-insensitive; the things we compare them against are
+    /// not. Without normalising, `Alice@Acme.test` claims `Acme.test` and a
+    /// later `bob@acme.test` matches nothing.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_domain_claim_is_case_insensitive(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user_on_domain(&pool, Role::StandardUser, "MixedCase.test").await;
+        let headers = add_auth_headers(&user);
+
+        let resp = server
+            .post("/admin/api/v1/organizations")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .json(&json!({ "name": "Mixed Case Ltd", "email": "billing@mixedcase.test" }))
+            .await;
+        resp.assert_status(axum::http::StatusCode::CREATED);
+        let username = resp.json::<serde_json::Value>()["username"].as_str().unwrap().to_string();
+        assert!(username.starts_with("mixedcase.test~"), "claim should be lowercased, got {username}");
+
+        // A colleague whose address is cased differently still finds it.
+        let mut conn = pool.acquire().await.unwrap();
+        assert!(
+            crate::db::handlers::Organizations::new(&mut conn)
+                .find_by_domain("mixedcase.test")
+                .await
+                .unwrap()
+                .is_some(),
+            "a differently-cased colleague must still match the workspace"
+        );
     }
 
     /// A domain can hold several workspaces - prod and dev, say - and a join

--- a/dwctl/src/auth/current_user.rs
+++ b/dwctl/src/auth/current_user.rs
@@ -191,12 +191,12 @@ async fn try_proxy_header_auth<P: sqlx_pool_router::PoolProvider + Clone + Send 
 
                     // Auto-org: join or create organization based on email domain
                     if let Some(domain) = crate::auth::utils::email_domain(&user.email)
-                        && !crate::auth::utils::is_personal_email_domain(domain)
+                        && !crate::auth::utils::is_personal_email_domain(&domain)
                     {
                         use crate::db::handlers::Organizations;
 
                         let mut org_repo = Organizations::new(&mut tx);
-                        match org_repo.find_by_domain(domain).await {
+                        match org_repo.find_by_domain(&domain).await {
                             Ok(Some(org)) => {
                                 // Org exists — ask to join rather than joining.
                                 //
@@ -207,7 +207,7 @@ async fn try_proxy_header_auth<P: sqlx_pool_router::PoolProvider + Clone + Send 
                                 // admin decides. Sharing an email domain is evidence that
                                 // someone probably belongs, not that they do.
                                 if let Err(e) = org_repo.create_join_request(org.id, user.id).await {
-                                    tracing::warn!("Failed to record join request for org {}: {e}", domain);
+                                    tracing::warn!("Failed to record join request for org {domain}: {e}");
                                 }
                             }
                             Ok(None) => {

--- a/dwctl/src/auth/current_user.rs
+++ b/dwctl/src/auth/current_user.rs
@@ -194,7 +194,6 @@ async fn try_proxy_header_auth<P: sqlx_pool_router::PoolProvider + Clone + Send 
                         && !crate::auth::utils::is_personal_email_domain(domain)
                     {
                         use crate::db::handlers::Organizations;
-                        use crate::db::models::organizations::OrganizationCreateDBRequest;
 
                         let mut org_repo = Organizations::new(&mut tx);
                         match org_repo.find_by_domain(domain).await {
@@ -212,17 +211,18 @@ async fn try_proxy_header_auth<P: sqlx_pool_router::PoolProvider + Clone + Send 
                                 }
                             }
                             Ok(None) => {
-                                // No org for this domain — create one with user as owner
-                                let org_request = OrganizationCreateDBRequest {
-                                    name: domain.to_string(),
-                                    email: user.email.clone(),
-                                    display_name: None,
-                                    avatar_url: None,
-                                    created_by: user.id,
-                                };
-                                if let Err(e) = org_repo.create(&org_request, &config.auth.default_user_roles).await {
-                                    tracing::warn!("Failed to auto-create org for domain {domain}: {e}");
-                                }
+                                // Nobody has claimed this domain yet, so there is nothing
+                                // to join and we deliberately don't invent one.
+                                //
+                                // Signing up used to auto-create an organization named
+                                // after the domain, which made the first person through
+                                // the door its owner by accident - typically whichever
+                                // engineer tried the product first, not whoever should
+                                // hold the billing account. The user starts in Personal
+                                // context and claims the domain if and when they create
+                                // a workspace, which is where the name is chosen and the
+                                // ownership is deliberate.
+                                tracing::debug!("No organization claims domain {domain}; leaving user in personal context");
                             }
                             Err(e) => {
                                 tracing::warn!("Failed to look up org by domain {domain}: {e}");
@@ -1747,34 +1747,54 @@ mod tests {
 
     // ── Auto-org on SSO signup ──────────────────────────────────────────
 
+    /// Signing up no longer conjures an organization.
+    ///
+    /// It used to create one named after the email domain, which made whoever
+    /// tried the product first its owner by accident - typically an engineer
+    /// evaluating it, not whoever should hold the billing account. The user
+    /// now starts in Personal context and claims the domain deliberately, by
+    /// creating a workspace.
     #[sqlx::test]
-    async fn test_proxy_header_signup_creates_org_for_business_email(pool: PgPool) {
+    async fn test_proxy_header_signup_does_not_create_an_org(pool: PgPool) {
         let mut config = create_test_config();
         config.auth.proxy_header.enabled = true;
         config.auth.proxy_header.auto_create_users = true;
 
         let state = crate::test::utils::create_test_app_state_with_config(pool.clone(), config).await;
 
-        let email = "alice@acme.com";
-        let external_id = "auth0|alice-acme";
-        let mut parts = create_test_parts_with_auth(external_id, email);
+        let mut parts = create_test_parts_with_auth("auth0|alice-acme", "alice@acme.com");
+        let current_user = CurrentUser::from_request_parts(&mut parts, &state).await.unwrap();
 
-        let result = CurrentUser::from_request_parts(&mut parts, &state).await;
-        assert!(result.is_ok());
-        let current_user = result.unwrap();
-
-        // Verify an org was created with username = domain
         let mut conn = pool.acquire().await.unwrap();
         let mut org_repo = Organizations::new(&mut conn);
-        let org = org_repo.find_by_domain("acme.com").await.unwrap();
-        assert!(org.is_some(), "Org should have been auto-created for acme.com");
+        assert!(
+            org_repo.find_by_domain("acme.com").await.unwrap().is_none(),
+            "signup must not claim the domain on the user's behalf"
+        );
+        assert!(
+            org_repo.list_user_organizations(current_user.id).await.unwrap().is_empty(),
+            "the user starts in personal context"
+        );
+    }
 
-        let org = org.unwrap();
-        assert_eq!(org.username, "acme.com");
-
-        // User should be owner
-        let role = org_repo.get_user_org_role(current_user.id, org.id).await.unwrap();
-        assert_eq!(role, Some("owner".to_string()));
+    /// Claim a domain the way creating a workspace does: an organization whose
+    /// username is the domain, owned by `owner`.
+    async fn claim_domain(pool: &PgPool, domain: &str, owner: crate::types::UserId) -> crate::types::UserId {
+        let mut conn = pool.acquire().await.unwrap();
+        let org = Organizations::new(&mut conn)
+            .create(
+                &crate::db::models::organizations::OrganizationCreateDBRequest {
+                    name: domain.to_string(),
+                    email: format!("billing@{domain}"),
+                    display_name: Some(domain.to_string()),
+                    avatar_url: None,
+                    created_by: owner,
+                },
+                &[crate::api::models::users::Role::StandardUser],
+            )
+            .await
+            .unwrap();
+        org.id
     }
 
     #[sqlx::test]
@@ -1790,9 +1810,10 @@ mod tests {
 
         let state = crate::test::utils::create_test_app_state_with_config(pool.clone(), config).await;
 
-        // First user still claims the unclaimed domain and owns the org.
+        // Someone has already claimed the domain by creating a workspace.
         let mut parts1 = create_test_parts_with_auth("auth0|first", "first@widgets.io");
         let first = CurrentUser::from_request_parts(&mut parts1, &state).await.unwrap();
+        claim_domain(&pool, "widgets.io", first.id).await;
 
         let mut parts2 = create_test_parts_with_auth("auth0|second", "second@widgets.io");
         let second = CurrentUser::from_request_parts(&mut parts2, &state).await.unwrap();
@@ -1837,7 +1858,8 @@ mod tests {
         let state = crate::test::utils::create_test_app_state_with_config(pool.clone(), config).await;
 
         let mut owner_parts = create_test_parts_with_auth("auth0|owner", "owner@widgets.io");
-        CurrentUser::from_request_parts(&mut owner_parts, &state).await.unwrap();
+        let owner = CurrentUser::from_request_parts(&mut owner_parts, &state).await.unwrap();
+        claim_domain(&pool, "widgets.io", owner.id).await;
 
         for i in 0..3 {
             let mut parts = create_test_parts_with_auth("auth0|joiner", "joiner@widgets.io");

--- a/dwctl/src/auth/utils.rs
+++ b/dwctl/src/auth/utils.rs
@@ -53,8 +53,15 @@ pub fn generate_random_display_name() -> String {
 
 /// Extract the domain part from an email address.
 /// Returns `None` if the email doesn't contain an `@`.
-pub fn email_domain(email: &str) -> Option<&str> {
-    email.rsplit_once('@').map(|(_, domain)| domain)
+/// The domain part of an email address, lowercased.
+///
+/// Normalised because domains are case-insensitive but the things we compare
+/// them against are not. Without it `Alice@Acme.com` claims `Acme.com`, a
+/// later `bob@acme.com` fails to match it and gets no join request, and -
+/// worse - `x@GMAIL.com` slips past `is_personal_email_domain` and claims
+/// gmail.com as a company domain.
+pub fn email_domain(email: &str) -> Option<String> {
+    email.rsplit_once('@').map(|(_, domain)| domain.to_ascii_lowercase())
 }
 
 /// Returns `true` if the domain belongs to a personal/free email provider

--- a/dwctl/src/db/handlers/organizations.rs
+++ b/dwctl/src/db/handlers/organizations.rs
@@ -106,6 +106,22 @@ impl<'c> Organizations<'c> {
     /// Find an organization by its domain (stored as username).
     /// Returns `None` if no active (non-deleted) organization exists with that domain.
     #[instrument(skip(self), fields(domain = %domain), err)]
+    /// The organization a join request for `domain` should go to.
+    ///
+    /// Organization usernames are `{domain}~{suffix}`, so one company can hold
+    /// several workspaces - prod and dev being the obvious pair - while
+    /// `users.username` stays unique. The bare `username = $1` arm matches
+    /// organizations created before the suffix existed, whose username is the
+    /// domain alone.
+    ///
+    /// `~` is the separator precisely because it can't occur in a domain, so
+    /// the prefix match is exact: "acme.com" cannot match an organization for
+    /// "acme.com.au", which a plain `LIKE 'acme.com%'` would have done and
+    /// routed a join request to the wrong company.
+    ///
+    /// Several may match; the oldest surviving one wins. That's the workspace a
+    /// colleague signing up is most likely to mean, and it stays stable as
+    /// later ones come and go.
     pub async fn find_by_domain(&mut self, domain: &str) -> Result<Option<UserDBResponse>> {
         let row = sqlx::query!(
             r#"
@@ -115,7 +131,14 @@ impl<'c> Organizations<'c> {
                    low_balance_notification_sent, low_balance_threshold,
                    auto_topup_amount, auto_topup_threshold, auto_topup_monthly_limit, user_type, verified, zero_data_retention
             FROM users
-            WHERE username = $1 AND user_type = 'organization' AND is_deleted = false
+            WHERE (username = $1 OR username LIKE $1 || '~%')
+              AND user_type = 'organization'
+              -- A soft-deleted workspace must never receive join requests:
+              -- nobody is left to approve them, so the requester would sit on a
+              -- queue no one can see.
+              AND is_deleted = false
+            ORDER BY created_at ASC
+            LIMIT 1
             "#,
             domain
         )

--- a/dwctl/src/test/utils.rs
+++ b/dwctl/src/test/utils.rs
@@ -354,12 +354,26 @@ pub fn create_test_config() -> crate::config::Config {
     }
 }
 
+/// A test user on a caller-chosen email domain.
+///
+/// Organizations claim their owner's email domain as their username, so tests
+/// that create more than one organization need owners on *different* domains -
+/// and tests about domain collisions need them on the same one. The default
+/// helper puts everyone on example.com, which makes both impossible to express.
+pub async fn create_test_user_on_domain(pool: &PgPool, role: Role, domain: &str) -> UserResponse {
+    create_test_user_inner(pool, role, Some(domain)).await
+}
+
 pub async fn create_test_user(pool: &PgPool, role: Role) -> UserResponse {
+    create_test_user_inner(pool, role, None).await
+}
+
+async fn create_test_user_inner(pool: &PgPool, role: Role, domain: Option<&str>) -> UserResponse {
     let mut conn = pool.acquire().await.expect("Failed to acquire connection");
     let mut users_repo = Users::new(&mut conn);
     let user_id = Uuid::new_v4();
     let username = format!("testuser_{}", user_id.simple());
-    let email = format!("{username}@example.com");
+    let email = format!("{username}@{}", domain.unwrap_or("example.com"));
 
     let roles = vec![role];
 


### PR DESCRIPTION
No fenced code blocks in this body — squash uses PR_BODY, and a code fence is what stopped release-please cutting a release for #1430.

## What signup used to do

First login with a business email domain created an organization named after that domain, with the user as owner. Whoever tried the product first became owner **by accident** — usually an engineer evaluating it, not whoever should hold the billing account — and the organization existed whether anyone wanted one or not.

Signup now creates nothing. A user whose domain is unclaimed starts in Personal context; the domain gets claimed when they deliberately create a workspace.

## How the domain is carried

Organization usernames are `{domain}~{suffix}`. The domain is what a colleague's signup matches on; the random suffix keeps `users.username` unique **without capping a domain at one workspace**, so a company can run prod and dev.

No schema change — the domain stays encoded in the field it was always encoded in, so there's nothing to migrate or backfill.

`~` is the separator specifically because it cannot occur in a domain. That keeps the match exact: a plain prefix match would make "acme.com" match a workspace belonging to **"acme.com.au"** and route that company's join requests to the wrong place.

Several workspaces can match, so **the oldest surviving one wins**. That's the one a colleague signing up most likely means, and it stays stable as later workspaces come and go. Organizations created before the suffix existed still match via the bare equality arm.

## Deleted workspaces

Excluded from matching. Nobody is left to approve a request, so the requester would sit on a queue no one can see. Deletion also scrubs the username to `deleted-{id}`, so a deleted workspace is unreachable by domain twice over — the test pins the behaviour rather than the belt and braces.

## Two guards on the claim

- The domain comes from the **owner's own address**, not the request body, so a caller can't claim a domain they don't have mail at.
- Owners on **personal email domains** fall back to the submitted name. There's nothing worth matching on, and a workspace claiming gmail.com would catch every consumer signup.

## Also here: a replication-lag fix

`/users/{id}/organizations` now uses the primary pool. Those summaries carry `verified`, and clients read it **straight after the write that sets it** — the card-verification return marks the organization verified, then the UI re-reads to drop its "Verification pending" badge. Off the replica that read can land before the flag propagates, leaving the badge up on an account that has just paid. `get_user` already avoids the same trap for the same reason.

## Test plan

- `cargo test -p dwctl` — **1950 pass**
- Rewrote the three tests encoding the old contract: signup no longer creates an org, and the two join-request tests claim the domain explicitly rather than relying on signup to do it
- New: a domain holds two workspaces and the oldest gets the join request; a deleted workspace stops matching

## Depends on

#1437 — `just lint rust` fails against main for every PR right now (stale fusillade-core baseline), so CI here stays red until that lands.

## Follow-up not in this PR

Onboarding still shows the create-workspace screen to a user whose domain is already claimed. Offering "request to join" instead is the matching app change and needs this deployed first.