### PR TITLE
fix(ci): track the fusillade-core 5.0.0 release baseline

### DIFF
--- a/.github/scripts/test-local-rust-workspace.sh
+++ b/.github/scripts/test-local-rust-workspace.sh
@@ -206,8 +206,8 @@ if set(release_manifest) != {
     )
 if release_manifest["fusillade-arsenal"] != "3.1.0":
     raise SystemExit("Fusillade Arsenal release baseline must remain 3.1.0")
-if release_manifest["fusillade-core"] != "4.1.0":
-    raise SystemExit("Fusillade Core release baseline must remain 4.1.0")
+if release_manifest["fusillade-core"] != "5.0.0":
+    raise SystemExit("Fusillade Core release baseline must remain 5.0.0")
 PY
 
 release_workflow=".github/workflows/release.yml"


### PR DESCRIPTION
**Every pull request's rust lint is currently failing against main**, not just ones touching Fusillade:

    Fusillade Core release baseline must remain 4.1.0

## Why

The guard in `.github/scripts/test-local-rust-workspace.sh` asserts an exact version so an accidental edit to `.release-please-manifest.json` gets caught. But a real release moves that version legitimately, and #1401 shipped fusillade-core 5.0.0 and updated the manifest without updating the assertion guarding it.

So the manifest says 5.0.0, the guard insists on 4.1.0, and `just lint rust` has failed on main ever since.

Arsenal is untouched — still 3.1.0 in both the manifest and the guard, which is why only core trips it.

## The change

One line pair, moving the baseline to 5.0.0.

Worth flagging that this will recur on the next core release. Making the guard read the value it's guarding would defeat its purpose, so the durable fix is a checklist item on the release PR rather than anything in code here.

## Test plan

`.github/scripts/test-local-rust-workspace.sh` passes; it exits non-zero on main. Sent separately from my org-domain work (#1435) since it blocks everyone's CI, not just mine.