### PR TITLE
fix: restore ZDR decrypt and JIT image signing on the daemon dispatch path

### DIFF
--- a/dwctl/src/inference/engine/dispatch_processor.rs
+++ b/dwctl/src/inference/engine/dispatch_processor.rs
@@ -1,0 +1,267 @@
+//! Pre-dispatch preparation for daemon-claimed requests.
+//!
+//! A thin [`RequestProcessor`] that performs the two dwctl-side steps which must
+//! happen AFTER a row is claimed from fusillade's DB but BEFORE the dispatch HTTP
+//! request exists, then delegates to [`DefaultRequestProcessor`]:
+//!
+//! 1. ZDR decrypt - the stored body is a `dwzdr1:` ciphertext envelope keyed per
+//!    request. It is not parseable JSON, so no middleware on the loopback can act
+//!    on it: every downstream layer (translation, cache, `outbound_request`,
+//!    onwards' strict parse) chokes first. It has to be decrypted here.
+//! 2. JIT image signing - `dw-img://{sha256}` tokens placed in the body by the
+//!    file-ingest path are swapped for fresh short-lived signed URLs. The edge
+//!    `image_normalizer_middleware` runs `Mode::All`, which matches HTTP(S) URLs
+//!    and `data:` URIs but NOT tokens, so the loopback pass does not do this.
+//!
+//! Both were previously carried by `DwctlRequestProcessor`, which also ran the
+//! server-side multi-step tool loop. COR-536 retired that loop and deleted the
+//! whole struct, taking these two unrelated cross-cutting steps with it - ZDR flex
+//! requests then dispatched ciphertext and 400'd at onwards' strict parse. This
+//! module restores only the pre-dispatch preparation; the tool loop stays retired
+//! (dispatch loops back through the full dwctl edge, which does that job now).
+//!
+//! Both ZDR failure branches terminalize by persisting `Failed` and returning
+//! `Ok(RequestCompletionResult::Failed(..))` rather than a bare `Err`: an `Err`
+//! only logs a task failure and leaves the row stuck in `processing` ("running")
+//! until the batch window expires.
+//!
+//! Planned removal: COR-521 moves ZDR encrypt/decrypt into dwctl's own middleware
+//! and drops fusillade's ZDR hooks. Once the decrypt has an edge home, this
+//! processor and the dwctl-injects-into-fusillade seam can go away entirely.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use fusillade::request::{Claimed, Failed, FailureReason, Request, RequestCompletionResult};
+use fusillade::{CancellationFuture, DefaultRequestProcessor, HttpClient, RequestProcessor, ShouldRetry, Storage};
+
+/// Prepares a claimed request for dispatch, then delegates to the default
+/// processor. Construct with [`DispatchProcessor::new`] and wire the optional
+/// capabilities with [`with_keystore`](Self::with_keystore) /
+/// [`with_image_normalizer`](Self::with_image_normalizer).
+pub struct DispatchProcessor {
+    /// Encrypted key custody for ZDR flex bodies. `None` disables ZDR
+    /// decryption (bodies pass through unchanged).
+    keystore: Option<crate::keystore::Keystore>,
+    /// Resolves `dw-img://` tokens to signed URLs. `None` disables JIT signing.
+    image_normalizer: Option<Arc<dyn crate::image_normalizer::ImageNormalizer>>,
+    /// TTL for JIT-signed URLs. Sized from the daemon's processing timeout so a
+    /// signed URL always outlives one full dispatch attempt.
+    dispatch_ttl: Duration,
+    default: DefaultRequestProcessor,
+}
+
+impl Default for DispatchProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DispatchProcessor {
+    pub fn new() -> Self {
+        Self {
+            keystore: None,
+            image_normalizer: None,
+            dispatch_ttl: Duration::from_secs(0),
+            default: DefaultRequestProcessor,
+        }
+    }
+
+    /// Wire in the keystore so ZDR request bodies are decrypted before dispatch.
+    pub fn with_keystore(mut self, keystore: Option<crate::keystore::Keystore>) -> Self {
+        self.keystore = keystore;
+        self
+    }
+
+    /// Wire in the normaliser so `dw-img://` tokens are signed before dispatch.
+    pub fn with_image_normalizer(mut self, normalizer: Arc<dyn crate::image_normalizer::ImageNormalizer>, dispatch_ttl: Duration) -> Self {
+        self.image_normalizer = Some(normalizer);
+        self.dispatch_ttl = dispatch_ttl;
+        self
+    }
+
+    /// Build a terminal `Failed` request with a generic client-facing reason.
+    /// The real cause is logged for operators, never surfaced to the caller.
+    fn failed(request: Request<Claimed>, reason: FailureReason) -> Request<Failed> {
+        Request {
+            state: Failed {
+                reason,
+                failed_at: chrono::Utc::now(),
+                retry_attempt: request.state.retry_attempt,
+                batch_expires_at: request.state.batch_expires_at,
+                routed_model: request.data.model.clone(),
+            },
+            data: request.data,
+        }
+    }
+
+    fn zdr_unprocessable() -> FailureReason {
+        FailureReason::RequestBuilderError {
+            error: "Zero-data-retention request could not be processed".to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl<S, H> RequestProcessor<S, H> for DispatchProcessor
+where
+    S: Storage + Send + Sync + 'static,
+    H: HttpClient + Clone + Send + Sync + 'static,
+{
+    async fn process(
+        &self,
+        mut request: Request<Claimed>,
+        http: H,
+        storage: &S,
+        should_retry: ShouldRetry,
+        cancellation: CancellationFuture,
+    ) -> fusillade::Result<RequestCompletionResult> {
+        // ZDR: the stored request body is a self-describing ciphertext envelope.
+        // Decrypt it here, before JIT signing and dispatch, so the rest of the
+        // flow (and the whole loopback edge) sees plaintext. The response is
+        // re-encrypted on its way back by fusillade's ResponseTransformer hook.
+        if crate::inference::zdr::is_zdr_body(&request.data.body) {
+            let Some(keystore) = self.keystore.as_ref() else {
+                // ZDR ciphertext claimed but no keystore configured: the prompt can
+                // never be decrypted. Terminalize rather than strand the row.
+                crate::background_error!(
+                    crate::metrics::errors::component::ZDR_DISPATCH,
+                    "keystore_missing",
+                    Error,
+                    request_id = %request.data.id.0,
+                    "ZDR request claimed but keystore is not configured; failing request"
+                );
+                let failed = Self::failed(request, Self::zdr_unprocessable());
+                storage.persist(&failed).await?;
+                return Ok(RequestCompletionResult::Failed(failed));
+            };
+            let key_id = crate::inference::zdr::key_id(&request.data.id.0, crate::inference::zdr::KeyKind::Request);
+            match keystore.get(&key_id).await {
+                Ok(Some(key)) => {
+                    match crate::inference::zdr::decrypt_body(&key, &request.data.body) {
+                        Ok(plaintext) => request.data.body = plaintext,
+                        Err(e) => {
+                            // Ciphertext present but undecryptable (corrupt envelope or
+                            // wrong wrap key) - never succeeds on retry.
+                            crate::background_error!(
+                                crate::metrics::errors::component::ZDR_DISPATCH,
+                                "decrypt_failed",
+                                Error,
+                                request_id = %request.data.id.0,
+                                error = %e,
+                                "ZDR request body could not be decrypted; failing request"
+                            );
+                            let failed = Self::failed(request, Self::zdr_unprocessable());
+                            storage.persist(&failed).await?;
+                            return Ok(RequestCompletionResult::Failed(failed));
+                        }
+                    }
+                    // TRANSITIONAL (dwctl ZDR): mark the dispatch so the loopback
+                    // analytics handler blanks the now-plaintext body instead of
+                    // logging it. fusillade forwards batch_metadata entries as
+                    // `x-fusillade-batch-<key>` headers, so this rides out as
+                    // `x-fusillade-batch-zdr: 1`; the outlet handler reads that.
+                    // Drop when reassembly moves into dwctl (COR-521).
+                    request
+                        .data
+                        .batch_metadata
+                        .insert(crate::inference::zdr::ZDR_MARKER_KEY.to_string(), "1".to_string());
+                }
+                Ok(None) => {
+                    // Key expired/deleted before dispatch: the prompt is gone and this
+                    // request can never be processed. Terminalize (persist + Ok(Failed))
+                    // so the daemon records it as terminally failed instead of leaving
+                    // the row in `processing` until the batch window expires.
+                    let failed = Self::failed(
+                        request,
+                        FailureReason::RequestBuilderError {
+                            error: "ZDR request key expired before dispatch; cannot decrypt".to_string(),
+                        },
+                    );
+                    storage.persist(&failed).await?;
+                    return Ok(RequestCompletionResult::Failed(failed));
+                }
+                Err(e) => {
+                    // Keystore unreachable (transient - e.g. Redis restart). Return a
+                    // retriable failure so the daemon re-pends the row. Do NOT persist:
+                    // the daemon's retry path re-pends it itself, and a persisted Failed
+                    // would look terminal and lose the retry.
+                    crate::background_error!(
+                        crate::metrics::errors::component::ZDR_DISPATCH,
+                        "keystore_unreachable",
+                        Warning,
+                        request_id = %request.data.id.0,
+                        error = %e,
+                        "ZDR keystore unreachable during dispatch; scheduling retry"
+                    );
+                    let failed = Self::failed(
+                        request,
+                        FailureReason::NetworkError {
+                            error: "Zero-data-retention request could not be processed".to_string(),
+                        },
+                    );
+                    return Ok(RequestCompletionResult::Failed(failed));
+                }
+            }
+        }
+
+        // JIT signing: any `dw-img://{sha256}` token embedded in the body (placed
+        // there by the file-ingest path) gets resolved to a fresh short-lived
+        // signed URL right before dispatch. The long-lived value at rest is only
+        // the opaque token; the signed URL exists only for this attempt's TTL, so
+        // retries get fresh URLs and per-attempt leak windows stay bounded.
+        // No-op when the normaliser is unset or the body carries no tokens.
+        if let Some(normalizer) = self.image_normalizer.clone() {
+            let ttl = self.dispatch_ttl;
+            // Fail loud if the body isn't parseable JSON. A row containing
+            // `dw-img://` tokens by construction always has a JSON body; an
+            // unparseable body here means corruption, and dispatching the literal
+            // token upstream (which cannot fetch a `dw-img://` URL) would surface
+            // as a confusing upstream error far from the root cause.
+            // ValidationError, not Other: malformed input never succeeds on retry.
+            let mut body_value: serde_json::Value = serde_json::from_str(&request.data.body).map_err(|e| {
+                fusillade::FusilladeError::ValidationError(format!(
+                    "JIT image signing: request body is not valid JSON ({e}); refusing to dispatch with unresolved tokens"
+                ))
+            })?;
+            let result = crate::image_normalizer::walker::substitute_with(
+                &mut body_value,
+                crate::image_normalizer::Mode::TokensOnly,
+                |maybe_token| {
+                    let normalizer = Arc::clone(&normalizer);
+                    async move {
+                        let token: crate::image_normalizer::ImageToken = maybe_token
+                            .parse()
+                            .map_err(|e: crate::image_normalizer::TokenParseError| format!("invalid dw-img token: {e}"))?;
+                        let signed = normalizer.sign(token, ttl).await.map_err(|e| format!("sign failed: {e}"))?;
+                        Ok::<String, String>(signed.url)
+                    }
+                },
+            )
+            .await;
+            match result {
+                Ok(count) if count > 0 => match serde_json::to_string(&body_value) {
+                    Ok(new_body) => request.data.body = new_body,
+                    Err(e) => {
+                        return Err(fusillade::FusilladeError::Other(anyhow::anyhow!(
+                            "re-serialise body after JIT signing: {e}"
+                        )));
+                    }
+                },
+                Ok(_) => {} // no tokens found, leave body alone
+                Err(e) => {
+                    return Err(fusillade::FusilladeError::Other(anyhow::anyhow!(
+                        "JIT image-URL signing failed: {e}"
+                    )));
+                }
+            }
+        }
+
+        // Everything dispatches through the default processor: the loopback
+        // re-enters the full dwctl edge, which owns translation, id-scrub and the
+        // streaming usage flags. No path-based branching here - the multi-step
+        // tool loop that used to intercept `/v1/responses` is retired (COR-536).
+        self.default.process(request, http, storage, should_retry, cancellation).await
+    }
+}

--- a/dwctl/src/inference/engine/dispatch_processor.rs
+++ b/dwctl/src/inference/engine/dispatch_processor.rs
@@ -101,6 +101,14 @@ impl DispatchProcessor {
             error: "Zero-data-retention request could not be processed".to_string(),
         }
     }
+
+    /// Generic terminal reason for non-ZDR pre-dispatch preparation failures
+    /// (JIT signing). Deliberately says nothing about tokens or signing.
+    fn dispatch_unprocessable() -> FailureReason {
+        FailureReason::RequestBuilderError {
+            error: "Request could not be prepared for dispatch".to_string(),
+        }
+    }
 }
 
 #[async_trait]
@@ -173,12 +181,16 @@ where
                     // request can never be processed. Terminalize (persist + Ok(Failed))
                     // so the daemon records it as terminally failed instead of leaving
                     // the row in `processing` until the batch window expires.
-                    let failed = Self::failed(
-                        request,
-                        FailureReason::RequestBuilderError {
-                            error: "ZDR request key expired before dispatch; cannot decrypt".to_string(),
-                        },
+                    // Client reason is the same generic one as the other ZDR branches;
+                    // the specific cause is logged for operators only.
+                    crate::background_error!(
+                        crate::metrics::errors::component::ZDR_DISPATCH,
+                        "key_expired",
+                        Error,
+                        request_id = %request.data.id.0,
+                        "ZDR request key expired or was deleted before dispatch; cannot decrypt"
                     );
+                    let failed = Self::failed(request, Self::zdr_unprocessable());
                     storage.persist(&failed).await?;
                     return Ok(RequestCompletionResult::Failed(failed));
                 }
@@ -219,12 +231,25 @@ where
             // unparseable body here means corruption, and dispatching the literal
             // token upstream (which cannot fetch a `dw-img://` URL) would surface
             // as a confusing upstream error far from the root cause.
-            // ValidationError, not Other: malformed input never succeeds on retry.
-            let mut body_value: serde_json::Value = serde_json::from_str(&request.data.body).map_err(|e| {
-                fusillade::FusilladeError::ValidationError(format!(
-                    "JIT image signing: request body is not valid JSON ({e}); refusing to dispatch with unresolved tokens"
-                ))
-            })?;
+            // Terminalize rather than returning `Err`: malformed input never
+            // succeeds on retry, and a bare `Err` only logs a task failure and
+            // strands the row in `processing` (same reasoning as the ZDR branches).
+            let mut body_value: serde_json::Value = match serde_json::from_str(&request.data.body) {
+                Ok(value) => value,
+                Err(e) => {
+                    crate::background_error!(
+                        crate::metrics::errors::component::ZDR_DISPATCH,
+                        "jit_signing_body_not_json",
+                        Error,
+                        request_id = %request.data.id.0,
+                        error = %e,
+                        "Request body is not valid JSON; refusing to dispatch with unresolved dw-img tokens"
+                    );
+                    let failed = Self::failed(request, Self::dispatch_unprocessable());
+                    storage.persist(&failed).await?;
+                    return Ok(RequestCompletionResult::Failed(failed));
+                }
+            };
             let result = crate::image_normalizer::walker::substitute_with(
                 &mut body_value,
                 crate::image_normalizer::Mode::TokensOnly,
@@ -244,16 +269,45 @@ where
                 Ok(count) if count > 0 => match serde_json::to_string(&body_value) {
                     Ok(new_body) => request.data.body = new_body,
                     Err(e) => {
-                        return Err(fusillade::FusilladeError::Other(anyhow::anyhow!(
-                            "re-serialise body after JIT signing: {e}"
-                        )));
+                        // Re-serialising a `Value` that was just parsed does not fail
+                        // for input reasons; treat it as terminal rather than
+                        // stranding the row on a bare `Err`.
+                        crate::background_error!(
+                            crate::metrics::errors::component::ZDR_DISPATCH,
+                            "jit_signing_reserialise_failed",
+                            Error,
+                            request_id = %request.data.id.0,
+                            error = %e,
+                            "Failed to re-serialise request body after JIT signing"
+                        );
+                        let failed = Self::failed(request, Self::dispatch_unprocessable());
+                        storage.persist(&failed).await?;
+                        return Ok(RequestCompletionResult::Failed(failed));
                     }
                 },
                 Ok(_) => {} // no tokens found, leave body alone
                 Err(e) => {
-                    return Err(fusillade::FusilladeError::Other(anyhow::anyhow!(
-                        "JIT image-URL signing failed: {e}"
-                    )));
+                    // Signing is a call to an external signer, so a failure here is
+                    // usually TRANSIENT (signer/network blip). Return a retriable
+                    // failure without persisting, so the daemon re-pends the row -
+                    // same shape as the keystore-unreachable branch above.
+                    // Terminalising here would permanently kill batch rows during a
+                    // signer outage.
+                    crate::background_error!(
+                        crate::metrics::errors::component::ZDR_DISPATCH,
+                        "jit_signing_failed",
+                        Warning,
+                        request_id = %request.data.id.0,
+                        error = %e,
+                        "JIT image-URL signing failed; scheduling retry"
+                    );
+                    let failed = Self::failed(
+                        request,
+                        FailureReason::NetworkError {
+                            error: "Request could not be prepared for dispatch".to_string(),
+                        },
+                    );
+                    return Ok(RequestCompletionResult::Failed(failed));
                 }
             }
         }

--- a/dwctl/src/inference/engine/mod.rs
+++ b/dwctl/src/inference/engine/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! - **writer**: batched in-process persistence of completed requests.
 //! - **outlet_handler**: outlet `RequestHandler` that feeds the writer channel.
+//! - **dispatch_processor**: pre-dispatch preparation (ZDR decrypt, JIT image
+//!   signing) for daemon-claimed requests, before the loopback call.
 
+pub mod dispatch_processor;
 pub mod outlet_handler;
 pub mod writer;

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -3233,6 +3233,28 @@ impl Application {
         let image_normalizer =
             crate::image_normalizer::from_config(&config.image_normalizer).map_err(|e| anyhow::anyhow!("image normaliser config: {e}"))?;
 
+        // Pre-dispatch preparation for daemon-claimed requests. MUST be installed
+        // before `setup_background_services` spawns the daemon, or claims can be
+        // dispatched without it. Two steps that cannot happen on the loopback:
+        //   - ZDR decrypt: the stored body is `dwzdr1:` ciphertext, so it is not
+        //     parseable JSON and every edge layer chokes before it could act.
+        //   - JIT image signing: the edge normaliser runs `Mode::All`, which does
+        //     not match the `dw-img://` tokens that file ingest stores.
+        // Derive the signing TTL from the daemon's processing timeout so a signed
+        // URL always outlives one full dispatch attempt.
+        {
+            let processing_timeout = std::time::Duration::from_millis(config.background_services.batch_daemon.processing_timeout_ms);
+            let dispatch_ttl = config.image_normalizer.signing.dispatch_ttl(processing_timeout);
+            let mut dispatch_processor =
+                crate::inference::engine::dispatch_processor::DispatchProcessor::new().with_keystore(keystore.clone());
+            if config.image_normalizer.enabled {
+                dispatch_processor = dispatch_processor.with_image_normalizer(image_normalizer.clone(), dispatch_ttl);
+            }
+            if let Err(e) = postgres_daemon.set_processor(Arc::new(dispatch_processor)) {
+                tracing::warn!(error = e, "Dispatch processor was already set; skipping");
+            }
+        }
+
         let mut bg_services = setup_background_services(BackgroundServicesInput {
             request_manager: request_manager.clone(),
             postgres_daemon: postgres_daemon.clone(),

--- a/dwctl/src/metrics/errors.rs
+++ b/dwctl/src/metrics/errors.rs
@@ -22,6 +22,7 @@ pub mod component {
     pub const TASK_WORKER: &str = "task_worker";
     pub const ONWARDS_SYNC: &str = "onwards_sync";
     pub const ZDR_KEY_SYNC: &str = "zdr_key_sync";
+    pub const ZDR_DISPATCH: &str = "zdr_dispatch";
     pub const ONWARDS_HEARTBEAT: &str = "onwards_heartbeat";
     pub const ANALYTICS: &str = "analytics";
     pub const ANALYTICS_BATCHER: &str = "analytics_batcher";


### PR DESCRIPTION
# fix: restore ZDR decrypt and JIT image signing on the daemon dispatch path

Restores two pre-dispatch steps that were removed as collateral when the
server-side multi-step tool loop was retired in COR-536 (#1317). One of them
caused a production incident; the other was silently broken.

## What broke

COR-536 deleted `dwctl/src/inference/engine/processor.rs`. That file was named,
constructed and documented as the multi-step tool loop's processor
(`DwctlRequestProcessor::new(response_store, multi_step_tool_executor,
multi_step_http_client, multi_step_loop_config)`), so retiring the loop meant
deleting it.

It was actually a decorator around `DefaultRequestProcessor`, and it ran two
unrelated cross-cutting steps for EVERY daemon-claimed request before branching:

1. **ZDR request decrypt.** The stored body is a `dwzdr1:` ciphertext envelope
   keyed per request. Without the decrypt, flex and background requests on
   zero-data-retention accounts dispatched ciphertext to the loopback. Ciphertext
   is not JSON, so onwards' strict handler rejected it via `parse_strict_request`
   as a syntax error (400, not 422), and fusillade terminalised every one as
   `non_retriable_http_status`. Non-retriable, so they did not self-heal.
2. **JIT `dw-img://` signing.** Batch file ingest replaces `image_url` values with
   opaque `dw-img://{sha256}` tokens at upload time, so the value at rest is never
   a live URL. The processor swapped those tokens for fresh short-lived signed URLs
   immediately before dispatch. Without it, batch requests carrying images
   dispatched the literal token upstream, which no provider can fetch. Latent
   rather than loud, because it only affects batches containing images.

Neither step is recoverable downstream:

- The edge cannot decrypt: ciphertext is unparseable, so translation, cache,
  `outbound_request` and onwards' strict parse all choke before anything could act.
- The edge does not sign tokens: `image_normalizer_middleware` runs `Mode::All`,
  which is `is_http_url(input) || looks_like_data_uri(input)`. It does not match
  `dw-img://` tokens; only `Mode::TokensOnly` does, and nothing else used it.

Flex was unaffected on the image side: flex submit returns early in
`inference_middleware` (`handle_flex` never calls `next`), so no inner middleware
runs at submit and the stored flex body holds original URLs, not tokens. Those are
normalised by the edge on the loopback pass as before.

## What this does

Adds `dwctl/src/inference/engine/dispatch_processor.rs`: a thin
`DispatchProcessor` that performs the two pre-dispatch steps and then delegates to
`DefaultRequestProcessor`. The ZDR block is a verbatim restore, including its
failure semantics:

- keystore missing, or ciphertext undecryptable -> terminalise by persisting
  `Failed` and returning `Ok(RequestCompletionResult::Failed(..))`. A bare `Err`
  would only log a task failure and leave the row stuck in `processing` ("running")
  until the batch window expires.
- keystore unreachable (transient, e.g. a cache restart) -> retriable failure with
  no persist, so the daemon re-pends the row instead of recording it as terminal.

Wired in `lib.rs` via `postgres_daemon.set_processor(..)` immediately before
`setup_background_services`, which is what spawns the daemon - installing it later
would let claims dispatch unprepared. `dispatch_ttl` is derived from the batch
daemon's `processing_timeout_ms` as before, so a signed URL always outlives one
full dispatch attempt.

Restores `metrics::errors::component::ZDR_DISPATCH`, which was deleted alongside
the processor and is required by the `background_error!` calls.

The tool loop stays retired. There is no path-based branching, no tool executor,
no tool resolver and no loop config: every claim delegates to
`DefaultRequestProcessor`, and the loopback re-entry owns translation, id-scrub
and the streaming usage flags.

## Why not fix this at the edge instead

That is the right end state and it is COR-521, which already specifies "dwctl does
the ZDR encrypt/decrypt at its own middleware instead". Doing it here would mean
designing a new middleware ordering constraint (the decrypt must sit outer to every
layer that parses the body) and relocating the `x-fusillade-batch-zdr` marker that
`ZdrBodyScrubber` relies on, under incident conditions. This change is the smallest
correct restore; COR-521 removes the seam properly. Comment added there recording
the incident and widening its scope to the request side.

## Testing

- `cargo check -p dwctl` clean.
- `cargo clippy -p dwctl --all-targets` clean (only pre-existing onwards warnings).
- `cargo test -p dwctl --lib zdr`: 14 passed, 0 failed.

**No new test, deliberately.** The only path that exercises either step is a real
daemon claim dispatching over a real loopback port, which the in-memory `axum_test`
transport cannot provide - the same gap already documented for flex and background
POST-then-GET coverage. A unit test here would need a full `Storage` mock and would
only re-cover `zdr.rs` logic that is already tested; it would not have caught this
regression, which was the hook not being installed at all. The real guard is a
real-port e2e harness, noted on COR-521 as the prerequisite for the migration.

## Risk

Restores previously-shipped behaviour on a path that is currently broken. The
processor is a no-op for requests that are neither ZDR nor token-bearing: it checks
`is_zdr_body` (a prefix test) and, when a normaliser is configured, walks the body
once for tokens before delegating unchanged.
