### PR TITLE
feat: adapt model concurrency to downstream 529 responses

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -540,6 +540,7 @@ background_services:
     # Performance & Concurrency Settings
     claim_batch_size: 100 # Maximum number of requests to claim in each iteration
     default_model_concurrency: 10 # Default concurrent requests per model
+    adaptive_concurrency_recovery_interval_ms: 1000 # Per-model AIMD adjustment cadence after downstream 529s
     claim_interval_ms: 1000 # Milliseconds to sleep between claim iterations
 
     # Split claim daemons (fusillade >= 20): batched and batchless (flex) rows

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -1498,6 +1498,10 @@ pub struct DaemonConfig {
     /// Default concurrency limit per model (default: 10)
     pub default_model_concurrency: usize,
 
+    /// Minimum time between per-model AIMD adjustments after downstream 529s
+    /// and successful responses (default: 1000ms).
+    pub adaptive_concurrency_recovery_interval_ms: u64,
+
     /// How long to sleep between claim iterations in milliseconds (default: 1000)
     pub claim_interval_ms: u64,
 
@@ -1903,6 +1907,7 @@ impl Default for DaemonConfig {
             mode: DaemonMode::Both,
             claim_batch_size: 100,
             default_model_concurrency: 10,
+            adaptive_concurrency_recovery_interval_ms: 1_000,
             claim_interval_ms: 1000,
             max_retries: Some(1000),
             stop_before_deadline_ms: Some(900_000),
@@ -1983,6 +1988,7 @@ impl DaemonConfig {
             mode: self.mode.into(),
             claim_batch_size: self.claim_batch_size,
             model_concurrency_limits: model_capacity_limits.unwrap_or_else(|| std::sync::Arc::new(dashmap::DashMap::new())),
+            adaptive_concurrency_recovery_interval_ms: self.adaptive_concurrency_recovery_interval_ms,
             model_escalations: Arc::new(DashMap::from_iter(self.model_escalations.clone())),
             claim_interval_ms: self.claim_interval_ms,
             max_retries: self.max_retries,
@@ -3962,6 +3968,52 @@ background_services:
                     .to_fusillade_config()
                     .additional_retryable_statuses
                     .is_empty()
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_adaptive_concurrency_recovery_interval_default_override_and_mapping() {
+        Jail::expect_with(|jail| {
+            jail.create_file("test.yaml", "secret_key: test-secret-key\n")?;
+            let args = Args {
+                config: "test.yaml".into(),
+                validate: false,
+            };
+
+            let config = Config::load(&args)?;
+            assert_eq!(
+                config.background_services.batch_daemon.adaptive_concurrency_recovery_interval_ms,
+                1_000
+            );
+            assert_eq!(
+                config
+                    .background_services
+                    .batch_daemon
+                    .to_fusillade_config()
+                    .adaptive_concurrency_recovery_interval_ms,
+                1_000
+            );
+
+            jail.create_file(
+                "test.yaml",
+                r#"
+secret_key: test-secret-key
+background_services:
+  batch_daemon:
+    adaptive_concurrency_recovery_interval_ms: 5000
+"#,
+            )?;
+            let config = Config::load(&args)?;
+            assert_eq!(
+                config
+                    .background_services
+                    .batch_daemon
+                    .to_fusillade_config()
+                    .adaptive_concurrency_recovery_interval_ms,
+                5_000
             );
 
             Ok(())

--- a/fusillade/README.md
+++ b/fusillade/README.md
@@ -97,6 +97,18 @@ let pools = TestDbPools::new(pool).await?;
 let store = Arc::new(PostgresRequestManager::new(pools, (&config).into()));
 ```
 
+Each daemon adapts those limits when a downstream model returns HTTP 529. The
+first 529 in a recovery interval halves that model's effective concurrency for
+new claims, down to a minimum of one. Concurrent 529 responses in the same
+interval are treated as one overload event. Successful responses then restore
+one permit per interval until the configured limit is reached. Work already in
+flight is allowed to finish; if it exceeds the reduced limit, the daemon simply
+stops claiming for that model until enough requests complete.
+
+The feedback state is local to each daemon and shared by all of its claim
+loops. `adaptive_concurrency_recovery_interval_ms` controls both burst
+coalescing and additive recovery cadence and defaults to `1000`ms.
+
 ### Database Retry Cadence
 
 `fusillade-arsenal` can retry transient SQLx pool-acquire failures such as
@@ -270,6 +282,7 @@ Configuration (all optional):
 | `batch_claim_require_live` | `false` | require an explicit `live` event to batch-claim |
 | `background_concurrency_limit` | `0` | per-model foreground threshold below which background workers may send; zero disables them |
 | `claim_ramp_exponent` | `0.56` | deadline-ramp curve (~59 min for 24h windows, ~10 min for 1h) |
+| `adaptive_concurrency_recovery_interval_ms` | `1000` | minimum per-model interval between 529 decreases and successful additive increases |
 
 **Breaking changes relative to v19:**
 

--- a/fusillade/src/daemon/adaptive_concurrency.rs
+++ b/fusillade/src/daemon/adaptive_concurrency.rs
@@ -1,0 +1,238 @@
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ConcurrencyAdjustment {
+    pub previous_limit: usize,
+    pub new_limit: usize,
+}
+
+#[derive(Debug)]
+struct ModelState {
+    effective_limit: usize,
+    next_decrease_at: Instant,
+    next_increase_at: Instant,
+}
+
+#[derive(Debug)]
+pub(super) struct AdaptiveConcurrencyController {
+    states: DashMap<String, ModelState>,
+    recovery_interval: Duration,
+}
+
+impl AdaptiveConcurrencyController {
+    pub(super) fn new(recovery_interval: Duration) -> Self {
+        Self {
+            states: DashMap::new(),
+            recovery_interval,
+        }
+    }
+
+    pub(super) fn effective_limit(&self, model: &str, configured_limit: usize) -> usize {
+        self.states
+            .get(model)
+            .map(|state| state.effective_limit.min(configured_limit))
+            .unwrap_or(configured_limit)
+    }
+
+    pub(super) fn record_overload(
+        &self,
+        model: &str,
+        configured_limit: usize,
+        now: Instant,
+    ) -> Option<ConcurrencyAdjustment> {
+        if configured_limit == 0 {
+            return None;
+        }
+
+        let mut state = self
+            .states
+            .entry(model.to_owned())
+            .or_insert_with(|| ModelState {
+                effective_limit: configured_limit,
+                next_decrease_at: now,
+                next_increase_at: now,
+            });
+        state.effective_limit = state.effective_limit.min(configured_limit);
+
+        if now < state.next_decrease_at {
+            return None;
+        }
+
+        let previous_limit = state.effective_limit;
+        state.effective_limit = (previous_limit / 2).max(1);
+        state.next_decrease_at = now + self.recovery_interval;
+        state.next_increase_at = now + self.recovery_interval;
+
+        (state.effective_limit != previous_limit).then_some(ConcurrencyAdjustment {
+            previous_limit,
+            new_limit: state.effective_limit,
+        })
+    }
+
+    pub(super) fn record_success(
+        &self,
+        model: &str,
+        configured_limit: usize,
+        now: Instant,
+    ) -> Option<ConcurrencyAdjustment> {
+        if configured_limit == 0 {
+            return None;
+        }
+
+        let mut state = self.states.get_mut(model)?;
+        state.effective_limit = state.effective_limit.min(configured_limit);
+
+        if state.effective_limit >= configured_limit || now < state.next_increase_at {
+            return None;
+        }
+
+        let previous_limit = state.effective_limit;
+        state.effective_limit += 1;
+        state.next_increase_at = now + self.recovery_interval;
+
+        Some(ConcurrencyAdjustment {
+            previous_limit,
+            new_limit: state.effective_limit,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::{AdaptiveConcurrencyController, ConcurrencyAdjustment};
+
+    const RECOVERY_INTERVAL: Duration = Duration::from_secs(1);
+
+    #[test]
+    fn overload_halves_the_configured_limit_with_a_floor_of_one() {
+        let controller = AdaptiveConcurrencyController::new(RECOVERY_INTERVAL);
+        let now = Instant::now();
+
+        assert_eq!(
+            controller.record_overload("large-model", 100, now),
+            Some(ConcurrencyAdjustment {
+                previous_limit: 100,
+                new_limit: 50,
+            })
+        );
+        assert_eq!(controller.effective_limit("large-model", 100), 50);
+
+        assert_eq!(controller.record_overload("small-model", 1, now), None);
+        assert_eq!(controller.effective_limit("small-model", 1), 1);
+        assert_eq!(controller.effective_limit("disabled-model", 0), 0);
+    }
+
+    #[test]
+    fn overload_burst_causes_only_one_decrease_per_interval() {
+        let controller = AdaptiveConcurrencyController::new(RECOVERY_INTERVAL);
+        let now = Instant::now();
+
+        assert!(controller.record_overload("model", 100, now).is_some());
+        assert_eq!(
+            controller.record_overload("model", 100, now + Duration::from_millis(999)),
+            None
+        );
+        assert_eq!(controller.effective_limit("model", 100), 50);
+
+        assert_eq!(
+            controller.record_overload("model", 100, now + RECOVERY_INTERVAL),
+            Some(ConcurrencyAdjustment {
+                previous_limit: 50,
+                new_limit: 25,
+            })
+        );
+    }
+
+    #[test]
+    fn successes_recover_additively_at_most_once_per_interval() {
+        let controller = AdaptiveConcurrencyController::new(RECOVERY_INTERVAL);
+        let now = Instant::now();
+        controller.record_overload("model", 8, now);
+
+        assert_eq!(
+            controller.record_success("model", 8, now + Duration::from_millis(999)),
+            None
+        );
+        assert_eq!(
+            controller.record_success("model", 8, now + RECOVERY_INTERVAL),
+            Some(ConcurrencyAdjustment {
+                previous_limit: 4,
+                new_limit: 5,
+            })
+        );
+        assert_eq!(
+            controller.record_success("model", 8, now + RECOVERY_INTERVAL),
+            None
+        );
+        assert_eq!(
+            controller.record_success("model", 8, now + RECOVERY_INTERVAL * 2),
+            Some(ConcurrencyAdjustment {
+                previous_limit: 5,
+                new_limit: 6,
+            })
+        );
+    }
+
+    #[test]
+    fn effective_limit_tracks_runtime_changes_to_the_configured_ceiling() {
+        let controller = AdaptiveConcurrencyController::new(RECOVERY_INTERVAL);
+        let now = Instant::now();
+        controller.record_overload("model", 100, now);
+
+        assert_eq!(controller.effective_limit("model", 20), 20);
+        assert_eq!(
+            controller.record_success("model", 20, now + RECOVERY_INTERVAL),
+            None
+        );
+        assert_eq!(controller.effective_limit("model", 20), 20);
+
+        assert_eq!(
+            controller.record_success("model", 60, now + RECOVERY_INTERVAL * 2),
+            Some(ConcurrencyAdjustment {
+                previous_limit: 20,
+                new_limit: 21,
+            })
+        );
+    }
+
+    #[test]
+    fn disabling_and_reenabling_a_model_does_not_wedge_its_limit_at_zero() {
+        let controller = AdaptiveConcurrencyController::new(RECOVERY_INTERVAL);
+        let now = Instant::now();
+        controller.record_overload("model", 100, now);
+
+        assert_eq!(controller.effective_limit("model", 0), 0);
+        assert_eq!(
+            controller.record_overload("model", 0, now + RECOVERY_INTERVAL),
+            None
+        );
+        assert_eq!(
+            controller.record_success("model", 0, now + RECOVERY_INTERVAL),
+            None
+        );
+
+        assert_eq!(controller.effective_limit("model", 100), 50);
+        assert_eq!(
+            controller.record_success("model", 100, now + RECOVERY_INTERVAL),
+            Some(ConcurrencyAdjustment {
+                previous_limit: 50,
+                new_limit: 51,
+            })
+        );
+    }
+
+    #[test]
+    fn independent_models_keep_independent_limits() {
+        let controller = AdaptiveConcurrencyController::new(RECOVERY_INTERVAL);
+        let now = Instant::now();
+
+        controller.record_overload("model-a", 100, now);
+
+        assert_eq!(controller.effective_limit("model-a", 100), 50);
+        assert_eq!(controller.effective_limit("model-b", 100), 100);
+    }
+}

--- a/fusillade/src/daemon/config.rs
+++ b/fusillade/src/daemon/config.rs
@@ -113,6 +113,13 @@ pub struct DaemonConfig {
         deserialize_with = "deserialize_model_concurrency_limits"
     )]
     pub model_concurrency_limits: Arc<dashmap::DashMap<String, usize>>,
+    /// Minimum time between adaptive concurrency adjustments for one model.
+    ///
+    /// HTTP 529 responses halve that model's effective concurrency at most
+    /// once during this interval. Successful responses restore one permit at
+    /// most once per interval until the configured limit is reached.
+    #[serde(default = "default_adaptive_concurrency_recovery_interval_ms")]
+    pub adaptive_concurrency_recovery_interval_ms: u64,
     #[serde(skip, default = "default_model_escalations")]
     pub model_escalations: Arc<dashmap::DashMap<String, ModelEscalationConfig>>,
     #[serde(default)]
@@ -340,6 +347,10 @@ fn default_upload_stall_poll_ms() -> u64 {
     crate::http::DEFAULT_UPLOAD_STALL_POLL.as_millis() as u64
 }
 
+fn default_adaptive_concurrency_recovery_interval_ms() -> u64 {
+    1_000
+}
+
 fn default_archive_sweep_interval_ms() -> u64 {
     5_000
 }
@@ -386,6 +397,8 @@ impl Default for DaemonConfig {
             mode: DaemonMode::default(),
             claim_batch_size: 100,
             model_concurrency_limits: Arc::new(dashmap::DashMap::new()),
+            adaptive_concurrency_recovery_interval_ms:
+                default_adaptive_concurrency_recovery_interval_ms(),
             model_escalations: default_model_escalations(),
             inject_deadline_priority: false,
             background_concurrency_limit: 0,
@@ -497,6 +510,31 @@ mod tests {
             let serde_encoding = serde_json::to_value(mode).unwrap();
             assert_eq!(serde_encoding.as_str().unwrap(), mode.metric_label());
         }
+    }
+
+    #[test]
+    fn adaptive_concurrency_recovery_interval_defaults_and_round_trips() {
+        let default_config = DaemonConfig::default();
+        assert_eq!(
+            default_config.adaptive_concurrency_recovery_interval_ms,
+            1_000
+        );
+
+        let mut serialized = serde_json::to_value(&default_config).unwrap();
+        serialized
+            .as_object_mut()
+            .unwrap()
+            .remove("adaptive_concurrency_recovery_interval_ms");
+        let decoded: DaemonConfig = serde_json::from_value(serialized).unwrap();
+        assert_eq!(decoded.adaptive_concurrency_recovery_interval_ms, 1_000);
+
+        let configured = DaemonConfig {
+            adaptive_concurrency_recovery_interval_ms: 5_000,
+            ..DaemonConfig::default()
+        };
+        let decoded: DaemonConfig =
+            serde_json::from_value(serde_json::to_value(configured).unwrap()).unwrap();
+        assert_eq!(decoded.adaptive_concurrency_recovery_interval_ms, 5_000);
     }
 
     #[test]

--- a/fusillade/src/daemon/mod.rs
+++ b/fusillade/src/daemon/mod.rs
@@ -3,10 +3,12 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+mod adaptive_concurrency;
 pub mod config;
 
+use adaptive_concurrency::{AdaptiveConcurrencyController, ConcurrencyAdjustment};
 use metrics::{counter, gauge, histogram};
 use tokio::task::JoinSet;
 
@@ -20,7 +22,7 @@ use crate::error::Result;
 use crate::http::HttpClient;
 use crate::manager::{ArchiveOutcome, DaemonStorage, Storage};
 use crate::processor::{DefaultRequestProcessor, RequestProcessor};
-use crate::request::{Claimed, DaemonId, Request, RequestCompletionResult};
+use crate::request::{Claimed, DaemonId, FailureReason, Request, RequestCompletionResult};
 
 pub use config::{
     DaemonConfig, DaemonMode, ModelEscalationConfig, ShouldRetryFn, default_should_retry,
@@ -34,6 +36,17 @@ pub use fusillade_core::daemon_record::{
 struct UserThroughputStats {
     completed: AtomicU64,
     failed: AtomicU64,
+}
+
+/// A claimed request after route-at-claim-time rewriting.
+///
+/// `request.data.model` is the downstream model that receives the request.
+/// `capacity_model` is the configured model whose claim slot this request
+/// consumes. They differ when escalation rewrites the route after the storage
+/// claim has already been made.
+struct PreparedRequest {
+    request: Request<Claimed>,
+    capacity_model: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -86,6 +99,52 @@ fn background_capacity(ordinary_limit: usize, background_limit: usize, in_flight
     ordinary_limit
         .min(background_limit)
         .saturating_sub(in_flight)
+}
+
+fn available_capacity_for_model(
+    controller: &AdaptiveConcurrencyController,
+    model: &str,
+    configured_limit: usize,
+    in_flight: usize,
+) -> usize {
+    controller
+        .effective_limit(model, configured_limit)
+        .saturating_sub(in_flight)
+}
+
+fn is_downstream_overload(reason: &FailureReason) -> bool {
+    matches!(
+        reason,
+        FailureReason::RetriableHttpStatus { status: 529, .. }
+            | FailureReason::NonRetriableHttpStatus { status: 529, .. }
+    )
+}
+
+fn emit_concurrency_decrease(model: &str, adjustment: ConcurrencyAdjustment) {
+    counter!("fusillade_adaptive_concurrency_decreases_total", "model" => model.to_owned())
+        .increment(1);
+    gauge!("fusillade_adaptive_concurrency_limit", "model" => model.to_owned())
+        .set(adjustment.new_limit as f64);
+    tracing::warn!(
+        model,
+        previous_limit = adjustment.previous_limit,
+        new_limit = adjustment.new_limit,
+        status = 529,
+        "Reduced model concurrency after downstream overload"
+    );
+}
+
+fn emit_concurrency_increase(model: &str, adjustment: ConcurrencyAdjustment) {
+    counter!("fusillade_adaptive_concurrency_increases_total", "model" => model.to_owned())
+        .increment(1);
+    gauge!("fusillade_adaptive_concurrency_limit", "model" => model.to_owned())
+        .set(adjustment.new_limit as f64);
+    tracing::debug!(
+        model,
+        previous_limit = adjustment.previous_limit,
+        new_limit = adjustment.new_limit,
+        "Increased model concurrency after successful response"
+    );
 }
 
 fn sla_dynamo_priority(deadline: chrono::DateTime<chrono::Utc>) -> i32 {
@@ -355,6 +414,10 @@ where
     /// daemon behavior.
     processor: Arc<dyn RequestProcessor<S, H>>,
     requests_in_flight: Arc<dashmap::DashMap<String, AtomicUsize>>,
+    /// Per-model AIMD state. The configured concurrency remains the hard
+    /// ceiling; HTTP 529 responses reduce this daemon's effective ceiling and
+    /// successful responses recover it gradually.
+    adaptive_concurrency: Arc<AdaptiveConcurrencyController>,
     /// Per-user in-flight request counts across all models, used to prioritise
     /// users with fewer active requests during claim (per-user fair scheduling).
     user_requests_in_flight: Arc<dashmap::DashMap<String, AtomicUsize>>,
@@ -397,6 +460,9 @@ where
         shutdown_token: tokio_util::sync::CancellationToken,
     ) -> Self {
         let should_retry = config.retry_predicate();
+        let adaptive_concurrency = Arc::new(AdaptiveConcurrencyController::new(
+            Duration::from_millis(config.adaptive_concurrency_recovery_interval_ms),
+        ));
         let config = DaemonConfig {
             should_retry,
             ..config
@@ -409,6 +475,7 @@ where
             config,
             processor: Arc::new(DefaultRequestProcessor),
             requests_in_flight: Arc::new(dashmap::DashMap::new()),
+            adaptive_concurrency,
             user_requests_in_flight: Arc::new(dashmap::DashMap::new()),
             leak_buckets: Arc::new(dashmap::DashMap::new()),
             user_throughput: Arc::new(dashmap::DashMap::new()),
@@ -466,7 +533,12 @@ where
                     .get(&model)
                     .map(|e| e.value().load(Ordering::Relaxed))
                     .unwrap_or(0);
-                let available = limit.saturating_sub(in_flight);
+                let available = available_capacity_for_model(
+                    &self.adaptive_concurrency,
+                    &model,
+                    limit,
+                    in_flight,
+                );
                 if available > 0 {
                     Some((model, available))
                 } else {
@@ -483,7 +555,10 @@ where
             .iter()
             .filter_map(|entry| {
                 let model = entry.key().clone();
-                let ordinary_limit = *entry.value();
+                let configured_limit = *entry.value();
+                let ordinary_limit = self
+                    .adaptive_concurrency
+                    .effective_limit(&model, configured_limit);
                 let in_flight = self
                     .requests_in_flight
                     .get(&model)
@@ -648,7 +723,7 @@ where
                 _ => unreachable!("foreground kind passed to background claim loop"),
             };
 
-            let mut claimed = match claim_result {
+            let claimed = match claim_result {
                 Ok(claimed) => {
                     consecutive_claim_failures = 0;
                     claimed
@@ -706,8 +781,8 @@ where
                 "Claimed requests from storage"
             );
 
-            self.prepare_claimed_requests(&mut claimed, kind);
-            self.dispatch_claimed_requests(&mut join_set, claimed, kind);
+            let prepared = self.prepare_claimed_requests(claimed, kind);
+            self.dispatch_claimed_requests(&mut join_set, prepared, kind);
         }
     }
 
@@ -813,7 +888,7 @@ where
                 _ => unreachable!("background kind passed to foreground claim loop"),
             };
 
-            let mut claimed = match claim_result {
+            let claimed = match claim_result {
                 Ok(claimed) => {
                     consecutive_claim_failures = 0;
                     claimed
@@ -875,13 +950,26 @@ where
                 self.stamp_leaks(&claimed);
             }
 
-            self.prepare_claimed_requests(&mut claimed, kind);
-            self.dispatch_claimed_requests(&mut join_set, claimed, kind);
+            let prepared = self.prepare_claimed_requests(claimed, kind);
+            self.dispatch_claimed_requests(&mut join_set, prepared, kind);
         }
     }
 
-    fn prepare_claimed_requests(&self, claimed: &mut [Request<Claimed>], kind: ClaimLoopKind) {
-        for request in claimed.iter_mut() {
+    fn prepare_claimed_requests(
+        &self,
+        claimed: Vec<Request<Claimed>>,
+        kind: ClaimLoopKind,
+    ) -> Vec<PreparedRequest> {
+        let mut prepared: Vec<_> = claimed
+            .into_iter()
+            .map(|request| PreparedRequest {
+                capacity_model: request.data.model.clone(),
+                request,
+            })
+            .collect();
+
+        for prepared_request in &mut prepared {
+            let request = &mut prepared_request.request;
             if kind.is_background() {
                 continue;
             }
@@ -920,7 +1008,8 @@ where
             }
         }
 
-        for request in claimed {
+        for prepared_request in &mut prepared {
+            let request = &mut prepared_request.request;
             let priority = if kind.is_background() {
                 BACKGROUND_DYNAMO_PRIORITY
             } else if self.config.inject_deadline_priority {
@@ -933,18 +1022,20 @@ where
             };
             inject_dynamo_priority(&mut request.data.body, priority);
         }
+
+        prepared
     }
 
     fn dispatch_claimed_requests(
         self: &Arc<Self>,
         join_set: &mut JoinSet<Result<()>>,
-        claimed: Vec<Request<Claimed>>,
+        claimed: Vec<PreparedRequest>,
         kind: ClaimLoopKind,
     ) {
         let mut by_model: HashMap<String, Vec<_>> = HashMap::new();
-        for request in claimed {
-            let model = request.data.model.clone();
-            by_model.entry(model).or_default().push(request);
+        for prepared_request in claimed {
+            let model = prepared_request.request.data.model.clone();
+            by_model.entry(model).or_default().push(prepared_request);
         }
 
         tracing::debug!(
@@ -956,7 +1047,11 @@ where
         for (model, requests) in by_model {
             tracing::debug!(model = %model, count = requests.len(), "Processing requests for model");
 
-            for request in requests {
+            for prepared_request in requests {
+                let PreparedRequest {
+                    request,
+                    capacity_model,
+                } = prepared_request;
                 let request_id = request.data.id;
                 let batch_id = request.data.batch_id;
 
@@ -968,6 +1063,7 @@ where
                 );
 
                 let model_clone = model.clone();
+                let capacity_model_clone = capacity_model.clone();
                 let user_id = request.data.created_by.clone();
                 let is_background = kind.is_background();
                 let uses_foreground_accounting = kind.uses_foreground_accounting();
@@ -1000,6 +1096,8 @@ where
                 let processor = self.processor.clone();
                 let retry_config: crate::request::transitions::RetryConfig = (&self.config).into();
                 let requests_in_flight = self.requests_in_flight.clone();
+                let adaptive_concurrency = self.adaptive_concurrency.clone();
+                let model_concurrency_limits = self.config.model_concurrency_limits.clone();
                 let user_throughput = self.user_throughput.clone();
                 let user_requests_in_flight = self.user_requests_in_flight.clone();
                 let requests_processed = self.requests_processed.clone();
@@ -1018,10 +1116,10 @@ where
                         .increment(1.0);
                 } else {
                     requests_in_flight
-                        .entry(model_clone.clone())
+                        .entry(capacity_model_clone.clone())
                         .or_default()
                         .fetch_add(1, Ordering::Relaxed);
-                    gauge!("fusillade_requests_in_flight", "model" => model_clone.clone())
+                    gauge!("fusillade_requests_in_flight", "model" => capacity_model_clone.clone())
                         .increment(1.0);
 
                     user_requests_in_flight
@@ -1040,6 +1138,7 @@ where
                     request_id = %request_id,
                     batch_id = ?batch_id,
                     model = %model,
+                    capacity_model = %capacity_model,
                     outcome = tracing::field::Empty,
                 );
 
@@ -1051,7 +1150,7 @@ where
                     }
 
                     let processing_start = std::time::Instant::now();
-                    let model_for_guard = model_clone.clone();
+                    let model_for_guard = capacity_model_clone.clone();
                     let user_for_guard = user_id.clone();
                     let cw_for_guard = completion_window.clone();
                     let in_flight_for_guard = requests_in_flight.clone();
@@ -1106,6 +1205,17 @@ where
                     match completion_result {
                         Ok(RequestCompletionResult::Completed(completed)) => {
                             tracing::Span::current().record("outcome", "completed");
+                            if let Some(configured_limit) = model_concurrency_limits
+                                .get(&capacity_model_clone)
+                                .map(|limit| *limit)
+                                && let Some(adjustment) = adaptive_concurrency.record_success(
+                                    &capacity_model_clone,
+                                    configured_limit,
+                                    Instant::now(),
+                                )
+                            {
+                                emit_concurrency_increase(&capacity_model_clone, adjustment);
+                            }
                             requests_processed.fetch_add(1, Ordering::Relaxed);
                             user_throughput.entry(user_id.clone()).or_insert_with(|| UserThroughputStats {
                                 completed: AtomicU64::new(0),
@@ -1136,6 +1246,18 @@ where
                         }
                         Ok(RequestCompletionResult::Failed(failed)) => {
                             tracing::Span::current().record("outcome", "failed");
+                            if is_downstream_overload(&failed.state.reason)
+                                && let Some(configured_limit) = model_concurrency_limits
+                                    .get(&capacity_model_clone)
+                                    .map(|limit| *limit)
+                                && let Some(adjustment) = adaptive_concurrency.record_overload(
+                                    &capacity_model_clone,
+                                    configured_limit,
+                                    Instant::now(),
+                                )
+                            {
+                                emit_concurrency_decrease(&capacity_model_clone, adjustment);
+                            }
                             let retry_attempt = failed.state.retry_attempt;
                             let reason_label = failed.state.reason.metric_label();
                             if failed.state.reason.is_retriable() {
@@ -1952,7 +2074,58 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
+    use super::adaptive_concurrency::AdaptiveConcurrencyController;
     use super::*;
+    use crate::request::FailureReason;
+
+    #[test]
+    fn available_capacity_uses_the_adaptive_limit_before_subtracting_in_flight() {
+        let controller = AdaptiveConcurrencyController::new(Duration::from_secs(1));
+        controller.record_overload("model", 100, Instant::now());
+
+        assert_eq!(
+            available_capacity_for_model(&controller, "model", 100, 20),
+            30
+        );
+        assert_eq!(
+            available_capacity_for_model(&controller, "other-model", 100, 20),
+            80
+        );
+        assert_eq!(
+            available_capacity_for_model(&controller, "model", 100, 60),
+            0
+        );
+    }
+
+    #[test]
+    fn only_http_529_is_a_downstream_overload_signal() {
+        for reason in [
+            FailureReason::RetriableHttpStatus {
+                status: 529,
+                body: String::new(),
+            },
+            FailureReason::NonRetriableHttpStatus {
+                status: 529,
+                body: String::new(),
+            },
+        ] {
+            assert!(is_downstream_overload(&reason));
+        }
+
+        for reason in [
+            FailureReason::RetriableHttpStatus {
+                status: 503,
+                body: String::new(),
+            },
+            FailureReason::NetworkError {
+                error: "connection reset".to_string(),
+            },
+        ] {
+            assert!(!is_downstream_overload(&reason));
+        }
+    }
 
     #[test]
     fn claim_failure_backoff_grows_exponentially_and_caps() {

--- a/fusillade/tests/integration.rs
+++ b/fusillade/tests/integration.rs
@@ -684,6 +684,347 @@ async fn test_daemon_respects_per_model_concurrency_limits(pool: sqlx::PgPool) {
 }
 
 #[sqlx::test(migrator = "fusillade_arsenal::MIGRATOR")]
+async fn test_daemon_halves_claim_capacity_after_escalated_model_529(pool: sqlx::PgPool) {
+    let http_client = Arc::new(MockHttpClient::new());
+    let first_wave = [
+        http_client.add_response_with_trigger(
+            "POST /v1/test",
+            Ok(HttpResponse {
+                status: 529,
+                body: r#"{"error":"model overloaded"}"#.to_string(),
+            }),
+        ),
+        http_client.add_response_with_trigger(
+            "POST /v1/test",
+            Ok(HttpResponse {
+                status: 200,
+                body: r#"{"result":"success"}"#.to_string(),
+            }),
+        ),
+        http_client.add_response_with_trigger(
+            "POST /v1/test",
+            Ok(HttpResponse {
+                status: 200,
+                body: r#"{"result":"success"}"#.to_string(),
+            }),
+        ),
+        http_client.add_response_with_trigger(
+            "POST /v1/test",
+            Ok(HttpResponse {
+                status: 200,
+                body: r#"{"result":"success"}"#.to_string(),
+            }),
+        ),
+    ];
+    let remaining_triggers: Vec<_> = (0..5)
+        .map(|_| {
+            http_client.add_response_with_trigger(
+                "POST /v1/test",
+                Ok(HttpResponse {
+                    status: 200,
+                    body: r#"{"result":"success"}"#.to_string(),
+                }),
+            )
+        })
+        .collect();
+
+    let model_concurrency_limits = Arc::new(dashmap::DashMap::new());
+    model_concurrency_limits.insert("source-model".to_string(), 4);
+    model_concurrency_limits.insert("overloaded-model".to_string(), 4);
+    let model_escalations = Arc::new(dashmap::DashMap::new());
+    model_escalations.insert(
+        "source-model".to_string(),
+        ModelEscalationConfig {
+            escalation_model: "overloaded-model".to_string(),
+            escalation_threshold_seconds: 7_200,
+        },
+    );
+    let config = DaemonConfig {
+        claim_batch_size: 20,
+        claim_interval_ms: 10,
+        model_concurrency_limits,
+        model_escalations,
+        adaptive_concurrency_recovery_interval_ms: 60_000,
+        max_retries: Some(3),
+        stop_before_deadline_ms: None,
+        backoff_ms: 10,
+        backoff_factor: 1,
+        max_backoff_ms: 10,
+        status_log_interval_ms: None,
+        heartbeat_interval_ms: 10_000,
+        cancellation_poll_interval_ms: 100,
+        ..Default::default()
+    };
+    let manager = postgres_store(pool, &config).await;
+    let templates = (0..8)
+        .map(|index| fusillade::RequestTemplateInput {
+            custom_id: Some(format!("request-{index}")),
+            endpoint: "https://api.example.com".to_string(),
+            method: "POST".to_string(),
+            path: "/v1/test".to_string(),
+            body: format!(r#"{{"prompt":"test-{index}"}}"#),
+            model: "source-model".to_string(),
+            api_key: "test-key".to_string(),
+        })
+        .collect();
+    let file_id = manager
+        .create_file("adaptive-concurrency".to_string(), None, templates)
+        .await
+        .unwrap();
+    let batch = manager
+        .create_batch(fusillade::batch::BatchInput {
+            file_id,
+            endpoint: "/v1/test".to_string(),
+            completion_window: "1h".to_string(),
+            metadata: None,
+            created_by: None,
+            api_key_id: None,
+            api_key: None,
+            total_requests: None,
+        })
+        .await
+        .unwrap();
+    mark_models_live_for_test(manager.as_ref(), &["source-model"]).await;
+    let request_ids: Vec<_> = manager
+        .get_batch_requests(batch.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|request| request.id())
+        .collect();
+
+    let shutdown_token = CancellationToken::new();
+    let daemon_handle = postgres_daemon(manager.clone(), http_client.clone(), config)
+        .run(shutdown_token.clone())
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while http_client.in_flight_count() != 4 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the configured initial concurrency should saturate");
+
+    let [
+        overload_trigger,
+        success_trigger_1,
+        success_trigger_2,
+        success_trigger_3,
+    ] = first_wave;
+    overload_trigger.send(()).unwrap();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while http_client.in_flight_count() != 3 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the 529 response should finish before the successful requests");
+
+    for trigger in [success_trigger_1, success_trigger_2, success_trigger_3] {
+        trigger.send(()).unwrap();
+    }
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while http_client.call_count() < 6 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("a second claim should start after the first wave completes");
+
+    let requests = manager.get_requests(request_ids).await.unwrap();
+    let active_requests = requests
+        .iter()
+        .filter(|request| {
+            request
+                .as_ref()
+                .is_ok_and(|request| matches!(request.variant(), "Claimed" | "Processing"))
+        })
+        .count();
+    assert_eq!(
+        active_requests, 2,
+        "a 529 should halve the next claim from four requests to two"
+    );
+    assert_eq!(http_client.in_flight_count(), 2);
+
+    for trigger in remaining_triggers {
+        trigger.send(()).unwrap();
+    }
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let status = manager.get_batch_status(batch.id).await.unwrap();
+            if status.completed_requests == 8 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("all requests should complete after the throttled waves drain");
+    shutdown_token.cancel();
+    tokio::time::timeout(Duration::from_secs(5), daemon_handle)
+        .await
+        .expect("daemon should stop")
+        .expect("daemon task should not panic")
+        .expect("daemon should stop cleanly");
+}
+
+#[sqlx::test(migrator = "fusillade_arsenal::MIGRATOR")]
+async fn background_529_throttles_foreground_claims_on_the_same_daemon(pool: sqlx::PgPool) {
+    let http_client = Arc::new(MockHttpClient::new());
+    let overload_trigger = http_client.add_response_with_trigger(
+        "POST /v1/adaptive-shared",
+        Ok(HttpResponse {
+            status: 529,
+            body: r#"{"error":"model overloaded"}"#.to_string(),
+        }),
+    );
+    let success_triggers: Vec<_> = (0..4)
+        .map(|_| {
+            http_client.add_response_with_trigger(
+                "POST /v1/adaptive-shared",
+                Ok(HttpResponse {
+                    status: 200,
+                    body: r#"{"result":"success"}"#.to_string(),
+                }),
+            )
+        })
+        .collect();
+
+    let model_concurrency_limits = Arc::new(dashmap::DashMap::new());
+    model_concurrency_limits.insert("shared-model".to_string(), 4);
+    let config = DaemonConfig {
+        mode: fusillade::DaemonMode::Both,
+        claim_batch_size: 10,
+        batch_claim_size: 10,
+        batch_claim_batch_size: 10,
+        claim_interval_ms: 10,
+        batch_claim_interval_ms: 10,
+        model_concurrency_limits,
+        background_concurrency_limit: 4,
+        inject_deadline_priority: true,
+        adaptive_concurrency_recovery_interval_ms: 60_000,
+        max_retries: Some(3),
+        stop_before_deadline_ms: None,
+        backoff_ms: 60_000,
+        backoff_factor: 1,
+        max_backoff_ms: 60_000,
+        status_log_interval_ms: None,
+        throughput_log_interval_ms: None,
+        heartbeat_interval_ms: 10_000,
+        cancellation_poll_interval_ms: 100,
+        purge_interval_ms: 0,
+        ..Default::default()
+    };
+    let manager = postgres_store(pool, &config).await;
+    let background_request_id = uuid::Uuid::new_v4();
+    manager
+        .create_background(CreateBackgroundInput {
+            request_id: background_request_id,
+            body: r#"{"kind":"background-overload"}"#.to_string(),
+            model: "shared-model".to_string(),
+            endpoint: "https://api.example.com".to_string(),
+            method: "POST".to_string(),
+            path: "/v1/adaptive-shared".to_string(),
+            api_key: "key".to_string(),
+            created_by: "background-owner".to_string(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    mark_models_live_for_test(manager.as_ref(), &["shared-model"]).await;
+
+    let shutdown_token = CancellationToken::new();
+    let daemon_handle = postgres_daemon(manager.clone(), http_client.clone(), config)
+        .run(shutdown_token.clone())
+        .unwrap();
+
+    wait_for_mock_calls(&http_client, 1).await;
+    overload_trigger.send(()).unwrap();
+    let overload_recorded_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        let background = manager
+            .get_request_detail(fusillade::RequestId(background_request_id))
+            .await
+            .unwrap();
+        if background.status == "pending" {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < overload_recorded_deadline,
+            "background 529 was not rescheduled before timeout"
+        );
+        tokio::task::yield_now().await;
+    }
+
+    let foreground_ids: Vec<_> = (0..4).map(|_| uuid::Uuid::new_v4()).collect();
+    for (index, request_id) in foreground_ids.iter().copied().enumerate() {
+        manager
+            .create_flex(CreateFlexInput {
+                request_id,
+                body: format!(r#"{{"kind":"foreground-{index}"}}"#),
+                model: "shared-model".to_string(),
+                endpoint: "https://api.example.com".to_string(),
+                method: "POST".to_string(),
+                path: "/v1/adaptive-shared".to_string(),
+                api_key: "key".to_string(),
+                created_by: format!("foreground-owner-{index}"),
+                metadata: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    wait_for_mock_calls(&http_client, 3).await;
+    assert_eq!(http_client.in_flight_count(), 2);
+    let stability_deadline = tokio::time::Instant::now() + Duration::from_millis(150);
+    while tokio::time::Instant::now() < stability_deadline {
+        assert_eq!(
+            http_client.call_count(),
+            3,
+            "background overload should halve foreground capacity from four to two"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let mut success_triggers = success_triggers.into_iter();
+    success_triggers.next().unwrap().send(()).unwrap();
+    success_triggers.next().unwrap().send(()).unwrap();
+    wait_for_mock_calls(&http_client, 5).await;
+    assert_eq!(http_client.in_flight_count(), 2);
+    success_triggers.next().unwrap().send(()).unwrap();
+    success_triggers.next().unwrap().send(()).unwrap();
+
+    let completion_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let mut all_completed = true;
+        for request_id in &foreground_ids {
+            let request = manager
+                .get_request_detail(fusillade::RequestId(*request_id))
+                .await
+                .unwrap();
+            all_completed &= request.status == "completed";
+        }
+        if all_completed {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < completion_deadline,
+            "foreground requests did not complete before timeout"
+        );
+        tokio::task::yield_now().await;
+    }
+
+    shutdown_token.cancel();
+    tokio::time::timeout(Duration::from_secs(5), daemon_handle)
+        .await
+        .expect("daemon should stop")
+        .expect("daemon task should not panic")
+        .expect("daemon should stop cleanly");
+}
+
+#[sqlx::test(migrator = "fusillade_arsenal::MIGRATOR")]
 async fn test_daemon_retries_configured_and_default_statuses(pool: sqlx::PgPool) {
     // Setup: Create HTTP client with failing responses, then success
     let http_client = Arc::new(MockHttpClient::new());


### PR DESCRIPTION
## Summary

- add a per-daemon, per-model AIMD controller that halves claim concurrency on exact downstream HTTP 529 responses and recovers additively
- share adaptive capacity across foreground/background request and batch claim loops, including route-at-claim escalation
- expose the recovery interval through configuration and add limit/change metrics plus operator documentation

## Tests

- `SQLX_OFFLINE=true just lint rust`
- `just test rust`
- focused adaptive-concurrency unit and integration tests, including cross-loop feedback and escalation capacity accounting