### PR TITLE
test: wait for onwards to apply config before returning from sync_onwards_config

### DIFF
--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -2310,12 +2310,64 @@ impl BackgroundServices {
             crate::sync::onwards_config::load_targets_from_db(pool, &[], self.strict_mode, &crate::config::RateLimitTiersConfig::default())
                 .await?;
 
+        // Snapshot the routing table this update should produce, before the
+        // config is handed to the channel.
+        //
+        // `send` only queues the config for `Targets::receive_updates`, which
+        // applies it on its own task, so returning as soon as it succeeds does
+        // not mean the proxy can serve the new config yet. A test that goes
+        // straight from here to a proxied request can beat the apply and get a
+        // 403 for an API key that is already committed to the database.
+        //
+        // Both the alias set and each pool's authorised-key count are checked:
+        // a stale pool that already has the right alias but not yet the new key
+        // is exactly what produces the spurious 403.
+        let expected: Vec<(String, usize)> = new_targets
+            .targets
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().keys().map_or(0, |keys| keys.len())))
+            .collect();
+
         // Send through the watch channel (same as automatic sync)
         sender
             .send(new_targets)
             .map_err(|_| anyhow::anyhow!("Failed to send targets update"))?;
 
-        Ok(())
+        // `onwards_targets` shares its maps with the router's `AppState`, so
+        // polling it observes exactly what a proxied request would resolve
+        // against. Reaching this point means the sender exists, which in turn
+        // means `receive_updates` was wired for this app, so an update that
+        // never lands is a real failure rather than a disabled-sync no-op.
+        //
+        // Note this cannot detect an update that changes nothing structural
+        // (e.g. only an endpoint URL) - such an update matches immediately and
+        // returns without waiting, exactly as before.
+        //
+        // The budget is deliberately longer than the config listener's periodic
+        // fallback sync: the listener shares this watch channel, so a periodic
+        // reload that started loading just before the test's own write could
+        // land after this send and briefly apply the older config. The next
+        // fallback sync corrects that, and waiting past one interval means the
+        // helper rides it out instead of failing the test.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        loop {
+            let live = &self.onwards_targets.targets;
+            let applied = live.len() == expected.len()
+                && expected.iter().all(|(alias, key_count)| {
+                    live.get(alias)
+                        .is_some_and(|pool| pool.keys().map_or(0, |keys| keys.len()) == *key_count)
+                });
+
+            if applied {
+                return Ok(());
+            }
+
+            if std::time::Instant::now() >= deadline {
+                anyhow::bail!("onwards did not apply the config update within 5s");
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
     }
 
     /// Manually refresh the per-key ZDR cache from the database (for testing).

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -2319,14 +2319,20 @@ impl BackgroundServices {
         // straight from here to a proxied request can beat the apply and get a
         // 403 for an API key that is already committed to the database.
         //
-        // Both the alias set and each pool's authorised-key count are checked:
-        // a stale pool that already has the right alias but not yet the new key
-        // is exactly what produces the spurious 403.
-        let expected: Vec<(String, usize)> = new_targets
+        // The alias set and each pool's authorised keys are compared by
+        // identity, not by count: a pool can carry the right number of keys and
+        // still not the one under test, which produces exactly the same 403 as
+        // a pool with no keys at all.
+        let expected: Vec<(String, Option<onwards::auth::KeySet>)> = new_targets
             .targets
             .iter()
-            .map(|entry| (entry.key().clone(), entry.value().keys().map_or(0, |keys| keys.len())))
+            .map(|entry| (entry.key().clone(), entry.value().keys().cloned()))
             .collect();
+
+        // Kept so the update can be re-asserted below. `Targets` is a handle of
+        // `Arc` maps and `receive_updates` only reads from the value it is
+        // given, so re-sending this clone is safe.
+        let desired = new_targets.clone();
 
         // Send through the watch channel (same as automatic sync)
         sender
@@ -2343,30 +2349,48 @@ impl BackgroundServices {
         // (e.g. only an endpoint URL) - such an update matches immediately and
         // returns without waiting, exactly as before.
         //
-        // The budget is deliberately longer than the config listener's periodic
-        // fallback sync: the listener shares this watch channel, so a periodic
-        // reload that started loading just before the test's own write could
-        // land after this send and briefly apply the older config. The next
-        // fallback sync corrects that, and waiting past one interval means the
-        // helper rides it out instead of failing the test.
+        // Waiting for the state to appear once is not enough. The config
+        // listener shares this watch channel, and a reload it started before
+        // the test's own write can finish afterwards and apply that older
+        // snapshot over this one - dropping the key again in the window between
+        // this function returning and the test issuing its request. So the
+        // state has to hold for a settle window, and any regression re-asserts
+        // the desired config rather than waiting for the listener's periodic
+        // sync to come back around.
+        const SETTLE: std::time::Duration = std::time::Duration::from_millis(250);
+        const REASSERT_EVERY: std::time::Duration = std::time::Duration::from_millis(200);
+
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        let mut stable_since: Option<std::time::Instant> = None;
+        let mut last_reassert = std::time::Instant::now();
+
         loop {
             let live = &self.onwards_targets.targets;
             let applied = live.len() == expected.len()
-                && expected.iter().all(|(alias, key_count)| {
-                    live.get(alias)
-                        .is_some_and(|pool| pool.keys().map_or(0, |keys| keys.len()) == *key_count)
-                });
+                && expected
+                    .iter()
+                    .all(|(alias, keys)| live.get(alias).is_some_and(|pool| pool.keys() == keys.as_ref()));
 
+            let now = std::time::Instant::now();
             if applied {
-                return Ok(());
+                if now.duration_since(*stable_since.get_or_insert(now)) >= SETTLE {
+                    return Ok(());
+                }
+            } else {
+                stable_since = None;
+                if now.duration_since(last_reassert) >= REASSERT_EVERY {
+                    sender
+                        .send(desired.clone())
+                        .map_err(|_| anyhow::anyhow!("Failed to re-send targets update"))?;
+                    last_reassert = now;
+                }
             }
 
-            if std::time::Instant::now() >= deadline {
-                anyhow::bail!("onwards did not apply the config update within 5s");
+            if now >= deadline {
+                anyhow::bail!("onwards did not apply the config update within 15s");
             }
 
-            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
         }
     }
 

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -2359,8 +2359,12 @@ impl BackgroundServices {
         // sync to come back around.
         const SETTLE: std::time::Duration = std::time::Duration::from_millis(250);
         const REASSERT_EVERY: std::time::Duration = std::time::Duration::from_millis(200);
+        // Comfortably inside SETTLE, so the settle window is still sampled many
+        // times, without waking the scheduler thousands of times per call.
+        const POLL_EVERY: std::time::Duration = std::time::Duration::from_millis(10);
+        const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        let deadline = std::time::Instant::now() + TIMEOUT;
         let mut stable_since: Option<std::time::Instant> = None;
         let mut last_reassert = std::time::Instant::now();
 
@@ -2387,10 +2391,10 @@ impl BackgroundServices {
             }
 
             if now >= deadline {
-                anyhow::bail!("onwards did not apply the config update within 15s");
+                anyhow::bail!("onwards did not apply the config update within {:?}", TIMEOUT);
             }
 
-            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            tokio::time::sleep(POLL_EVERY).await;
         }
     }
 


### PR DESCRIPTION
## Problem

`BackgroundServices::sync_onwards_config` (the `#[cfg(test)]` helper that ~18 test call sites use to push config into the proxy) returns as soon as the watch channel accepts the new targets:

    sender.send(new_targets).map_err(...)?;
    Ok(())

But `send` only *queues* the config. `Targets::receive_updates` applies it on its own spawned task, mutating the shared maps in place. So when the helper returns, the proxy may still be serving the previous routing table — most importantly, without the API key the test just created.

A test that goes straight from `sync_onwards_config` to a proxied request therefore races the apply and gets a **403 for a key that is already committed to the database**.

## Evidence

Both of these failed in CI on unrelated PRs, with the same signature — `Config file changed, updating targets…` immediately followed by a 403 on the proxied call:

- `test::responses::test_chat_completion_creates_retrievable_response` — expected 200, got 403
- `test::strict_mode::test_strict_mode_trusted_flag_bypasses_sanitization` — expected 429, got 403

Both passed on a plain re-run with no code change. Across three runs of one PR the race hit two different tests, so it is frequent enough to cost reruns on changes that have nothing to do with routing.

## Why the existing guards didn't catch it

Several helpers already poll `GET /ai/v1/models` until the model appears and treat that as readiness. That endpoint is *control-layer* model discovery served from the database — as `anthropic_models_uses_control_layer_model_discovery` states outright — not onwards' in-memory routing table. It can therefore return 200 with the model listed while the proxy still has no pool, or a pool without the new key. The gate looked meaningful and never was.

## Fix

Make the helper wait until the live routing table actually reflects what was sent.

`BackgroundServices.onwards_targets` is the same `Targets` value that `receive_updates` was called on, and the router's `AppState` is built from a clone of it — all three share the same `Arc<DashMap>`. Polling it observes exactly what a proxied request would resolve against.

The helper snapshots the expected routing table before sending, then waits for the live table to match. Three details matter, and the second and third were added after a first version of this fix **still flaked in CI** — see below:

1. **Keys are compared by identity, not count.** A pool can hold the right *number* of keys and still not the one under test, which produces exactly the same 403 as a pool with none.
2. **The state has to hold for a settle window (250ms), not just appear once.** The config listener shares this watch channel, and a reload it began before the test's own write can finish *afterwards* and apply that older snapshot over ours — dropping the key again in the window between this function returning and the test issuing its request.
3. **A regression re-asserts the config** rather than waiting for the listener's periodic sync to come back around, so convergence doesn't depend on the fallback interval.

Notes on the edges:

- **No hang risk when sync is disabled.** The sender and `receive_updates` are wired inside the same `if config.background_services.onwards_sync.enabled` block, so reaching the wait implies a consumer task exists. When sync is disabled the helper already returns `Err("Onwards sync not enabled")` before this point. A timeout is therefore a genuine failure and bails with a clear message rather than hanging.
- **Structural changes only.** An update that changes nothing in the alias set or key counts (e.g. only an endpoint URL) matches immediately and returns without waiting — exactly the behaviour as before, so nothing regresses, but those cases aren't improved either.
- The now-redundant `/ai/v1/models` polls in the individual helpers are left in place; they're harmless, and removing them would spread this change over several test files for no functional gain.

## The first version of this fix was not enough

Worth recording, because it shows the race has two halves. The first version waited for the expected state to appear once, comparing key *counts*. CI then failed on this very PR with the same signature in a third test — `test_realtime_zdr_suppresses_stored_bodies`, expected 200, got 403 — and the log showed **two** `Config file changed, updating targets…` lines before the request. That is the listener applying a second, older snapshot after the wait had already been satisfied. Hence the settle window and the re-assert.

## Testing

- Both affected modules run repeatedly, to confirm the race is gone rather than just re-rolled: `test::responses` (9 tests) and `test::strict_mode` (10 tests), five consecutive runs each, all green. Timings are unchanged — the wait returns in ~1ms when the apply has already landed.
- **Full `dwctl` lib suite: 1965 passed, 0 failed, 2 ignored.** This is the check that mattered most: the helper is used by ~18 call sites across 6 test files, and making it wait rather than return immediately would newly *fail* any test that leaves config in a state which never converges. None do.
- `just lint rust` clean.

