### PR TITLE
feat(recompute): surface reasoning and total tokens

### DIFF
--- a/dwctl/src/recompute/mod.rs
+++ b/dwctl/src/recompute/mod.rs
@@ -43,6 +43,23 @@
 //! (`credits_transactions.source_id` is the analytics row id), and the balance derives from
 //! the ledger. One document in, a chain of pure derivations after it.
 //!
+//! # Everything is recomputed; nothing is assumed still correct
+//!
+//! The engine re-derives **every** usage figure the row stores — prompt, completion,
+//! reasoning, total, and the cache split — not just the ones a given incident is known to
+//! have broken. A field that comes back identical is then a *measurement* that it was fine,
+//! reported as a zero delta, rather than an assumption nobody checked.
+//!
+//! That distinction matters more than it sounds. In the August incident the completion
+//! counts happened to be correct on all 1,044 rows, and it would have been tempting to
+//! hard-code "completion is fine, skip it". The next incident will break a different field —
+//! the July one broke *everything*, because the response carried no usage at all — and a
+//! recompute that only looks where the last bug was is a recompute that misses the next one.
+//!
+//! So the only thing this module treats as un-recomputable is the cache split (below), and
+//! that is a property of the data being gone, not a judgement about which fields are
+//! trustworthy.
+//!
 //! Two findings from that work belong here, because whatever eventually reports or applies
 //! these corrections has to honour them:
 //!
@@ -166,6 +183,16 @@ impl Disagreement {
 pub struct RecomputedUsage {
     /// The counts to bill on, in the shape [`crate::pricing`] prices.
     pub counts: TokenCounts,
+    /// Reasoning tokens, re-read from the response. A *subset* of `counts.completion` rather
+    /// than an addition to it, so it does not affect price — but `http_analytics` stores it
+    /// as its own column, and a repair that leaves it stale makes the row internally
+    /// inconsistent. Zero for shapes with no such concept (Anthropic folds thinking into
+    /// `output_tokens` and reports no separate count).
+    pub reasoning: i64,
+    /// Total tokens as the response reports them, or `prompt + completion` where the shape
+    /// carries no total (Anthropic). Stored on its own column in `http_analytics`, so it is
+    /// recomputed rather than assumed to still follow from the other two.
+    pub total: i64,
     /// How `counts.prompt` was arrived at.
     pub prompt_source: TokenSource,
     /// How `counts.completion` was arrived at.
@@ -223,6 +250,8 @@ pub fn recompute_from_stored_response(
             cache_creation_1h: cache.creation_1h,
             cache_creation_24h: cache.creation_24h,
         },
+        reasoning: metrics.reasoning_tokens,
+        total: metrics.total_tokens,
         prompt_source: TokenSource::Reported,
         completion_source: TokenSource::Reported,
         disagreement: None,
@@ -283,6 +312,8 @@ mod tests {
                 cache_creation_1h: c1h,
                 cache_creation_24h: 0,
             },
+            reasoning: 0,
+            total: prompt + 50,
             prompt_source: TokenSource::Reported,
             completion_source: TokenSource::Reported,
             disagreement: None,

--- a/dwctl/src/recompute/replay.rs
+++ b/dwctl/src/recompute/replay.rs
@@ -302,6 +302,44 @@ mod tests {
         );
     }
 
+    /// Reasoning tokens are their own column in `http_analytics`, so a repair that leaves
+    /// them stale makes the row internally inconsistent. They were being computed by the
+    /// serializer and then dropped on the floor; this pins that they survive.
+    #[test]
+    fn reasoning_and_total_are_recomputed_not_dropped() {
+        let e = exchange(
+            "/v1/chat/completions",
+            r#"{"model":"m","messages":[{"role":"user","content":"hi"}]}"#,
+            r#"{"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"x"},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":80,"total_tokens":180,"completion_tokens_details":{"reasoning_tokens":60}}}"#,
+        );
+        let (req, resp) = e.to_outlet_pair().unwrap();
+        let got = recompute_from_stored_response(&req, &resp, CreationTier::FiveMinute).unwrap();
+
+        assert_eq!(got.counts.prompt, 100);
+        assert_eq!(got.counts.completion, 80);
+        assert_eq!(got.reasoning, 60, "reasoning is a subset of completion, not an addition");
+        assert_eq!(got.total, 180);
+    }
+
+    /// Anthropic reports no `total_tokens` and folds thinking into `output_tokens`, so total
+    /// is derived and reasoning is legitimately zero. Pinned so a future change to that
+    /// branch cannot silently start reporting a total of 0 for a whole ingress.
+    #[test]
+    fn anthropic_total_is_derived_and_reasoning_is_zero() {
+        let e = exchange(
+            "/v1/messages",
+            r#"{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":16}"#,
+            r#"{"id":"msg_1","type":"message","role":"assistant","model":"m","content":[],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":565,"output_tokens":658,"cache_read_input_tokens":17631,"cache_creation_input_tokens":538}}"#,
+        );
+        let (req, resp) = e.to_outlet_pair().unwrap();
+        let got = recompute_from_stored_response(&req, &resp, CreationTier::FiveMinute).unwrap();
+
+        assert_eq!(got.counts.prompt, 18_734);
+        assert_eq!(got.counts.completion, 658);
+        assert_eq!(got.reasoning, 0, "Anthropic folds thinking into output_tokens");
+        assert_eq!(got.total, 18_734 + 658, "no total reported - derived from the two");
+    }
+
     /// A stored status we cannot parse means a corrupt or never-populated row. Any
     /// substitute value asserts something about success or failure that the data does not
     /// support, and everything downstream gates on 2xx — so refuse the item instead.


### PR DESCRIPTION
## The bug

The engine re-derived `reasoning_tokens` and `total_tokens` from the stored response and then **dropped them on the floor**. `TokenMetrics` computes all four counts, but `RecomputedUsage` only kept prompt and completion, via `TokenCounts`.

Both dropped fields are their own columns in `http_analytics`. A repair driven by this report would have left them stale — producing rows internally inconsistent with their own prompt and completion.

## Why they're not in `TokenCounts`

`TokenCounts` is the *pricing* shape. Reasoning is a subset of completion rather than an addition to it, and neither field affects cost. They belong to the report, so they sit on `RecomputedUsage` alongside it.

## The general point, now in the module docs

**Everything is recomputed; nothing is assumed still correct.** A field that comes back identical has been *measured* as fine and shows as a zero delta — it is not a field the engine skipped.

Which fields a bug breaks isn't knowable in advance:

- **August** — completion counts intact, prompt and cache creation broken. It would have been tempting to hard-code "completion is fine, skip it".
- **July** — every count destroyed, because the provider returned no `usage` object at all.

A recompute that only looks where the last bug was is one that misses the next one. The only thing this module treats as un-recomputable remains the cache split, and that's a property of the evidence being gone, not a judgement about which fields to trust.

## Tests

Two, including the awkward case:

- a chat completion carrying `completion_tokens_details.reasoning_tokens: 60` → reasoning 60, total 180
- **Anthropic**: reports no `total_tokens` and folds thinking into `output_tokens`, so total is *derived* (`18,734 + 658`) and reasoning is legitimately 0. Without this test a future change to that branch could silently start reporting `total = 0` across a whole ingress.

## Testing

`just lint rust` clean, `cargo test -p dwctl --lib` green — 2016 tests.

Pairs with the runbook change in internal#1390, whose report shape assumes these fields are available.