### PR TITLE
fix: Anthropic usage frame spec follow-ups (always-zero scalars, no 2…

### DIFF
--- a/dwctl/src/inference/translation/anthropic/mod.rs
+++ b/dwctl/src/inference/translation/anthropic/mod.rs
@@ -382,7 +382,11 @@ mod tests {
     }
 
     #[test]
-    fn response_usage_omits_cache_fields_when_uncached() {
+    fn response_usage_reports_zero_cache_fields_when_uncached() {
+        // The live Anthropic API always includes the cache scalars (0 when
+        // caching is unused) — match it exactly. The per-TTL `cache_creation`
+        // object stays conditional, and its 24h tier is never emitted (24h
+        // writes are disabled at the server config level).
         let chat = json!({
             "id": "c", "model": "m",
             "choices": [ { "message": { "content": "hi" }, "finish_reason": "stop" } ],
@@ -391,8 +395,33 @@ mod tests {
         let bytes = response::from_chat_completions(Bytes::from(serde_json::to_vec(&chat).unwrap())).unwrap();
         let out: Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(out["usage"]["input_tokens"], 10);
-        assert!(out["usage"].get("cache_read_input_tokens").is_none());
-        assert!(out["usage"].get("cache_creation_input_tokens").is_none());
+        assert_eq!(out["usage"]["cache_read_input_tokens"], 0);
+        assert_eq!(out["usage"]["cache_creation_input_tokens"], 0);
+        assert!(out["usage"].get("cache_creation").is_none());
+    }
+
+    #[test]
+    fn response_usage_never_emits_the_24h_tier() {
+        // The OpenAI frame carries all three tiers; the customer frame must
+        // carry only the two Anthropic defines — an always-zero 24h field
+        // would imply a product we have turned off.
+        let chat = json!({
+            "id": "c", "model": "m",
+            "choices": [ { "message": { "content": "hi" }, "finish_reason": "stop" } ],
+            "usage": { "prompt_tokens": 100, "completion_tokens": 2,
+                "prompt_tokens_details": { "cached_tokens": 0 },
+                "cache_creation_input_tokens": 40,
+                "cache_creation": { "ephemeral_5m_input_tokens": 40, "ephemeral_1h_input_tokens": 0, "ephemeral_24h_input_tokens": 0 } }
+        });
+        let bytes = response::from_chat_completions(Bytes::from(serde_json::to_vec(&chat).unwrap())).unwrap();
+        let out: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(out["usage"]["input_tokens"], 60, "100 - 40 created");
+        assert_eq!(out["usage"]["cache_creation"]["ephemeral_5m_input_tokens"], 40);
+        assert!(
+            out["usage"]["cache_creation"].get("ephemeral_24h_input_tokens").is_none(),
+            "24h tier must not reach the customer frame: {}",
+            out["usage"]
+        );
     }
 
     #[test]

--- a/dwctl/src/inference/translation/anthropic/model.rs
+++ b/dwctl/src/inference/translation/anthropic/model.rs
@@ -218,13 +218,15 @@ pub enum StopReason {
 pub struct Usage {
     pub input_tokens: u64,
     pub output_tokens: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cache_read_input_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cache_creation_input_tokens: Option<u64>,
-    /// Per-TTL creation breakdown (Anthropic's `cache_creation` object; the 24h
-    /// field is a dwctl extension). Billing prices each tier at its own write
-    /// premium, so dropping this on translation billed creations at list.
+    /// Always serialized (0 when caching is unused), matching the live
+    /// Anthropic API rather than the SDKs' looser Optional typing.
+    #[serde(default)]
+    pub cache_read_input_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u64,
+    /// Per-TTL creation breakdown (Anthropic's `cache_creation` object).
+    /// Billing prices each tier at its own write premium, so dropping this on
+    /// translation billed creations at list.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_creation: Option<CacheCreation>,
 }
@@ -232,14 +234,17 @@ pub struct Usage {
 /// The `cache_creation` per-TTL breakdown. Field names match what the cache
 /// layer splices into the OpenAI frame, so the analytics extractor reads either
 /// shape with one code path.
+///
+/// Deliberately NO 24h field: it exists internally, but 24h writes are
+/// disabled at the server config level, so emitting an always-zero
+/// `ephemeral_24h_input_tokens` on the customer frame would only mislead
+/// (Anthropic's spec has exactly the two fields below).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheCreation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ephemeral_5m_input_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ephemeral_1h_input_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ephemeral_24h_input_tokens: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------

--- a/dwctl/src/inference/translation/anthropic/response.rs
+++ b/dwctl/src/inference/translation/anthropic/response.rs
@@ -65,7 +65,7 @@ pub fn from_chat_completions(body: Bytes) -> Result<Bytes, TranslationError> {
     }
 
     let (input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, cache_creation) =
-        resp.get("usage").map(anthropic_usage).unwrap_or((0, 0, None, None, None));
+        resp.get("usage").map(anthropic_usage).unwrap_or((0, 0, 0, 0, None));
 
     // vLLM/sglang expose the matched stop sequence (a string) at
     // `choices[].stop_reason`. When present, Anthropic reports
@@ -136,10 +136,10 @@ pub fn anthropic_error(status: StatusCode, message: String) -> (StatusCode, Byte
 /// `input + cache_read + cache_creation` reconstructs the full prompt. The analytics
 /// serializer relies on exactly that sum to recover `prompt_tokens` (total input);
 /// subtracting only one bucket here would make it double-bill the other. Returns
-/// `(input, output, cache_read, cache_creation)`; the cache values are `None`
-/// when zero/absent so they serialise out. Shared by the blocking and streaming
-/// paths.
-pub(super) fn anthropic_usage(usage: &Value) -> (u64, u64, Option<u64>, Option<u64>, Option<super::model::CacheCreation>) {
+/// `(input, output, cache_read, cache_creation)`; the cache scalars are plain
+/// counts (0 when unused) and always serialize, matching the live Anthropic API.
+/// Shared by the blocking and streaming paths.
+pub(super) fn anthropic_usage(usage: &Value) -> (u64, u64, u64, u64, Option<super::model::CacheCreation>) {
     let prompt = usage.get("prompt_tokens").and_then(Value::as_u64).unwrap_or(0);
     let output = usage.get("completion_tokens").and_then(Value::as_u64).unwrap_or(0);
     let cached = usage
@@ -157,8 +157,8 @@ pub(super) fn anthropic_usage(usage: &Value) -> (u64, u64, Option<u64>, Option<u
     (
         prompt.saturating_sub(cached).saturating_sub(creation),
         output,
-        (cached > 0).then_some(cached),
-        (creation > 0).then_some(creation),
+        cached,
+        creation,
         breakdown,
     )
 }

--- a/dwctl/src/inference/translation/anthropic/streaming.rs
+++ b/dwctl/src/inference/translation/anthropic/streaming.rs
@@ -59,8 +59,8 @@ pub struct AnthropicStreamReframer {
     matched_stop: Option<String>,
     input_tokens: u64,
     output_tokens: u64,
-    cache_read: Option<u64>,
-    cache_creation: Option<u64>,
+    cache_read: u64,
+    cache_creation: u64,
     cache_creation_breakdown: Option<super::model::CacheCreation>,
 }
 
@@ -261,16 +261,14 @@ impl StreamReframer for AnthropicStreamReframer {
             Some(s) => ("stop_sequence", json!(s)),
             None => (self.stop_reason.unwrap_or("end_turn"), Value::Null),
         };
-        // input_tokens is non-standard on message_delta but included so the count
-        // is not lost (message_start could only carry 0). See module docs. Cache
-        // counts are added only when present.
+        // The current Messages schema carries input_tokens and the cache fields on
+        // `message_delta.usage` (older SDKs typed them Optional), and our
+        // message_start could only carry 0 — upstream OpenAI SSE reveals usage in
+        // its final chunk. Emit the full set here; the cache scalars are always
+        // present (0 when unused), matching the live Anthropic API.
         let mut usage = json!({ "input_tokens": self.input_tokens, "output_tokens": self.output_tokens });
-        if let Some(cache_read) = self.cache_read {
-            usage["cache_read_input_tokens"] = json!(cache_read);
-        }
-        if let Some(cache_creation) = self.cache_creation {
-            usage["cache_creation_input_tokens"] = json!(cache_creation);
-        }
+        usage["cache_read_input_tokens"] = json!(self.cache_read);
+        usage["cache_creation_input_tokens"] = json!(self.cache_creation);
         if let Some(breakdown) = &self.cache_creation_breakdown {
             // Per-TTL breakdown: billing prices each tier at its own write
             // premium, and the analytics extractor reads this exact object.

--- a/dwctl/src/request_logging/serializers.rs
+++ b/dwctl/src/request_logging/serializers.rs
@@ -859,9 +859,7 @@ impl From<&AiResponse> for TokenMetrics {
                 // reduced value subtracts the cached tokens twice and bills them at
                 // nothing. Add the cache buckets back to recover the full prompt.
                 let usage = &response.usage;
-                let prompt_tokens = (usage.input_tokens
-                    + usage.cache_read_input_tokens.unwrap_or(0)
-                    + usage.cache_creation_input_tokens.unwrap_or(0)) as i64;
+                let prompt_tokens = (usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens) as i64;
                 let completion_tokens = usage.output_tokens as i64;
                 Self {
                     prompt_tokens,


### PR DESCRIPTION
…4h tier)

Three follow-ups from the billing-fix audit, none changing token counts:

- cache_read_input_tokens / cache_creation_input_tokens are now plain counts that always serialize (0 when caching is unused), matching the live Anthropic API instead of the SDKs' looser Optional typing
- the cache_creation object no longer emits an ephemeral_24h_input_tokens field: 24h writes are disabled at the server config level, so an always-zero tier on the customer frame would imply a product we have turned off (Anthropic's spec defines exactly the 5m and 1h fields)
- the streaming module's 'input_tokens is non-standard on message_delta' comment predates the current Messages schema, which carries input and cache fields on message_delta.usage; the delta now always emits the cache scalars alongside them