### PR TITLE
feat(organizations): let a user see their own pending join requests

### DIFF
--- a/.sqlx/query-1d503ed699849350f076dd299b44e5778d9a2dce804de6c72c0f37f0eb007667.json
+++ b/.sqlx/query-1d503ed699849350f076dd299b44e5778d9a2dce804de6c72c0f37f0eb007667.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT uo.id, uo.user_id, uo.organization_id, uo.role, uo.status,\n                   uo.created_at, uo.invite_email, uo.invited_by, uo.expires_at\n            FROM user_organizations uo\n            INNER JOIN users o ON o.id = uo.organization_id\n            WHERE uo.user_id = $1\n              AND uo.status = 'requested'\n              AND o.is_deleted = false\n            ORDER BY uo.created_at ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "organization_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "role",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "invite_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "invited_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "1d503ed699849350f076dd299b44e5778d9a2dce804de6c72c0f37f0eb007667"
+}

--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -1552,15 +1552,21 @@ pub async fn list_user_organizations<P: PoolProvider>(
 /// automatically when the caller's email domain matches a claimed organization,
 /// which makes the invisible case the common one.
 ///
-/// Scoped to the caller's own requests. It deliberately does not answer "does
-/// an organization exist for this domain" in general: that would let anyone
-/// probe for the existence of a company's workspace by signing up.
+/// Answers only "what have *I* asked to join". It deliberately does not answer
+/// "does an organization exist for this domain" in general: that would let
+/// anyone probe for the existence of a company's workspace by signing up.
+///
+/// On authorization, note that "own" is about the *subject* of the query, not
+/// the caller: a platform manager holding ReadAll on Users may read another
+/// user's requests, exactly as they may read that user's organizations via
+/// `/users/{id}/organizations` beside it. An ordinary caller is confined to
+/// their own, and a non-`current` path they don't own is a 403.
 #[utoipa::path(
     get,
     path = "/users/{user_id}/join-requests",
     tag = "organizations",
     summary = "List user's pending join requests",
-    description = "List organizations the user has asked to join and is awaiting a decision on.",
+    description = "List organizations the user has asked to join and is awaiting a decision on. Readable by that user, or by a platform manager with read-all on users.",
     params(
         ("user_id" = String, Path, description = "User ID (UUID) or 'current' for current user"),
     ),
@@ -1610,6 +1616,14 @@ pub async fn list_user_join_requests<P: PoolProvider>(
     let mut users_repo = Users::new(&mut pool_conn);
     let org_map = users_repo.get_bulk(org_ids).await?;
 
+    // `filter_map` cannot silently swallow a live request here: both halves
+    // apply the same `is_deleted = false` filter — `list_user_join_requests`
+    // INNER JOINs it, `get_bulk` has it in its WHERE — so a request that
+    // survived the first query has its organization in `org_map`. The only way
+    // to miss is the organization being deleted between the two, and dropping
+    // it is then the correct answer rather than a lost row: a deleted
+    // organization has nobody left to approve, which is exactly why the query
+    // excludes them in the first place.
     let responses: Vec<crate::api::models::organizations::PendingJoinRequestResponse> = requests
         .iter()
         .filter_map(|r| {

--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -1543,6 +1543,90 @@ pub async fn list_user_organizations<P: PoolProvider>(
     Ok(Json(summaries))
 }
 
+/// List the caller's own outstanding join requests.
+///
+/// The requester-side counterpart to `/organizations/{id}/join-requests`. That
+/// endpoint is gated on managing the organization, which a requester by
+/// definition cannot do — they are not a member yet — so without this a user
+/// has no way to learn that a request exists on their behalf. Signup files one
+/// automatically when the caller's email domain matches a claimed organization,
+/// which makes the invisible case the common one.
+///
+/// Scoped to the caller's own requests. It deliberately does not answer "does
+/// an organization exist for this domain" in general: that would let anyone
+/// probe for the existence of a company's workspace by signing up.
+#[utoipa::path(
+    get,
+    path = "/users/{user_id}/join-requests",
+    tag = "organizations",
+    summary = "List user's pending join requests",
+    description = "List organizations the user has asked to join and is awaiting a decision on.",
+    params(
+        ("user_id" = String, Path, description = "User ID (UUID) or 'current' for current user"),
+    ),
+    responses(
+        (status = 200, description = "Pending join requests", body = Vec<crate::api::models::organizations::PendingJoinRequestResponse>),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+    ),
+    security(
+        ("BearerAuth" = []),
+        ("CookieAuth" = []),
+        ("X-Doubleword-User" = [])
+    )
+)]
+#[tracing::instrument(skip_all)]
+pub async fn list_user_join_requests<P: PoolProvider>(
+    State(state): State<AppState<P>>,
+    Path(user_id): Path<UserIdOrCurrent>,
+    current_user: CurrentUser,
+) -> Result<Json<Vec<crate::api::models::organizations::PendingJoinRequestResponse>>> {
+    let target_user_id = match user_id {
+        UserIdOrCurrent::Current(_) => current_user.id,
+        UserIdOrCurrent::Id(uuid) => uuid,
+    };
+
+    let can_all = can_read_all_resources(&current_user, Resource::Users);
+    let can_own = can_read_own_resource(&current_user, Resource::Users, target_user_id);
+    if !can_all && !can_own {
+        return Err(Error::InsufficientPermissions {
+            required: Permission::Allow(Resource::Users, Operation::ReadOwn),
+            action: Operation::ReadOwn,
+            resource: format!("Join requests for user {target_user_id}"),
+        });
+    }
+
+    // Primary, not the replica: signup records the request during the very
+    // first login, and onboarding reads this immediately afterwards to decide
+    // whether to offer "request to join" instead of "create a workspace". Off
+    // the replica that read can land before the row propagates, and the user
+    // gets the create-workspace screen this endpoint exists to replace. Same
+    // trap `list_user_organizations` above avoids for the same reason.
+    let mut pool_conn = state.db.write().acquire().await.map_err(|e| Error::Database(e.into()))?;
+    let mut repo = Organizations::new(&mut pool_conn);
+    let requests = repo.list_user_join_requests(target_user_id).await?;
+
+    let org_ids: Vec<UserId> = requests.iter().map(|r| r.organization_id).collect();
+    let mut users_repo = Users::new(&mut pool_conn);
+    let org_map = users_repo.get_bulk(org_ids).await?;
+
+    let responses: Vec<crate::api::models::organizations::PendingJoinRequestResponse> = requests
+        .iter()
+        .filter_map(|r| {
+            org_map
+                .get(&r.organization_id)
+                .map(|o| crate::api::models::organizations::PendingJoinRequestResponse {
+                    id: r.id,
+                    organization_id: o.id,
+                    organization_name: o.username.clone(),
+                    requested_at: r.created_at,
+                })
+        })
+        .collect();
+
+    Ok(Json(responses))
+}
+
 /// Validate and confirm an active organization context.
 ///
 /// Sets a `dw_active_org` cookie so the browser sends it automatically with all
@@ -2818,6 +2902,127 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(role, None, "the request must still be outstanding");
+    }
+
+    /// The requester can't read the organization-scoped queue - that's gated on
+    /// managing the org, which they can't do until they're approved. Without a
+    /// user-scoped view, a request filed on their behalf at signup would be
+    /// invisible to the only person waiting on it.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_user_sees_their_own_pending_join_request(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let owner = create_test_user(&pool, Role::StandardUser).await;
+        let joiner = create_test_user(&pool, Role::StandardUser).await;
+        let (org_id, request_id) = org_with_join_request(&pool, owner.id, joiner.id).await;
+        let joiner_headers = add_auth_headers(&joiner);
+
+        // The org-scoped queue stays shut to them.
+        let resp = server
+            .get(&format!("/admin/api/v1/organizations/{org_id}/join-requests"))
+            .add_header(&joiner_headers[0].0, &joiner_headers[0].1)
+            .add_header(&joiner_headers[1].0, &joiner_headers[1].1)
+            .await;
+        resp.assert_status(axum::http::StatusCode::FORBIDDEN);
+
+        let resp = server
+            .get("/admin/api/v1/users/current/join-requests")
+            .add_header(&joiner_headers[0].0, &joiner_headers[0].1)
+            .add_header(&joiner_headers[1].0, &joiner_headers[1].1)
+            .await;
+        resp.assert_status_ok();
+        let body = resp.json::<serde_json::Value>();
+        let items = body.as_array().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["id"].as_str().unwrap(), request_id.to_string());
+        assert_eq!(items[0]["organization_id"].as_str().unwrap(), org_id.to_string());
+        assert!(items[0]["organization_name"].as_str().is_some_and(|n| !n.is_empty()));
+
+        // It carries only the organization's identity - nothing about who else
+        // is in it, or is queued for it.
+        assert!(items[0].get("user").is_none());
+        assert!(items[0].get("member_count").is_none());
+    }
+
+    /// Approval is the end of the request, so the banner it drives must clear
+    /// on its own rather than lingering after the user is already inside.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_own_join_requests_clear_once_decided(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let owner = create_test_user(&pool, Role::StandardUser).await;
+        let joiner = create_test_user(&pool, Role::StandardUser).await;
+        let (org_id, request_id) = org_with_join_request(&pool, owner.id, joiner.id).await;
+        let joiner_headers = add_auth_headers(&joiner);
+        let owner_headers = add_auth_headers(&owner);
+
+        let resp = server
+            .get("/admin/api/v1/users/current/join-requests")
+            .add_header(&joiner_headers[0].0, &joiner_headers[0].1)
+            .add_header(&joiner_headers[1].0, &joiner_headers[1].1)
+            .await;
+        resp.assert_status_ok();
+        assert_eq!(
+            resp.json::<serde_json::Value>().as_array().unwrap().len(),
+            1,
+            "outstanding before the decision"
+        );
+
+        let resp = server
+            .post(&format!("/admin/api/v1/organizations/{org_id}/join-requests/{request_id}/approve"))
+            .add_header(&owner_headers[0].0, &owner_headers[0].1)
+            .add_header(&owner_headers[1].0, &owner_headers[1].1)
+            .await;
+        resp.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+        let resp = server
+            .get("/admin/api/v1/users/current/join-requests")
+            .add_header(&joiner_headers[0].0, &joiner_headers[0].1)
+            .add_header(&joiner_headers[1].0, &joiner_headers[1].1)
+            .await;
+        resp.assert_status_ok();
+        assert!(
+            resp.json::<serde_json::Value>().as_array().unwrap().is_empty(),
+            "an approved request is no longer pending"
+        );
+
+        // The membership it became is visible in the place that does list it.
+        let resp = server
+            .get("/admin/api/v1/users/current/organizations")
+            .add_header(&joiner_headers[0].0, &joiner_headers[0].1)
+            .add_header(&joiner_headers[1].0, &joiner_headers[1].1)
+            .await;
+        resp.assert_status_ok();
+        assert_eq!(resp.json::<serde_json::Value>().as_array().unwrap().len(), 1);
+    }
+
+    /// Requests are the caller's own business: one user must not be able to
+    /// enumerate which organizations another has asked to join.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_own_join_requests_are_not_readable_by_other_users(pool: PgPool) {
+        let (server, _bg) = create_test_app(pool.clone(), false).await;
+        let owner = create_test_user(&pool, Role::StandardUser).await;
+        let joiner = create_test_user(&pool, Role::StandardUser).await;
+        let (_org_id, _) = org_with_join_request(&pool, owner.id, joiner.id).await;
+
+        let snooper = create_test_user(&pool, Role::StandardUser).await;
+        let snooper_headers = add_auth_headers(&snooper);
+        let resp = server
+            .get(&format!("/admin/api/v1/users/{}/join-requests", joiner.id))
+            .add_header(&snooper_headers[0].0, &snooper_headers[0].1)
+            .add_header(&snooper_headers[1].0, &snooper_headers[1].1)
+            .await;
+        resp.assert_status(axum::http::StatusCode::FORBIDDEN);
+
+        // Their own list is unaffected by the attempt, and empty.
+        let resp = server
+            .get("/admin/api/v1/users/current/join-requests")
+            .add_header(&snooper_headers[0].0, &snooper_headers[0].1)
+            .add_header(&snooper_headers[1].0, &snooper_headers[1].1)
+            .await;
+        resp.assert_status_ok();
+        assert!(resp.json::<serde_json::Value>().as_array().unwrap().is_empty());
     }
 
     #[sqlx::test]

--- a/dwctl/src/api/models/organizations.rs
+++ b/dwctl/src/api/models/organizations.rs
@@ -280,9 +280,12 @@ pub struct OrganizationSummary {
 /// readable from here.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PendingJoinRequestResponse {
-    /// The join request itself, not the organization.
+    /// The join request itself, not the organization. A `user_organizations`
+    /// row id — deliberately `Uuid` rather than `UserId`, which it is not and
+    /// which would invite a caller to pass it where a user is expected. Same
+    /// convention as `OrganizationMemberResponse::id` above.
     #[schema(value_type = String, format = "uuid")]
-    pub id: UserId,
+    pub id: uuid::Uuid,
     #[schema(value_type = String, format = "uuid")]
     pub organization_id: UserId,
     /// The organization's `username`. Carries the `{domain}~{suffix}` form for

--- a/dwctl/src/api/models/organizations.rs
+++ b/dwctl/src/api/models/organizations.rs
@@ -266,3 +266,30 @@ pub struct OrganizationSummary {
     /// workspace able to pay" must read it from here when acting as an org.
     pub verified: bool,
 }
+
+/// An organization the caller has asked to join and is waiting on.
+///
+/// Signup files these automatically when the caller's email domain matches a
+/// claimed organization, so the requester is typically unaware one exists.
+/// Onboarding reads this to say so, rather than presenting the create-workspace
+/// screen as if their company had no workspace.
+///
+/// Deliberately thinner than [`OrganizationSummary`]: the caller is not a
+/// member, so this carries only what identifies the organization they are
+/// queued for. Nothing about its membership, billing or configuration is
+/// readable from here.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PendingJoinRequestResponse {
+    /// The join request itself, not the organization.
+    #[schema(value_type = String, format = "uuid")]
+    pub id: UserId,
+    #[schema(value_type = String, format = "uuid")]
+    pub organization_id: UserId,
+    /// The organization's `username`. Carries the `{domain}~{suffix}` form for
+    /// organizations created since domains became claimable; clients that want
+    /// to show a company name should strip at the separator.
+    pub organization_name: String,
+    /// When the request was filed — on the requester's first login for one
+    /// raised by domain match.
+    pub requested_at: chrono::DateTime<chrono::Utc>,
+}

--- a/dwctl/src/db/handlers/organizations.rs
+++ b/dwctl/src/db/handlers/organizations.rs
@@ -556,6 +556,38 @@ impl<'c> Organizations<'c> {
         Ok(row.into())
     }
 
+    /// A user's own outstanding join requests, oldest first.
+    ///
+    /// The mirror of [`Self::list_join_requests`], which answers "who wants
+    /// into my organization" for an owner. This one answers "what have I asked
+    /// to join" for the requester, who is by definition not a member yet and so
+    /// cannot read the organization-scoped queue.
+    ///
+    /// Deleted organizations are excluded for the same reason they don't match
+    /// on signup: nobody is left to approve the request, so surfacing it would
+    /// promise an outcome that can never arrive.
+    #[instrument(skip(self), fields(user_id = %abbrev_uuid(&user_id)), err)]
+    pub async fn list_user_join_requests(&mut self, user_id: UserId) -> Result<Vec<OrganizationMemberDBResponse>> {
+        let rows = sqlx::query_as!(
+            MemberRow,
+            r#"
+            SELECT uo.id, uo.user_id, uo.organization_id, uo.role, uo.status,
+                   uo.created_at, uo.invite_email, uo.invited_by, uo.expires_at
+            FROM user_organizations uo
+            INNER JOIN users o ON o.id = uo.organization_id
+            WHERE uo.user_id = $1
+              AND uo.status = 'requested'
+              AND o.is_deleted = false
+            ORDER BY uo.created_at ASC
+            "#,
+            user_id
+        )
+        .fetch_all(&mut *self.db)
+        .await?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
     /// Outstanding join requests for an organization, oldest first.
     #[instrument(skip(self), fields(org_id = %abbrev_uuid(&org_id)), err)]
     pub async fn list_join_requests(&mut self, org_id: UserId) -> Result<Vec<OrganizationMemberDBResponse>> {

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1478,6 +1478,13 @@ pub async fn build_router(
             "/users/{user_id}/organizations",
             get(api::handlers::organizations::list_user_organizations),
         )
+        // A user's own outstanding join requests. Sits on the user rather than
+        // the organization because the requester isn't a member yet, so the
+        // organization-scoped queue below is closed to them.
+        .route(
+            "/users/{user_id}/join-requests",
+            get(api::handlers::organizations::list_user_join_requests),
+        )
         // Organization session context (validates membership, client stores org ID for X-Organization-Id header)
         .route("/session/organization", post(api::handlers::organizations::set_active_organization))
         // Support requests


### PR DESCRIPTION
Signup files a join request when the caller's email domain matches a claimed organization — the behaviour #1430 put in place of the silent auto-join. Nothing surfaces that request to the person it belongs to.

The only endpoint that lists join requests is scoped to an organization and gated on *managing* it, which a requester cannot do: they are not a member yet, which is the entire point of the request. So the row exists, an owner may act on it, and the one party actually waiting on the outcome has no way to learn it was ever filed. Clients are left showing the create-workspace screen to someone whose company already has a workspace, which is how a domain ends up with a second workspace nobody meant to create.

## What this adds

`GET /users/{user_id}/join-requests` — the requester-side counterpart to `/organizations/{id}/join-requests`. Same `UserIdOrCurrent` path convention and own/all permission split as `/users/{user_id}/organizations` beside it.

## Deliberate limits

- **Own requests only.** It does not answer "does an organization exist for this domain" in general. That would let anyone probe for the existence of a company's workspace by signing up with a matching address.
- **Thin response.** The caller is not a member, so it carries what identifies the organization they are queued for and nothing about its membership, billing or configuration. A test asserts the absence rather than trusting the struct to stay thin.
- **Deleted organizations excluded**, matching the domain-matching rule #1435 established: nobody is left to approve the request, so surfacing it would promise an outcome that can never arrive.

## Pool choice

Reads go to the primary. Signup records the request during the very first login and a client reads this immediately afterwards to decide what to render — off the replica that read can land before the row propagates, and the user gets exactly the screen this endpoint exists to replace. The same inter-endpoint consistency trap `list_user_organizations` already avoids for the same reason.

## Test plan

- `cargo test -p dwctl` — **1968 passed, 0 failed**
- `just lint rust` — clean
- `cargo sqlx prepare --check --workspace` — passes; one new query added to the offline cache
- New cases: the requester sees their own request while the org-scoped queue still 403s them; the request disappears once approved and the membership shows up in the endpoint that does list memberships; another user gets 403 trying to read someone else's requests

## Consumed by

doublewordai/app-doubleword-private#186, which uses it to tell a team signup that their domain already has a workspace instead of silently offering them a second one. That PR is safe to merge first — without this endpoint the query 404s and the notice stays hidden.