### PR TITLE
fix: stop a strict request parse from zero-billing streamed requests

### DIFF
--- a/dwctl/src/request_logging/models.rs
+++ b/dwctl/src/request_logging/models.rs
@@ -3,15 +3,15 @@
 use std::collections::HashMap;
 
 use async_openai::types::chat::{CreateChatCompletionResponse, CreateChatCompletionStreamResponse};
-// Chat REQUESTS use onwards' strict schema, not async-openai's. onwards is the
-// owner of the chat request shape (dwctl already reuses it in translation) and it
-// models `reasoning_effort` as a permissive `serde_json::Value`, so canonical
-// values async-openai has not caught up with - notably `max`, which
+use async_openai::types::completions::{CreateCompletionRequest, CreateCompletionResponse};
+use async_openai::types::embeddings::{CreateBase64EmbeddingResponse, CreateEmbeddingRequest, CreateEmbeddingResponse};
+// Chat REQUESTS use onwards' strict schema, not async-openai's. onwards owns the
+// chat request shape (dwctl already reuses it in translation) and models
+// `reasoning_effort` as a permissive `serde_json::Value`, so canonical values
+// async-openai has not caught up with - notably `max`, which
 // `crate::reasoning::ReasoningEffort` defines and the platform routes on - still
 // deserialize instead of collapsing the request to `AiRequest::Other`.
 use onwards::strict::schemas::chat_completions::ChatCompletionRequest;
-use async_openai::types::completions::{CreateCompletionRequest, CreateCompletionResponse};
-use async_openai::types::embeddings::{CreateBase64EmbeddingResponse, CreateEmbeddingRequest, CreateEmbeddingResponse};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;

--- a/dwctl/src/request_logging/models.rs
+++ b/dwctl/src/request_logging/models.rs
@@ -2,7 +2,14 @@
 
 use std::collections::HashMap;
 
-use async_openai::types::chat::{CreateChatCompletionRequest, CreateChatCompletionResponse, CreateChatCompletionStreamResponse};
+use async_openai::types::chat::{CreateChatCompletionResponse, CreateChatCompletionStreamResponse};
+// Chat REQUESTS use onwards' strict schema, not async-openai's. onwards is the
+// owner of the chat request shape (dwctl already reuses it in translation) and it
+// models `reasoning_effort` as a permissive `serde_json::Value`, so canonical
+// values async-openai has not caught up with - notably `max`, which
+// `crate::reasoning::ReasoningEffort` defines and the platform routes on - still
+// deserialize instead of collapsing the request to `AiRequest::Other`.
+use onwards::strict::schemas::chat_completions::ChatCompletionRequest;
 use async_openai::types::completions::{CreateCompletionRequest, CreateCompletionResponse};
 use async_openai::types::embeddings::{CreateBase64EmbeddingResponse, CreateEmbeddingRequest, CreateEmbeddingResponse};
 use serde::{Deserialize, Serialize};
@@ -25,7 +32,13 @@ pub enum SseParseError {
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum AiRequest {
-    ChatCompletions(CreateChatCompletionRequest),
+    ChatCompletions(ChatCompletionRequest),
+    // NOT onwards' schemas, deliberately: `AiRequest` is untagged, so classification
+    // depends on each variant's REQUIRED fields to disambiguate. onwards'
+    // `CompletionRequest` requires only `model`, so it would swallow embeddings (and
+    // anything else) before the right variant was tried. async-openai's stricter
+    // shapes are what make the untagged match work. Chat is safe on onwards' schema
+    // because `messages` is required there and it is tried first.
     Completions(CreateCompletionRequest),
     Embeddings(CreateEmbeddingRequest),
     Other(Value),

--- a/dwctl/src/request_logging/serializers.rs
+++ b/dwctl/src/request_logging/serializers.rs
@@ -309,22 +309,6 @@ pub fn parse_ai_response(request_data: &RequestData, response_data: &ResponseDat
             utils::parse_anthropic_non_streaming_response(&body_str).or_else(|_| utils::parse_non_streaming_response(&body_str))
         }
     } else {
-        // Whether the CLIENT asked for a stream, read straight off the raw request
-        // body rather than via the typed `AiRequest`. The typed parse is strict (it
-        // goes through async-openai), so a single unrecognised field or enum value -
-        // e.g. `reasoning_effort: "max"`, which our canonical `reasoning::ReasoningEffort`
-        // supports but async-openai 0.34 does not - collapses the whole request to
-        // `AiRequest::Other`. That used to lose the stream flag, send a streamed body
-        // to the non-streaming parser, and bill the request ZERO tokens. Reading the
-        // flag from raw JSON makes the dispatch immune to request-schema drift, and
-        // matches what the `/messages` and `/responses` branches already do.
-        let body_stream_flag = request_data
-            .body
-            .as_ref()
-            .and_then(|b| serde_json::from_slice::<Value>(b).ok())
-            .and_then(|v| v.get("stream").and_then(Value::as_bool))
-            .unwrap_or(false);
-        let is_streaming = body_stream_flag || fusillade_stream;
         // Parse response based on request type
         match parse_ai_request(request_data) {
             Ok(parsed_request) => {
@@ -339,12 +323,26 @@ pub fn parse_ai_response(request_data: &RequestData, response_data: &ResponseDat
                         utils::parse_responses_non_streaming_response(&body_str).or_else(|_| utils::parse_non_streaming_response(&body_str))
                     }
                 } else {
+                    // The stream flag must survive a request the strict variants could
+                    // not model. A single unrecognised field or enum value - e.g.
+                    // `reasoning_effort: "max"`, which `crate::reasoning::ReasoningEffort`
+                    // defines and the platform routes on - drops the request into
+                    // `AiRequest::Other`. Reading the flag off the typed variant alone
+                    // used to lose it there, send a streamed body to the non-streaming
+                    // parser, and bill the request ZERO tokens. `Other` carries the raw
+                    // `Value`, so take the flag from that instead of re-parsing the body.
+                    let is_streaming = fusillade_stream
+                        || match &parsed_request.request {
+                            AiRequest::ChatCompletions(req) => req.stream.unwrap_or(false),
+                            AiRequest::Completions(req) => req.stream.unwrap_or(false),
+                            AiRequest::Other(value) => value.get("stream").and_then(Value::as_bool).unwrap_or(false),
+                            AiRequest::Embeddings(_) => false,
+                        };
                     // Endpoint choice still comes from the typed request (it tells chat
-                    // from completions from embeddings); only the stream flag is read
-                    // raw. An unparseable request (`Other`) on a streaming body falls
-                    // back to the chat streaming parser - chat is the only streaming
-                    // endpoint reachable here besides `/completions`, and the legacy
-                    // parser would reject a chat SSE body anyway.
+                    // from completions from embeddings). An unmodelled request (`Other`)
+                    // on a streaming body falls back to the chat streaming parser - chat
+                    // is the only streaming endpoint reachable here besides
+                    // `/completions`, and the legacy parser rejects a chat SSE body.
                     match parsed_request.request {
                         AiRequest::ChatCompletions(_) if is_streaming => utils::parse_streaming_response(&body_str),
                         AiRequest::Completions(_) if is_streaming => utils::parse_completions_streaming_response(&body_str),

--- a/dwctl/src/request_logging/serializers.rs
+++ b/dwctl/src/request_logging/serializers.rs
@@ -309,6 +309,22 @@ pub fn parse_ai_response(request_data: &RequestData, response_data: &ResponseDat
             utils::parse_anthropic_non_streaming_response(&body_str).or_else(|_| utils::parse_non_streaming_response(&body_str))
         }
     } else {
+        // Whether the CLIENT asked for a stream, read straight off the raw request
+        // body rather than via the typed `AiRequest`. The typed parse is strict (it
+        // goes through async-openai), so a single unrecognised field or enum value -
+        // e.g. `reasoning_effort: "max"`, which our canonical `reasoning::ReasoningEffort`
+        // supports but async-openai 0.34 does not - collapses the whole request to
+        // `AiRequest::Other`. That used to lose the stream flag, send a streamed body
+        // to the non-streaming parser, and bill the request ZERO tokens. Reading the
+        // flag from raw JSON makes the dispatch immune to request-schema drift, and
+        // matches what the `/messages` and `/responses` branches already do.
+        let body_stream_flag = request_data
+            .body
+            .as_ref()
+            .and_then(|b| serde_json::from_slice::<Value>(b).ok())
+            .and_then(|v| v.get("stream").and_then(Value::as_bool))
+            .unwrap_or(false);
+        let is_streaming = body_stream_flag || fusillade_stream;
         // Parse response based on request type
         match parse_ai_request(request_data) {
             Ok(parsed_request) => {
@@ -323,12 +339,17 @@ pub fn parse_ai_response(request_data: &RequestData, response_data: &ResponseDat
                         utils::parse_responses_non_streaming_response(&body_str).or_else(|_| utils::parse_non_streaming_response(&body_str))
                     }
                 } else {
+                    // Endpoint choice still comes from the typed request (it tells chat
+                    // from completions from embeddings); only the stream flag is read
+                    // raw. An unparseable request (`Other`) on a streaming body falls
+                    // back to the chat streaming parser - chat is the only streaming
+                    // endpoint reachable here besides `/completions`, and the legacy
+                    // parser would reject a chat SSE body anyway.
                     match parsed_request.request {
-                        AiRequest::ChatCompletions(chat_req) if chat_req.stream.unwrap_or(false) || fusillade_stream => {
-                            utils::parse_streaming_response(&body_str)
-                        }
-                        AiRequest::Completions(completion_req) if completion_req.stream.unwrap_or(false) || fusillade_stream => {
-                            utils::parse_completions_streaming_response(&body_str)
+                        AiRequest::ChatCompletions(_) if is_streaming => utils::parse_streaming_response(&body_str),
+                        AiRequest::Completions(_) if is_streaming => utils::parse_completions_streaming_response(&body_str),
+                        AiRequest::Other(_) if is_streaming => {
+                            utils::parse_streaming_response(&body_str).or_else(|_| utils::parse_completions_streaming_response(&body_str))
                         }
                         _ => utils::parse_non_streaming_response(&body_str),
                     }
@@ -2023,6 +2044,61 @@ mod tests {
             duration: Duration::from_millis(100),
             duration_to_first_byte: Duration::from_millis(50),
         }
+    }
+
+    /// `reasoning_effort: "max"` is a canonical value (`crate::reasoning::ReasoningEffort`)
+    /// that async-openai 0.34 does not know. Chat requests are typed against onwards'
+    /// strict schema, which models the field as a permissive `Value`, so the request
+    /// must still classify as `ChatCompletions` rather than collapsing to `Other`.
+    #[test]
+    fn chat_request_with_reasoning_effort_max_is_not_downgraded_to_other() {
+        let body = r#"{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"max"}"#;
+        let mut data = responses_request_data(None);
+        data.uri = "/v1/chat/completions".parse::<Uri>().unwrap();
+        data.body = Some(Bytes::from(body));
+
+        match parse_ai_request(&data).unwrap().request {
+            AiRequest::ChatCompletions(req) => {
+                assert_eq!(req.model, "gpt-4o");
+                assert_eq!(req.reasoning_effort, Some(serde_json::json!("max")));
+            }
+            other => panic!("expected ChatCompletions, got {other:?}"),
+        }
+    }
+
+    /// Billing regression guard: a STREAMED chat request whose body the typed parser
+    /// cannot fully model must still be parsed with the streaming response parser.
+    /// Reading `stream` from the typed request used to lose the flag, feed an SSE body
+    /// to the non-streaming parser, and bill the request zero tokens.
+    #[test]
+    fn streaming_response_is_parsed_even_when_request_type_is_unrecognised() {
+        // `messages` is deliberately malformed for every typed variant, so the request
+        // lands as `AiRequest::Other` - standing in for any future schema drift.
+        let body = r#"{"model":"gpt-4o","messages":42,"stream":true}"#;
+        let mut req = responses_request_data(None);
+        req.uri = "/v1/chat/completions".parse::<Uri>().unwrap();
+        req.body = Some(Bytes::from(body));
+        assert!(
+            matches!(parse_ai_request(&req).unwrap().request, AiRequest::Other(_)),
+            "fixture must produce an unrecognised request for this guard to mean anything"
+        );
+
+        let sse = concat!(
+            "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",",
+            "\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",",
+            "\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":7,\"total_tokens\":12}}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let parsed = parse_ai_response(&req, &responses_response_data(sse.to_string())).expect("streamed body should parse");
+
+        match &parsed {
+            AiResponse::ChatCompletionsStream(chunks) => assert!(!chunks.is_empty()),
+            other => panic!("expected ChatCompletionsStream, got {other:?}"),
+        }
+        let metrics = crate::request_logging::serializers::TokenMetrics::from(&parsed);
+        assert_eq!(metrics.completion_tokens, 7, "streamed request must not bill zero tokens");
+        assert_eq!(metrics.prompt_tokens, 5);
     }
 
     #[test]


### PR DESCRIPTION
# fix: stop a strict request parse from zero-billing streamed requests

Two defects, found while investigating why `reasoning_effort: "max"` was rejected.
The second one silently bills streamed requests nothing.

## 1. `reasoning_effort: "max"` did not deserialize

dwctl defines the canonical effort values in `reasoning.rs`:

```rust
pub enum ReasoningEffort { None, Minimal, Low, Medium, High, Xhigh, Max }
```

The platform accepts `max`, validates against it, and routes on it. But
`AiRequest::ChatCompletions` was typed against async-openai 0.34's
`CreateChatCompletionRequest`, whose own `ReasoningEffort` stops at `xhigh`. So a
value we define and route on could not be parsed back when logging and billing the
same request.

## 2. That parse failure zero-billed streamed requests

`AiRequest` is untagged with `Other(Value)` last, so any unrecognised field collapses
the whole request to `Other`. `serializers.rs` then read the `stream` flag off the
typed request:

```rust
AiRequest::ChatCompletions(chat_req) if chat_req.stream.unwrap_or(false) || fusillade_stream => ...
_ => utils::parse_non_streaming_response(&body_str),
```

`Other` matched `_`, so the stream flag was lost, an SSE body went to the
non-streaming parser, failed, and landed as `AiResponse::Other` - which bills zero
tokens and fires the `missing_usage` alarm. The customer is served normally and
charged nothing.

Confirmed live: the alarm fires with exactly this signature - `uri=/chat/completions`,
`response_type=other`, `fusillade_stream=true`, `response_model=None`.

## What this changes

- **Chat requests now type against onwards' strict schema**
  (`onwards::strict::schemas::chat_completions::ChatCompletionRequest`), which models
  `reasoning_effort` as `Option<serde_json::Value>`. onwards is the crate we own, is
  the owner the type-unification plan named for chat requests, and dwctl already
  reuses this struct in translation. `max` parses.
- **The stream flag is read from the raw request body**, matching what the
  `/messages` and `/responses` branches already do, plus an
  `AiRequest::Other(_) if is_streaming` arm. Billing no longer depends on the typed
  parse succeeding, so this closes the class rather than one value: any future field
  or enum value that async-openai has not caught up with now costs a variant label in
  the logs instead of the charge.

The typed request still selects the endpoint (chat vs completions vs embeddings);
only the stream flag comes from raw JSON.

## Deliberately unchanged

`Completions` and `Embeddings` stay on async-openai. Moving them to onwards' schemas
for symmetry was tried and broke classification: onwards' `CompletionRequest`
requires only `model`, so in an untagged enum it swallows embeddings bodies before
the right variant is tried. The stricter async-openai shapes are load-bearing for
disambiguation. Chat is safe on onwards' schema because `messages` is required there
and it is tried first. This reasoning is now a comment on the enum so the attempt is
not repeated.

## Testing

- `cargo check -p dwctl` clean.
- `cargo test -p dwctl --lib request_logging`: 132 passed, 0 failed.
- New: `chat_request_with_reasoning_effort_max_is_not_downgraded_to_other` - asserts
  the request classifies as `ChatCompletions` and `reasoning_effort` survives as
  `"max"`.
- New: `streaming_response_is_parsed_even_when_request_type_is_unrecognised` - the
  billing guard. Feeds a request the typed parser cannot model, asserts it lands as
  `Other` (so the fixture is meaningful), then asserts the SSE response still parses
  as `ChatCompletionsStream` and bills 5/7 tokens rather than zero.

## Success metric, with a caveat

Watch `sum(rate(dwctl_background_errors_total{reason="missing_usage"}[1h]))` for a
step down.

Expect a partial reduction, not a collapse to zero. A large share of that alarm is
upstream connections hanging up mid-stream, where no usage frame is ever emitted -
unrelated to this change. The remaining residue also includes the response side,
which this PR does not touch (see below).

## Follow-ups (not in this PR)

- **Path-based dispatch for `AiRequest`.** The root cause behind both defects is that
  the enum guesses the endpoint from body shape. That is why `/responses` needs path
  detection plus a bespoke `ResponsesRequest { model, stream }` side-struct, why
  `/messages` reads `stream` from raw JSON inline, and why swapping in a permissive
  type immediately mis-classified. Dispatching chat/completions/embeddings by path
  too would make variant ownership stop being load-bearing, let the enum be symmetric,
  and make `Responses`/`Anthropic` request variants addable.
- **Response-side tolerance.** `CreateChatCompletionResponse` carries strict enums
  (`ServiceTier`, `FinishReason`). A provider emitting a value outside those sets
  drops to `AiResponse::Other` and bills zero, on non-streaming requests too. Unlike
  the request side the dependency cannot be removed - billing genuinely needs that
  parse - so those fields need to become tolerant.
