### PR TITLE
fix(inference): normalize null-like tool call arguments

### DIFF
--- a/onwards/src/strict/handlers.rs
+++ b/onwards/src/strict/handlers.rs
@@ -2717,6 +2717,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_strict_chat_response_normalizes_null_like_tool_arguments() {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .onwards_key("sk-test".to_string())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        let mock_response = r#"{
+            "id":"chatcmpl-tools",
+            "object":"chat.completion",
+            "created":1,
+            "model":"provider-model",
+            "choices":[{
+                "index":0,
+                "message":{
+                    "role":"assistant",
+                    "content":null,
+                    "tool_calls":[
+                        {"id":"missing","type":"function","function":{"name":"missing"}},
+                        {"id":"null","type":"function","function":{"name":"null","arguments":null}},
+                        {"id":"empty","type":"function","function":{"name":"empty","arguments":""}},
+                        {"id":"string-null","type":"function","function":{"name":"string_null","arguments":"null"}},
+                        {"id":"valid","type":"function","function":{"name":"valid","arguments":"{\"query\":\"x\"}"}}
+                    ]
+                },
+                "finish_reason":"tool_calls"
+            }]
+        }"#;
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        let state = AppState::with_client(targets, mock_client);
+        let router = crate::strict::build_strict_router(state);
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let calls = body["choices"][0]["message"]["tool_calls"]
+            .as_array()
+            .unwrap();
+
+        assert_eq!(calls[0]["function"]["arguments"], "{}");
+        assert_eq!(calls[1]["function"]["arguments"], "{}");
+        assert_eq!(calls[2]["function"]["arguments"], "{}");
+        assert_eq!(calls[3]["function"]["arguments"], "{}");
+        assert_eq!(calls[4]["function"]["arguments"], r#"{"query":"x"}"#);
+    }
+
+    #[tokio::test]
     // Onwards no longer manipulates the request body: it validates the shape and
     // forwards the ORIGINAL bytes verbatim. The id-scrub that used to live here moved
     // to dwctl's outbound_request middleware, so onwards must pass caller fields

--- a/onwards/src/strict/schemas/chat_completions.rs
+++ b/onwards/src/strict/schemas/chat_completions.rs
@@ -13,6 +13,31 @@ pub(crate) fn generated_chat_completion_id() -> String {
     format!("chatcmpl-{}", Uuid::new_v4())
 }
 
+fn normalize_null_like_tool_call_arguments(message: &mut Value) {
+    let Some(tool_calls) = message.get_mut("tool_calls").and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    for tool_call in tool_calls {
+        let Some(function) = tool_call.get_mut("function").and_then(Value::as_object_mut) else {
+            continue;
+        };
+
+        let null_like = match function.get("arguments") {
+            None | Some(Value::Null) => true,
+            Some(Value::String(arguments)) => {
+                let arguments = arguments.trim();
+                arguments.is_empty() || arguments == "null"
+            }
+            Some(_) => false,
+        };
+
+        if null_like {
+            function.insert("arguments".to_string(), Value::String("{}".to_string()));
+        }
+    }
+}
+
 fn normalize_chat_message_value(value: &mut Value) {
     let Some(object) = value.as_object_mut() else {
         return;
@@ -20,6 +45,8 @@ fn normalize_chat_message_value(value: &mut Value) {
 
     ensure_field(object, "role", || Value::String("assistant".to_string()));
     ensure_field(object, "content", || Value::Null);
+
+    normalize_null_like_tool_call_arguments(value);
 }
 
 fn normalize_chat_choice_value(value: &mut Value, fallback_index: usize) {


### PR DESCRIPTION
## Summary

- Canonicalize missing, JSON-null, empty, and string-null tool-call arguments to the OpenAI-compatible empty object string (`{}`).
- Apply the normalization immediately before strict Chat Completions response deserialization, which is the production path with `onwards.strict_mode` enabled.
- Add one strict-router regression test that exercises the upstream response through the real production handler path.

## Scope

This change is deliberately limited to non-streaming successful responses handled by the strict Chat Completions router. It does not change non-strict sanitization, streaming responses, request validation, or other API protocols.

## Rationale

Some OpenAI-compatible providers represent an empty function argument set as an omitted value, JSON `null`, an empty string, or the JSON string `"null"`. In the strict response path those forms either fail typed response deserialization or survive until a client replays the tool call. Canonicalizing them at this boundary prevents a provider response quirk from breaking the agent loop while preserving non-empty and malformed non-string values unchanged.

## Verification

- The strict-router regression test failed before the implementation with HTTP 502 instead of 200.
- `cargo test -p onwards test_strict_chat_response_normalizes_null_like_tool_arguments -- --nocapture` passed.
- `cargo test -p onwards`: 476 unit tests passed; 12 doctests passed; 3 doctests ignored.
- `git diff --check` passed.
