### PR TITLE
fix(ci): track the fusillade-arsenal 4.0.0 release baseline

### DIFF
--- a/.github/scripts/test-local-rust-workspace.sh
+++ b/.github/scripts/test-local-rust-workspace.sh
@@ -204,8 +204,8 @@ if set(release_manifest) != {
     raise SystemExit(
         "release manifest must track dwctl, Onwards, and Fusillade Arsenal independently"
     )
-if release_manifest["fusillade-arsenal"] != "3.1.0":
-    raise SystemExit("Fusillade Arsenal release baseline must remain 3.1.0")
+if release_manifest["fusillade-arsenal"] != "4.0.0":
+    raise SystemExit("Fusillade Arsenal release baseline must remain 4.0.0")
 if release_manifest["fusillade-core"] != "5.0.0":
     raise SystemExit("Fusillade Core release baseline must remain 5.0.0")
 PY


### PR DESCRIPTION
## Problem

`main` is currently red for every pull request.

Releasing fusillade-arsenal 4.0.0 (#1400) moved `.release-please-manifest.json` to `"fusillade-arsenal": "4.0.0"`, but the workspace topology guard in `.github/scripts/test-local-rust-workspace.sh` still pins the baseline at `3.1.0`:

```python
if release_manifest["fusillade-arsenal"] != "3.1.0":
    raise SystemExit("Fusillade Arsenal release baseline must remain 3.1.0")
```

So `just lint rust` exits non-zero with `Fusillade Arsenal release baseline must remain 3.1.0`, failing `workspace / rust lint` and, through it, `workspace / rust gate`. This hits any PR whose checks run against current main — it is not specific to the branch that surfaced it.

## Fix

Move the pin to the version that was actually released. This mirrors the earlier fusillade-core 5.0.0 baseline update: the pin is a deliberate tripwire for accidental version bumps, so it is updated to match the intentional release rather than removed.

Note the other `3.1.0` occurrences, in `test-sync-fusillade-release-dependencies.sh`, are synthetic fixture data written into a temp directory for that script's own scenario. They are deliberately left alone — changing them would alter what that test exercises.

## Verification

`bash .github/scripts/test-local-rust-workspace.sh` passes with the change (`Onwards floating image tag tests passed`) and fails without it.