### PR TITLE
fix: filtered-empty key list keeps scoping controls and correct empty…

### DIFF
--- a/dashboard/src/components/features/api-keys/ApiKeys/ApiKeys.functional.test.tsx
+++ b/dashboard/src/components/features/api-keys/ApiKeys/ApiKeys.functional.test.tsx
@@ -1239,6 +1239,76 @@ describe("API Keys Component - Functional Tests", () => {
       ).not.toBeInTheDocument();
     });
 
+    it("keeps the scoping controls when a member filter matches no keys", async () => {
+      const user = userEvent.setup();
+      enterOrgContext("owner");
+
+      server.use(
+        // Server-side filter emulation: James holds no keys, so filtering
+        // by him yields an empty page.
+        http.get("/admin/api/v1/users/:userId/api-keys", ({ request }) => {
+          const url = new URL(request.url);
+          const createdBy = url.searchParams.get("created_by");
+          const all = [
+            {
+              id: "mgr-key",
+              name: "Manager Key",
+              created_at: "2026-01-01T00:00:00Z",
+              created_by: managerId,
+              secret_revealed_at: "2026-01-01T00:00:00Z",
+            },
+          ];
+          const data = createdBy
+            ? all.filter((k) => k.created_by === createdBy)
+            : all;
+          return HttpResponse.json({
+            data,
+            total_count: data.length,
+            skip: 0,
+            limit: 10,
+          });
+        }),
+      );
+
+      const { container } = render(<ApiKeys />, { wrapper: createWrapper() });
+      await within(container).findByText("Manager Key");
+
+      await user.click(
+        within(container).getByRole("combobox", { name: /filter by member/i }),
+      );
+      await user.click(
+        screen.getByRole("option", { name: "james.wilson@acme.com" }),
+      );
+
+      // Filtered-empty state: NOT the unscoped "create your first key"
+      // onboarding, and the controls stay mounted so the admin can back
+      // out of the filter.
+      await waitFor(() => {
+        expect(
+          within(container).getByText(/no keys match this filter/i),
+        ).toBeInTheDocument();
+      });
+      expect(
+        within(container).getByText(/holds no api keys in this organization/i),
+      ).toBeInTheDocument();
+      expect(
+        within(container).queryByText(/no api keys configured/i),
+      ).not.toBeInTheDocument();
+      expect(
+        within(container).getByRole("tab", { name: /all keys/i }),
+      ).toBeInTheDocument();
+      expect(
+        within(container).getByRole("combobox", { name: /filter by member/i }),
+      ).toBeInTheDocument();
+
+      // Backing out restores the list without leaving the page.
+      await user.click(
+        within(container).getByRole("combobox", { name: /filter by member/i }),
+      );
+      await user.click(screen.getByRole("option", { name: "All members" }));
+      await within(container).findByText("Manager Key");
+    });
+
     it("bulk-rotates the selected keys and shows the new secrets once", async () => {
       const user = userEvent.setup();
       enterOrgContext("owner");

--- a/dashboard/src/components/features/api-keys/ApiKeys/ApiKeys.tsx
+++ b/dashboard/src/components/features/api-keys/ApiKeys/ApiKeys.tsx
@@ -520,7 +520,10 @@ export const ApiKeys: React.FC = () => {
         </div>
       )}
 
-      {showScopingControls && apiKeys.length > 0 && (
+      {/* Keep the scoping controls mounted whenever a filter is active —
+          a member with zero keys must leave the admin a way to back out,
+          not dump them on the unscoped empty state. */}
+      {showScopingControls && (apiKeys.length > 0 || createdByFilter != null) && (
         <div className="mb-4 flex flex-wrap items-center gap-3">
           <Tabs
             value={keyScope}
@@ -551,7 +554,29 @@ export const ApiKeys: React.FC = () => {
         </div>
       )}
 
-      {apiKeys.length > 0 ? (
+      {apiKeys.length === 0 && createdByFilter != null ? (
+        <div
+          className="text-center py-12"
+          role="status"
+          aria-label="No keys for this filter"
+        >
+          <div className="p-4 bg-doubleword-neutral-100 rounded-full w-16 h-16 mx-auto mb-4 flex items-center justify-center">
+            <Key className="w-8 h-8 text-doubleword-neutral-600" />
+          </div>
+          <h3
+            className="text-lg font-medium text-doubleword-neutral-900 mb-2"
+            role="heading"
+            aria-level={3}
+          >
+            No keys match this filter
+          </h3>
+          <p className="text-doubleword-neutral-600">
+            {keyScope === "mine"
+              ? "You don't hold any keys in this organization yet."
+              : "The selected member holds no API keys in this organization. Try another member or switch back to all members."}
+          </p>
+        </div>
+      ) : apiKeys.length > 0 ? (
         <DataTable
           columns={columns}
           data={apiKeys}


### PR DESCRIPTION
… state

Filtering to a member with no keys (server-side ?created_by) rendered the unscoped 'No API keys configured' onboarding and unmounted the tabs/member filter, stranding the admin. Zero rows under an active filter now shows a filtered-empty message with the controls still mounted to back out.