### PR TITLE
fix(onwards): accept JSON-escaped model values in model extraction

### DIFF
--- a/onwards/src/lib.rs
+++ b/onwards/src/lib.rs
@@ -427,7 +427,7 @@ pub fn extract_model_from_request(headers: &HeaderMap, body_bytes: &[u8]) -> Opt
         }
         None => {
             let extracted: ExtractedModel = serde_json::from_slice(body_bytes).ok()?;
-            Some(extracted.model.to_string())
+            Some(extracted.model.into_owned())
         }
     }
 }
@@ -926,6 +926,36 @@ mod tests {
     /// Helper to create a single-provider pool from a target
     fn pool(target: Target) -> ProviderPool {
         target.into_pool()
+    }
+
+    /// RFC 8259 permits escaping any character in a JSON string, including the
+    /// solidus (`\/`) that PHP's `json_encode` escapes by default. Extraction
+    /// must decode escapes rather than reject strings containing them.
+    #[test]
+    fn test_extract_model_decodes_json_escapes() {
+        let headers = HeaderMap::new();
+        for body in [
+            br#"{"model":"zai-org/GLM-5.2-FP8","messages":[]}"#.as_slice(),
+            br#"{"model":"zai-org\/GLM-5.2-FP8","messages":[]}"#.as_slice(),
+            br#"{"model":"zai-org\u002FGLM-5.2-FP8","messages":[]}"#.as_slice(),
+        ] {
+            assert_eq!(
+                extract_model_from_request(&headers, body).as_deref(),
+                Some("zai-org/GLM-5.2-FP8"),
+                "body: {}",
+                String::from_utf8_lossy(body)
+            );
+        }
+    }
+
+    #[test]
+    fn test_extract_model_decodes_escaped_backslash() {
+        let headers = HeaderMap::new();
+        let body = br#"{"model":"weird\\model","messages":[]}"#;
+        assert_eq!(
+            extract_model_from_request(&headers, body).as_deref(),
+            Some(r"weird\model")
+        );
     }
 
     #[tokio::test]

--- a/onwards/src/models.rs
+++ b/onwards/src/models.rs
@@ -3,14 +3,22 @@
 //! This module defines the request and response structures used by the proxy's
 //! API endpoints, particularly the `/v1/models` endpoint which lists available
 //! targets as OpenAI-compatible models.
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 /// Requests to the /v1/{*} endpoints get forwarded onto OpenAI compatible targets.
 /// The target is chosen based on the model specified in the request body.
+///
+/// `Cow` rather than `&str`: a borrowed `&str` cannot represent a JSON string
+/// containing escape sequences (e.g. the RFC 8259 solidus escape `\/` that PHP's
+/// `json_encode` emits by default), so deserialization would reject those
+/// requests outright. `Cow` stays zero-copy for unescaped strings and allocates
+/// only when unescaping is required.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct ExtractedModel<'a> {
     #[serde(borrow)]
-    pub(crate) model: &'a str,
+    pub(crate) model: Cow<'a, str>,
 }
 
 /// The returned models from the /v1/models endpoint.


### PR DESCRIPTION
A model string containing any JSON escape sequence (e.g. the RFC 8259 solidus escape \/ that PHP's json_encode emits by default) was rejected with a 400, because ExtractedModel deserialized into a borrowed &str, which serde_json cannot produce when unescaping is required. Use Cow<str> so extraction stays zero-copy for unescaped strings and allocates only when an escape must be decoded.