### PR TITLE
feat(recompute): add the read-only dry-run endpoint

### DIFF
--- a/.sqlx/query-92ba633b44d57433b05f4dd4a406a82ebdfee3954c8ff33bcc7772aeb8492412.json
+++ b/.sqlx/query-92ba633b44d57433b05f4dd4a406a82ebdfee3954c8ff33bcc7772aeb8492412.json
@@ -1,0 +1,153 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            ha.id                              AS \"analytics_id!\",\n            ha.user_id,\n            ha.model,\n            ha.timestamp                       AS \"timestamp!\",\n            ha.uri                             AS \"uri!\",\n            ha.status_code,\n            ha.fusillade_request_id,\n            ha.fusillade_batch_id,\n            ha.prompt_tokens                   AS \"prompt_tokens!\",\n            ha.completion_tokens               AS \"completion_tokens!\",\n            ha.reasoning_tokens                AS \"reasoning_tokens!\",\n            ha.total_tokens                    AS \"total_tokens!\",\n            ha.cache_read_input_tokens         AS \"cache_read!\",\n            ha.cache_creation_5m_input_tokens  AS \"cache_creation_5m!\",\n            ha.cache_creation_1h_input_tokens  AS \"cache_creation_1h!\",\n            ha.cache_creation_24h_input_tokens AS \"cache_creation_24h!\",\n            ha.total_cost,\n            ha.input_price_per_token,\n            ha.output_price_per_token,\n            -- `?` overrides sqlx's nullability inference: rt.body is NOT NULL in its own\n            -- table, but this is a LEFT JOIN, so it is absent for any row with no fusillade\n            -- link. Without the override sqlx types it as String and the None case vanishes.\n            rt.body                            AS \"request_body?\",\n            r.response_body                    AS \"response_body?\",\n            r.response_status                  AS \"response_status?\"\n        FROM http_analytics ha\n        LEFT JOIN fusillade.requests r          ON r.id  = ha.fusillade_request_id\n        LEFT JOIN fusillade.request_templates rt ON rt.id = r.template_id\n        WHERE ha.timestamp >= $1\n          AND ha.timestamp <= $2\n          AND ($3::uuid IS NULL OR ha.user_id = $3)\n          AND ($4::text IS NULL OR ha.uri LIKE $4)\n          AND ($5::text IS NULL OR ha.model = $5)\n          -- Only rows that were billed: attributed, successful, and priced. A NULL\n          -- total_cost is a free model, where no charge was ever expected.\n          AND ha.user_id IS NOT NULL\n          AND ha.status_code BETWEEN 200 AND 299\n        ORDER BY ha.id\n        LIMIT $6\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "analytics_id!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "model",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "timestamp!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "uri!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "status_code",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "fusillade_request_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "fusillade_batch_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "prompt_tokens!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 9,
+        "name": "completion_tokens!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 10,
+        "name": "reasoning_tokens!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "total_tokens!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 12,
+        "name": "cache_read!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 13,
+        "name": "cache_creation_5m!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 14,
+        "name": "cache_creation_1h!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 15,
+        "name": "cache_creation_24h!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 16,
+        "name": "total_cost",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 17,
+        "name": "input_price_per_token",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 18,
+        "name": "output_price_per_token",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 19,
+        "name": "request_body?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "response_body?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "response_status?",
+        "type_info": "Int2"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "Timestamptz",
+        "Uuid",
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "92ba633b44d57433b05f4dd4a406a82ebdfee3954c8ff33bcc7772aeb8492412"
+}

--- a/dwctl/src/api/handlers/mod.rs
+++ b/dwctl/src/api/handlers/mod.rs
@@ -51,6 +51,7 @@ pub mod payments;
 pub mod probes;
 pub mod provider_display_configs;
 pub mod queue;
+pub mod recompute;
 pub mod requests;
 pub mod sla_capacity;
 pub mod static_assets;

--- a/dwctl/src/api/handlers/recompute.rs
+++ b/dwctl/src/api/handlers/recompute.rs
@@ -1,0 +1,135 @@
+//! Admin endpoint for the usage-recompute dry run.
+//!
+//! **Read-only, structurally.** The handler is handed `state.db.read()` and nothing else, so
+//! it cannot write even by mistake — the pool it holds has no path to a mutation. Applying a
+//! correction is a separate, human-run sequence documented in the internal
+//! `usage-recompute-repair` runbook; see [`crate::recompute`] for why that split exists.
+//!
+//! The response is a document meant to be saved: it is the only record of what was
+//! calculated, and the repair scripts consume it.
+
+use axum::Json;
+use axum::extract::{Query, State};
+use chrono::{DateTime, Duration, Utc};
+use serde::Deserialize;
+use utoipa::IntoParams;
+use uuid::Uuid;
+
+use crate::AppState;
+use crate::auth::permissions::{RequiresPermission, operation, resource};
+use crate::errors::{Error, Result};
+use crate::recompute::cache_fields::CreationTier;
+use crate::recompute::report::RecomputeReport;
+use crate::recompute::source::CorpusFilter;
+use sqlx_pool_router::PoolProvider;
+
+/// The largest corpus a single call will return.
+///
+/// A recompute reads whole stored response bodies, so the cost is in megabytes rather than
+/// rows. Incident corpora measured so far are ~1k rows; this leaves headroom without letting
+/// a mistyped predicate pull the whole table into memory.
+const MAX_LIMIT: i64 = 25_000;
+const DEFAULT_LIMIT: i64 = 5_000;
+
+/// The widest time window accepted, to stop an unbounded scan of a 185M-row table.
+const MAX_WINDOW_DAYS: i64 = 31;
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct RecomputeQuery {
+    /// Start of the window (inclusive). Anchor this on the deploy that introduced the bug.
+    pub start: DateTime<Utc>,
+    /// End of the window (inclusive).
+    pub end: DateTime<Utc>,
+    /// Restrict to one user. Usually set — incidents are rarely spread evenly.
+    pub user_id: Option<Uuid>,
+    /// SQL `LIKE` pattern against the request path, e.g. `/messages%`.
+    pub uri_pattern: Option<String>,
+    /// Restrict to one model alias.
+    pub model: Option<String>,
+    /// Cap on rows returned. Defaults to 5,000, hard maximum 25,000.
+    pub limit: Option<i64>,
+    /// Tier to attribute a flat cache-creation total to when the stored body gives no
+    /// breakdown: `5m` (default), `1h`, or `24h`.
+    ///
+    /// Do not guess. `prompt_cache_entries.ttl_tier` records the real tier per entry — query
+    /// it for the corpus and pass the answer. Rows relying on this are flagged
+    /// `cache_tier_inferred` so the assumption is visible rather than buried.
+    pub flat_creation_tier: Option<String>,
+}
+
+/// Recompute the usage of already-billed requests and report what changed.
+#[utoipa::path(
+    get,
+    path = "/usage-recompute",
+    tag = "analytics",
+    summary = "Dry-run recompute of recorded usage",
+    description = "Replays stored request/response payloads through the live serializer and re-prices them, \
+reporting stored vs recomputed usage per request. Read-only: it writes nothing. Applying a correction is a \
+separate documented procedure.",
+    responses(
+        (status = 200, description = "The recompute report.", body = RecomputeReport),
+        (status = 400, description = "Invalid or unbounded corpus predicate."),
+        (status = 403, description = "Requires analytics read access.")
+    ),
+    params(RecomputeQuery)
+)]
+#[tracing::instrument(skip_all, fields(user_id = %current_user.id))]
+pub async fn recompute_usage<P: PoolProvider>(
+    Query(query): Query<RecomputeQuery>,
+    State(state): State<AppState<P>>,
+    current_user: RequiresPermission<resource::Analytics, operation::ReadAll>,
+) -> Result<Json<RecomputeReport>> {
+    if query.end <= query.start {
+        return Err(Error::BadRequest {
+            message: "end must be after start".to_string(),
+        });
+    }
+    if query.end - query.start > Duration::days(MAX_WINDOW_DAYS) {
+        return Err(Error::BadRequest {
+            message: format!("window must be at most {MAX_WINDOW_DAYS} days; narrow it and run several corpora"),
+        });
+    }
+
+    let limit = query.limit.unwrap_or(DEFAULT_LIMIT);
+    if limit <= 0 || limit > MAX_LIMIT {
+        return Err(Error::BadRequest {
+            message: format!("limit must be between 1 and {MAX_LIMIT}"),
+        });
+    }
+
+    let flat_tier = match query.flat_creation_tier.as_deref() {
+        None | Some("5m") => CreationTier::FiveMinute,
+        Some("1h") => CreationTier::OneHour,
+        Some("24h") => CreationTier::TwentyFourHour,
+        Some(other) => {
+            return Err(Error::BadRequest {
+                message: format!("unknown flat_creation_tier {other:?}; expected 5m, 1h or 24h"),
+            });
+        }
+    };
+
+    let filter = CorpusFilter {
+        start: query.start,
+        end: query.end,
+        user_id: query.user_id,
+        uri_pattern: query.uri_pattern,
+        model: query.model,
+        limit,
+    };
+
+    // The read pool, deliberately: this path has no write handle at all.
+    let report = crate::recompute::recompute_corpus(state.db.read(), &filter, flat_tier)
+        .await
+        .map_err(|e| Error::Internal {
+            operation: format!("recompute usage: {e}"),
+        })?;
+
+    tracing::info!(
+        rows_total = report.summary.rows_total,
+        rows_changed = report.summary.rows_changed,
+        net_correction = %report.summary.net_correction,
+        "usage recompute dry run"
+    );
+
+    Ok(Json(report))
+}

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1532,6 +1532,10 @@ pub async fn build_router(
         .route("/requests/aggregate", get(api::handlers::requests::aggregate_requests))
         .route("/requests/aggregate-by-user", get(api::handlers::requests::aggregate_by_user))
         .route("/usage", get(api::handlers::requests::get_usage))
+        // Dry-run recompute of recorded usage. Read-only by construction — it is handed the
+        // read pool and has no write handle; corrections are applied by a documented human
+        // procedure, not by this endpoint.
+        .route("/usage-recompute", get(api::handlers::recompute::recompute_usage))
         // Probes management
         .route("/probes", get(api::handlers::probes::list_probes))
         .route("/probes", post(api::handlers::probes::create_probe))

--- a/dwctl/src/pricing/mod.rs
+++ b/dwctl/src/pricing/mod.rs
@@ -36,7 +36,7 @@ use crate::db::models::api_keys::ApiKeyPurpose;
 /// The split usually reconciles to `prompt` but is not guaranteed to; see
 /// [`compute_total_cost`] for the two-tier safety rule that handles drift and corruption.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct TokenCounts {
+pub struct TokenCounts {
     pub prompt: i64,
     pub completion: i64,
     pub cache_read: i64,

--- a/dwctl/src/recompute/mod.rs
+++ b/dwctl/src/recompute/mod.rs
@@ -85,21 +85,27 @@
 //! since been fixed — rather than a second opinion from a parallel implementation that
 //! could itself be wrong.
 //!
-//! # The one thing a recompute cannot do
+//! # The cache split
 //!
-//! It cannot recalculate the **cache split** (`cache_read_input_tokens` and the three
-//! `cache_creation_*` tiers). A tokenizer returns a total; it cannot say how much of that
-//! total was a cache *read* (billed at the ~0.1x read multiplier) versus a cache *write*
-//! (1.25–2.5x). The state that decided this lived in `prompt_cache_entries`, which is a
-//! cache and not a ledger: rows are upserted in place under a UNIQUE key, `expires_at`
-//! slides forward on every read, and entries age out on a 5m/1h window. By the time
-//! anyone is remediating, the evidence is gone.
+//! The split is carried through from the stored response. Where the response reported it
+//! correctly — both incidents so far — re-deriving a number already held exactly can only
+//! introduce error.
 //!
-//! So the split is **carried through from the stored response, never invented**. If a
-//! future incident corrupts the split itself rather than the total, this module cannot
-//! repair it and the remediation is manual. That limitation is accepted and deliberate;
-//! it does not block the incidents above, where the split was recorded correctly and only
-//! the total was wrong.
+//! It is reconstructable when it has to be: recompute the request's prefix hashes
+//! (deterministic from the request body and the scope
+//! `(principal_id, virtual_model, tokenizer_version)`), then for each breakpoint ask whether
+//! an episode covering that hash was live at the request's timestamp. Live means a cache
+//! read; not live means a creation.
+//!
+//! Two bounds on that, both of which belong in any report built on it:
+//!
+//! - **Retention.** `prompt_cache_entries` currently retains expired rows, so all history is
+//!   available. Once the sweeper ships with its grace period (7 days), anything older cannot
+//!   be reconstructed.
+//! - **Accuracy before the episode-per-row cutover.** A post-expiry write revives the same
+//!   row in place and keeps the original `created_at`, so `[created_at, expires_at]` can
+//!   contain dead gaps and over-approximates liveness. Answers for that period classify some
+//!   creations as reads, which under-bills, and must be labelled approximate.
 
 use crate::pricing::TokenCounts;
 use crate::request_logging::serializers::{TokenMetrics, extract_from_last_usage, parse_ai_response};
@@ -164,8 +170,11 @@ pub async fn recompute_corpus(
         })
         .collect::<Vec<_>>();
 
+    let oldest = corpus.iter().map(|r| r.timestamp).min();
+
     Ok(report::RecomputeReport {
         generated_at: chrono::Utc::now(),
+        warnings: report::corpus_warnings(oldest),
         corpus: serde_json::json!({
             "start": filter.start,
             "end": filter.end,

--- a/dwctl/src/recompute/mod.rs
+++ b/dwctl/src/recompute/mod.rs
@@ -43,6 +43,23 @@
 //! (`credits_transactions.source_id` is the analytics row id), and the balance derives from
 //! the ledger. One document in, a chain of pure derivations after it.
 //!
+//! # Everything is recomputed; nothing is assumed still correct
+//!
+//! The engine re-derives **every** usage figure the row stores — prompt, completion,
+//! reasoning, total, and the cache split — not just the ones a given incident is known to
+//! have broken. A field that comes back identical is then a *measurement* that it was fine,
+//! reported as a zero delta, rather than an assumption nobody checked.
+//!
+//! That distinction matters more than it sounds. In the August incident the completion
+//! counts happened to be correct on all 1,044 rows, and it would have been tempting to
+//! hard-code "completion is fine, skip it". The next incident will break a different field —
+//! the July one broke *everything*, because the response carried no usage at all — and a
+//! recompute that only looks where the last bug was is a recompute that misses the next one.
+//!
+//! So the only thing this module treats as un-recomputable is the cache split (below), and
+//! that is a property of the data being gone, not a judgement about which fields are
+//! trustworthy.
+//!
 //! Two findings from that work belong here, because whatever eventually reports or applies
 //! these corrections has to honour them:
 //!
@@ -166,6 +183,16 @@ impl Disagreement {
 pub struct RecomputedUsage {
     /// The counts to bill on, in the shape [`crate::pricing`] prices.
     pub counts: TokenCounts,
+    /// Reasoning tokens, re-read from the response. A *subset* of `counts.completion` rather
+    /// than an addition to it, so it does not affect price — but `http_analytics` stores it
+    /// as its own column, and a repair that leaves it stale makes the row internally
+    /// inconsistent. Zero for shapes with no such concept (Anthropic folds thinking into
+    /// `output_tokens` and reports no separate count).
+    pub reasoning: i64,
+    /// Total tokens as the response reports them, or `prompt + completion` where the shape
+    /// carries no total (Anthropic). Stored on its own column in `http_analytics`, so it is
+    /// recomputed rather than assumed to still follow from the other two.
+    pub total: i64,
     /// How `counts.prompt` was arrived at.
     pub prompt_source: TokenSource,
     /// How `counts.completion` was arrived at.
@@ -223,6 +250,8 @@ pub fn recompute_from_stored_response(
             cache_creation_1h: cache.creation_1h,
             cache_creation_24h: cache.creation_24h,
         },
+        reasoning: metrics.reasoning_tokens,
+        total: metrics.total_tokens,
         prompt_source: TokenSource::Reported,
         completion_source: TokenSource::Reported,
         disagreement: None,
@@ -283,6 +312,8 @@ mod tests {
                 cache_creation_1h: c1h,
                 cache_creation_24h: 0,
             },
+            reasoning: 0,
+            total: prompt + 50,
             prompt_source: TokenSource::Reported,
             completion_source: TokenSource::Reported,
             disagreement: None,

--- a/dwctl/src/recompute/mod.rs
+++ b/dwctl/src/recompute/mod.rs
@@ -101,21 +101,94 @@
 //! it does not block the incidents above, where the split was recorded correctly and only
 //! the total was wrong.
 
-// The engine lands before its callers: the dry-run job, the API handlers and the persisted
-// run/item tables are the next commits on this branch. Until those exist the only consumers
-// are this module's tests, so the whole surface reads as dead. Remove this attribute once
-// `recompute::job` is wired into `crate::tasks`.
-#![allow(dead_code)]
-
 use crate::pricing::TokenCounts;
 use crate::request_logging::serializers::{TokenMetrics, extract_from_last_usage, parse_ai_response};
 use outlet::{RequestData, ResponseData};
 
 pub mod cache_fields;
 pub mod replay;
+pub mod report;
+pub mod source;
 
 use cache_fields::{CacheReading, CreationTier, cache_tokens_both_shapes};
 use replay::RecomputeError;
+
+/// Recompute a whole corpus and build the report.
+///
+/// Read-only by construction: it takes a `&PgPool` it only ever `SELECT`s through, and the
+/// report it returns is a document. Nothing here writes, and nothing it returns is applied
+/// automatically — see the module docs.
+#[tracing::instrument(skip(pool, filter), fields(limit = filter.limit))]
+pub async fn recompute_corpus(
+    pool: &sqlx::PgPool,
+    filter: &source::CorpusFilter,
+    flat_tier: CreationTier,
+) -> Result<report::RecomputeReport, sqlx::Error> {
+    let corpus = source::load_corpus(pool, filter).await?;
+
+    let rows = corpus
+        .iter()
+        .map(|row| {
+            let Some(exchange) = &row.exchange else {
+                // No body at all. For a ZDR account this is permanent and expected; the
+                // tokens simply cannot be verified, only the dollars-from-stored-tokens
+                // check remains available.
+                return report::ReportRow::unreplayable(
+                    row,
+                    report::Evidence::ColumnsOnly,
+                    "no stored request/response body for this request".to_string(),
+                );
+            };
+
+            let replayed = exchange
+                .to_outlet_pair()
+                .and_then(|(req, resp)| recompute_from_stored_response(&req, &resp, flat_tier));
+
+            match replayed {
+                Ok(usage) => {
+                    // Price with the rates resolved at inference time, carried on the row.
+                    // Re-resolving the tariff here would silently re-base a correction onto
+                    // pricing that changed after the request was served.
+                    let cost = crate::pricing::charged_cost(
+                        &usage.counts,
+                        row.model.as_deref(),
+                        row.input_price_per_token,
+                        row.output_price_per_token,
+                        cache_multipliers_for(row),
+                        crate::metrics::errors::component::ANALYTICS,
+                    );
+                    report::ReportRow::replayed(row, &usage, cost)
+                }
+                Err(e) => report::ReportRow::unreplayable(row, report::Evidence::NotReplayable, e.to_string()),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(report::RecomputeReport {
+        generated_at: chrono::Utc::now(),
+        corpus: serde_json::json!({
+            "start": filter.start,
+            "end": filter.end,
+            "user_id": filter.user_id,
+            "uri_pattern": filter.uri_pattern,
+            "model": filter.model,
+            "limit": filter.limit,
+        }),
+        summary: report::ReportSummary::of(&rows),
+        rows,
+    })
+}
+
+/// Whether dwctl's cache discount applied to this request, inferred from the row itself.
+///
+/// The live path gates the discount on a `model_cache_tariffs` row valid at inference time.
+/// A recompute cannot re-resolve that without risking a tariff that changed since, so it
+/// uses the evidence already on the row: a request that recorded cache tokens was, by
+/// definition, priced by a cache-enabled model at the time. One that recorded none gets no
+/// multipliers, which is exactly the "provider's own caching, not ours" case.
+fn cache_multipliers_for(row: &source::CorpusRow) -> Option<crate::pricing::CacheMultipliers> {
+    (row.stored_cache_total() > 0).then(crate::pricing::CacheMultipliers::default)
+}
 
 /// Where a recomputed figure came from, and therefore how much it can be trusted.
 ///
@@ -276,6 +349,12 @@ pub fn recompute_from_stored_response(
 ///   re-pricing a request on a contested count.
 ///
 /// The cache split is untouched in every branch.
+///
+// Not yet reachable: the corpus recompute reads usage from the stored response, which is
+// exact and covers both incidents seen so far. This is the entry point for the tokenizer
+// path — needed when a response carries no usage at all (the July shape) — and is kept with
+// its tests because the precedence rules it encodes are the hard part, not the plumbing.
+#[allow(dead_code)]
 pub fn fold_render(mut usage: RecomputedUsage, rendered_prompt: i64, tolerance_bps: i64) -> RecomputedUsage {
     let reported_prompt = usage.counts.prompt;
 

--- a/dwctl/src/recompute/replay.rs
+++ b/dwctl/src/recompute/replay.rs
@@ -302,6 +302,44 @@ mod tests {
         );
     }
 
+    /// Reasoning tokens are their own column in `http_analytics`, so a repair that leaves
+    /// them stale makes the row internally inconsistent. They were being computed by the
+    /// serializer and then dropped on the floor; this pins that they survive.
+    #[test]
+    fn reasoning_and_total_are_recomputed_not_dropped() {
+        let e = exchange(
+            "/v1/chat/completions",
+            r#"{"model":"m","messages":[{"role":"user","content":"hi"}]}"#,
+            r#"{"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"x"},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":80,"total_tokens":180,"completion_tokens_details":{"reasoning_tokens":60}}}"#,
+        );
+        let (req, resp) = e.to_outlet_pair().unwrap();
+        let got = recompute_from_stored_response(&req, &resp, CreationTier::FiveMinute).unwrap();
+
+        assert_eq!(got.counts.prompt, 100);
+        assert_eq!(got.counts.completion, 80);
+        assert_eq!(got.reasoning, 60, "reasoning is a subset of completion, not an addition");
+        assert_eq!(got.total, 180);
+    }
+
+    /// Anthropic reports no `total_tokens` and folds thinking into `output_tokens`, so total
+    /// is derived and reasoning is legitimately zero. Pinned so a future change to that
+    /// branch cannot silently start reporting a total of 0 for a whole ingress.
+    #[test]
+    fn anthropic_total_is_derived_and_reasoning_is_zero() {
+        let e = exchange(
+            "/v1/messages",
+            r#"{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":16}"#,
+            r#"{"id":"msg_1","type":"message","role":"assistant","model":"m","content":[],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":565,"output_tokens":658,"cache_read_input_tokens":17631,"cache_creation_input_tokens":538}}"#,
+        );
+        let (req, resp) = e.to_outlet_pair().unwrap();
+        let got = recompute_from_stored_response(&req, &resp, CreationTier::FiveMinute).unwrap();
+
+        assert_eq!(got.counts.prompt, 18_734);
+        assert_eq!(got.counts.completion, 658);
+        assert_eq!(got.reasoning, 0, "Anthropic folds thinking into output_tokens");
+        assert_eq!(got.total, 18_734 + 658, "no total reported - derived from the two");
+    }
+
     /// A stored status we cannot parse means a corrupt or never-populated row. Any
     /// substitute value asserts something about success or failure that the data does not
     /// support, and everything downstream gates on 2xx — so refuse the item instead.

--- a/dwctl/src/recompute/report.rs
+++ b/dwctl/src/recompute/report.rs
@@ -1,0 +1,252 @@
+//! The dry-run report: what each request currently says, what it should say, and why.
+//!
+//! This is a **downloadable document, not a database table**. The operator saves it, attaches
+//! it to the incident, and feeds it to the repair scripts. It is deliberately the only piece
+//! of state the feature produces — every later repair step derives from the database
+//! (analytics from this file, billing from analytics, balance from the ledger), so there is
+//! no run history to persist, migrate or garbage-collect.
+//!
+//! Every usage field is reported, including ones that did not change. A field showing a zero
+//! delta has been *measured* as correct; it is not a field the engine skipped. Which fields a
+//! bug breaks is not knowable in advance — the August incident left completion counts intact,
+//! the July one destroyed every count in the response — so the report never pre-judges.
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::Serialize;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::RecomputedUsage;
+use super::source::CorpusRow;
+use crate::pricing::TokenCounts;
+
+/// How much of a row's answer rests on evidence versus inference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "PascalCase")]
+pub enum Evidence {
+    /// Body present and re-read. The counts are what the provider actually reported.
+    BodyFrame,
+    /// No body available — ZDR, no fusillade link, or purged. Nothing can be verified about
+    /// the tokens; only the stored columns are known.
+    ColumnsOnly,
+    /// A body exists but could not be replayed (unparseable, corrupt status). Needs a human;
+    /// deliberately not folded into any total.
+    NotReplayable,
+}
+
+/// The usage figures for one request, on either side of the comparison.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct UsageFigures {
+    pub prompt_tokens: i64,
+    pub completion_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub total_tokens: i64,
+    pub cache_read: i64,
+    pub cache_creation_5m: i64,
+    pub cache_creation_1h: i64,
+    pub cache_creation_24h: i64,
+    #[schema(value_type = Option<String>)]
+    pub cost: Option<Decimal>,
+}
+
+/// One request's before and after.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ReportRow {
+    pub analytics_id: i64,
+    pub fusillade_request_id: Option<Uuid>,
+    /// Non-null means a batch corpus, which needs the `batch_aggregates` analytics columns
+    /// delta-folded as well. Carried because the recomputed numbers alone cannot say so.
+    pub fusillade_batch_id: Option<Uuid>,
+    pub timestamp: DateTime<Utc>,
+    pub model: Option<String>,
+    pub stored: UsageFigures,
+    /// Absent when the row could not be replayed.
+    pub recomputed: Option<UsageFigures>,
+    pub evidence: Evidence,
+    /// `reported` / `rendered` / `estimated`, when a recompute happened.
+    pub token_source: Option<String>,
+    /// The stored body gave only a flat creation total, so the tier — and therefore the write
+    /// multiplier — was assigned by rule. Resolve it against `prompt_cache_entries` rather
+    /// than accepting it; see the repair runbook.
+    pub cache_tier_inferred: bool,
+    /// True when anything at all differs from what is stored.
+    pub changed: bool,
+    /// Why a row could not be replayed, when it could not.
+    pub note: Option<String>,
+}
+
+/// Corpus-level totals. Read these before the rows.
+#[derive(Debug, Clone, Serialize, ToSchema, Default)]
+pub struct ReportSummary {
+    pub rows_total: i64,
+    pub rows_changed: i64,
+    pub rows_unchanged: i64,
+    pub rows_not_replayable: i64,
+    pub rows_columns_only: i64,
+    pub rows_tier_inferred: i64,
+    pub stored_prompt_tokens: i64,
+    pub recomputed_prompt_tokens: i64,
+    pub stored_completion_tokens: i64,
+    pub recomputed_completion_tokens: i64,
+    #[schema(value_type = String)]
+    pub stored_cost: Decimal,
+    #[schema(value_type = String)]
+    pub recomputed_cost: Decimal,
+    /// `recomputed_cost − stored_cost`. Positive means undercharged.
+    #[schema(value_type = String)]
+    pub net_correction: Decimal,
+}
+
+/// The document.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct RecomputeReport {
+    pub generated_at: DateTime<Utc>,
+    /// The corpus predicate, echoed back so the file is self-describing months later.
+    pub corpus: serde_json::Value,
+    pub summary: ReportSummary,
+    pub rows: Vec<ReportRow>,
+}
+
+impl UsageFigures {
+    fn from_stored(row: &CorpusRow) -> Self {
+        Self {
+            prompt_tokens: row.stored_prompt_tokens,
+            completion_tokens: row.stored_completion_tokens,
+            reasoning_tokens: row.stored_reasoning_tokens,
+            total_tokens: row.stored_total_tokens,
+            cache_read: row.stored_cache_read,
+            cache_creation_5m: row.stored_cache_creation_5m,
+            cache_creation_1h: row.stored_cache_creation_1h,
+            cache_creation_24h: row.stored_cache_creation_24h,
+            cost: row.stored_total_cost,
+        }
+    }
+
+    fn from_recomputed(usage: &RecomputedUsage, cost: Option<Decimal>) -> Self {
+        let TokenCounts {
+            prompt,
+            completion,
+            cache_read,
+            cache_creation_5m,
+            cache_creation_1h,
+            cache_creation_24h,
+        } = usage.counts;
+        Self {
+            prompt_tokens: prompt,
+            completion_tokens: completion,
+            reasoning_tokens: usage.reasoning,
+            total_tokens: usage.total,
+            cache_read,
+            cache_creation_5m,
+            cache_creation_1h,
+            cache_creation_24h,
+            cost,
+        }
+    }
+
+    /// Field-by-field equality. Cost compares numerically so that trailing-zero differences
+    /// in `numeric` scale are not reported as a change — an artefact, not a correction.
+    fn differs_from(&self, other: &Self) -> bool {
+        self.prompt_tokens != other.prompt_tokens
+            || self.completion_tokens != other.completion_tokens
+            || self.reasoning_tokens != other.reasoning_tokens
+            || self.total_tokens != other.total_tokens
+            || self.cache_read != other.cache_read
+            || self.cache_creation_5m != other.cache_creation_5m
+            || self.cache_creation_1h != other.cache_creation_1h
+            || self.cache_creation_24h != other.cache_creation_24h
+            || match (self.cost, other.cost) {
+                (Some(a), Some(b)) => a != b,
+                (None, None) => false,
+                _ => true,
+            }
+    }
+}
+
+impl ReportRow {
+    /// A row that was replayed successfully.
+    pub fn replayed(row: &CorpusRow, usage: &RecomputedUsage, cost: Option<Decimal>) -> Self {
+        let stored = UsageFigures::from_stored(row);
+        let recomputed = UsageFigures::from_recomputed(usage, cost);
+        let changed = stored.differs_from(&recomputed);
+        Self {
+            analytics_id: row.analytics_id,
+            fusillade_request_id: row.fusillade_request_id,
+            fusillade_batch_id: row.fusillade_batch_id,
+            timestamp: row.timestamp,
+            model: row.model.clone(),
+            stored,
+            recomputed: Some(recomputed),
+            evidence: Evidence::BodyFrame,
+            token_source: Some(usage.prompt_source.as_str().to_string()),
+            cache_tier_inferred: usage.cache_tier_inferred,
+            changed,
+            note: None,
+        }
+    }
+
+    /// A row that could not be replayed. Reported rather than dropped: a corpus with silent
+    /// omissions is worse than one that says what it could not do.
+    pub fn unreplayable(row: &CorpusRow, evidence: Evidence, note: String) -> Self {
+        Self {
+            analytics_id: row.analytics_id,
+            fusillade_request_id: row.fusillade_request_id,
+            fusillade_batch_id: row.fusillade_batch_id,
+            timestamp: row.timestamp,
+            model: row.model.clone(),
+            stored: UsageFigures::from_stored(row),
+            recomputed: None,
+            evidence,
+            token_source: None,
+            cache_tier_inferred: false,
+            changed: false,
+            note: Some(note),
+        }
+    }
+}
+
+impl ReportSummary {
+    pub fn of(rows: &[ReportRow]) -> Self {
+        let mut s = Self {
+            rows_total: rows.len() as i64,
+            ..Default::default()
+        };
+        for r in rows {
+            match r.evidence {
+                Evidence::NotReplayable => s.rows_not_replayable += 1,
+                Evidence::ColumnsOnly => s.rows_columns_only += 1,
+                Evidence::BodyFrame => {}
+            }
+            if r.cache_tier_inferred {
+                s.rows_tier_inferred += 1;
+            }
+            s.stored_prompt_tokens += r.stored.prompt_tokens;
+            s.stored_completion_tokens += r.stored.completion_tokens;
+            s.stored_cost += r.stored.cost.unwrap_or_default();
+
+            match &r.recomputed {
+                Some(rec) => {
+                    if r.changed {
+                        s.rows_changed += 1;
+                    } else {
+                        s.rows_unchanged += 1;
+                    }
+                    s.recomputed_prompt_tokens += rec.prompt_tokens;
+                    s.recomputed_completion_tokens += rec.completion_tokens;
+                    s.recomputed_cost += rec.cost.unwrap_or_default();
+                }
+                // An un-replayed row contributes its STORED figures to the recomputed totals,
+                // so the two sides stay comparable and `net_correction` is the real delta
+                // rather than one inflated by rows nobody could check.
+                None => {
+                    s.recomputed_prompt_tokens += r.stored.prompt_tokens;
+                    s.recomputed_completion_tokens += r.stored.completion_tokens;
+                    s.recomputed_cost += r.stored.cost.unwrap_or_default();
+                }
+            }
+        }
+        s.net_correction = s.recomputed_cost - s.stored_cost;
+        s
+    }
+}

--- a/dwctl/src/recompute/report.rs
+++ b/dwctl/src/recompute/report.rs
@@ -105,7 +105,32 @@ pub struct RecomputeReport {
     /// The corpus predicate, echoed back so the file is self-describing months later.
     pub corpus: serde_json::Value,
     pub summary: ReportSummary,
+    /// Conditions that limit what this report can be trusted for. Empty is the normal case.
+    pub warnings: Vec<String>,
     pub rows: Vec<ReportRow>,
+}
+
+/// Days of `prompt_cache_entries` history the cache sweeper will retain.
+///
+/// Beyond this the entries backing a cache-split reconstruction are pruned, so a corpus older
+/// than the grace cannot have its split re-derived — only carried through from the response,
+/// or not recovered at all if the response never reported one.
+pub const CACHE_GRACE_DAYS: i64 = 7;
+
+/// Warnings that depend on the corpus rather than any individual row.
+pub fn corpus_warnings(oldest: Option<DateTime<Utc>>) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(oldest) = oldest {
+        let age = (Utc::now() - oldest).num_days();
+        if age > CACHE_GRACE_DAYS {
+            out.push(format!(
+                "corpus reaches {age} days back, beyond the {CACHE_GRACE_DAYS}-day cache retention grace: \
+                 prompt_cache_entries for the older rows may already be pruned, so the cache split \
+                 cannot be re-derived for them and the tier cannot be resolved from ttl_tier"
+            ));
+        }
+    }
+    out
 }
 
 impl UsageFigures {
@@ -203,6 +228,29 @@ impl ReportRow {
             changed: false,
             note: Some(note),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn corpus_within_the_grace_warns_about_nothing() {
+        let recent = Utc::now() - chrono::Duration::days(CACHE_GRACE_DAYS - 1);
+        assert!(corpus_warnings(Some(recent)).is_empty());
+        assert!(corpus_warnings(None).is_empty(), "an empty corpus has nothing to warn about");
+    }
+
+    /// Beyond the grace the cache entries backing a split reconstruction may already be
+    /// pruned, so the report has to say so rather than silently reporting a split it could
+    /// not have re-derived.
+    #[test]
+    fn corpus_beyond_the_grace_warns() {
+        let old = Utc::now() - chrono::Duration::days(CACHE_GRACE_DAYS + 3);
+        let warnings = corpus_warnings(Some(old));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("cache retention grace"), "got: {}", warnings[0]);
     }
 }
 

--- a/dwctl/src/recompute/source.rs
+++ b/dwctl/src/recompute/source.rs
@@ -1,0 +1,384 @@
+//! Loading a corpus of already-billed requests, with the payloads needed to replay them.
+//!
+//! One query, driven off `http_analytics` and joined to the fusillade rows that hold the
+//! bodies. Deliberately **not** one lookup per request: probing `http_analytics` per row
+//! saturated the Neon pageserver during the July remediation and had to be killed after
+//! fourteen minutes. A corpus is bounded and scanned once.
+//!
+//! Bodies come from fusillade (`request_templates.body`, `requests.response_body`) and never
+//! from outlet. Outlet does not store wire bytes — it round-trips the body through typed
+//! structs and re-serialises, which silently drops the cache extension fields while
+//! `prompt_tokens_details.cached_tokens` survives. A body read from there looks plausibly
+//! cache-annotated while the numbers that matter are gone.
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::replay::StoredExchange;
+
+/// Which requests to recompute.
+///
+/// Every field narrows the set; the time window is required because an unbounded scan of a
+/// 185M-row table is never what anyone means. Anchor a corpus on the deploy window that
+/// introduced the bug plus whatever identifies the affected traffic — not on the symptom,
+/// or rows that happen to look plausible are missed.
+#[derive(Debug, Clone)]
+pub struct CorpusFilter {
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    /// Restrict to one user. Usually set: incidents are rarely spread evenly.
+    pub user_id: Option<Uuid>,
+    /// SQL `LIKE` pattern against `http_analytics.uri`, e.g. `/messages%`.
+    pub uri_pattern: Option<String>,
+    /// Restrict to one model alias.
+    pub model: Option<String>,
+    /// Hard cap. A recompute reads whole response bodies, so an unbounded corpus is a
+    /// memory and IO hazard as much as a correctness one.
+    pub limit: i64,
+}
+
+/// One already-billed request: what analytics currently says, plus the payload to check it
+/// against.
+#[derive(Debug, Clone)]
+pub struct CorpusRow {
+    pub analytics_id: i64,
+    pub user_id: Option<Uuid>,
+    pub model: Option<String>,
+    pub timestamp: DateTime<Utc>,
+    pub fusillade_request_id: Option<Uuid>,
+    /// Present on batch traffic. Carried because a batch corpus needs its `batch_aggregates`
+    /// analytics columns delta-folded, and that is not inferable from the numbers alone.
+    pub fusillade_batch_id: Option<Uuid>,
+
+    // What is stored today — the "before" side of every delta.
+    pub stored_prompt_tokens: i64,
+    pub stored_completion_tokens: i64,
+    pub stored_reasoning_tokens: i64,
+    pub stored_total_tokens: i64,
+    pub stored_cache_read: i64,
+    pub stored_cache_creation_5m: i64,
+    pub stored_cache_creation_1h: i64,
+    pub stored_cache_creation_24h: i64,
+    pub stored_total_cost: Option<Decimal>,
+
+    /// Prices as they were resolved at inference time. Re-pricing uses these rather than
+    /// re-resolving the tariff, so a correction cannot be silently re-based onto a tariff
+    /// that changed after the fact.
+    pub input_price_per_token: Option<Decimal>,
+    pub output_price_per_token: Option<Decimal>,
+
+    /// The payload, when fusillade still holds it. `None` means not replayable — a ZDR row,
+    /// a row with no fusillade link, or one whose bodies have been purged.
+    pub exchange: Option<StoredExchange>,
+}
+
+impl CorpusRow {
+    /// Whether the cache split is all zero, i.e. this request recorded no caching at all.
+    pub fn stored_cache_total(&self) -> i64 {
+        self.stored_cache_read + self.stored_cache_creation_5m + self.stored_cache_creation_1h + self.stored_cache_creation_24h
+    }
+}
+
+/// Load the corpus in one scan.
+///
+/// `uri` doubles as the replay endpoint: `http_analytics` stores the path the caller used
+/// (`/messages?beta=true`, `/chat/completions`) without the proxy prefix, which is exactly
+/// the shape response parsing dispatches on.
+#[tracing::instrument(skip(pool), fields(limit = filter.limit))]
+pub async fn load_corpus(pool: &PgPool, filter: &CorpusFilter) -> Result<Vec<CorpusRow>, sqlx::Error> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT
+            ha.id                              AS "analytics_id!",
+            ha.user_id,
+            ha.model,
+            ha.timestamp                       AS "timestamp!",
+            ha.uri                             AS "uri!",
+            ha.status_code,
+            ha.fusillade_request_id,
+            ha.fusillade_batch_id,
+            ha.prompt_tokens                   AS "prompt_tokens!",
+            ha.completion_tokens               AS "completion_tokens!",
+            ha.reasoning_tokens                AS "reasoning_tokens!",
+            ha.total_tokens                    AS "total_tokens!",
+            ha.cache_read_input_tokens         AS "cache_read!",
+            ha.cache_creation_5m_input_tokens  AS "cache_creation_5m!",
+            ha.cache_creation_1h_input_tokens  AS "cache_creation_1h!",
+            ha.cache_creation_24h_input_tokens AS "cache_creation_24h!",
+            ha.total_cost,
+            ha.input_price_per_token,
+            ha.output_price_per_token,
+            -- `?` overrides sqlx's nullability inference: rt.body is NOT NULL in its own
+            -- table, but this is a LEFT JOIN, so it is absent for any row with no fusillade
+            -- link. Without the override sqlx types it as String and the None case vanishes.
+            rt.body                            AS "request_body?",
+            r.response_body                    AS "response_body?",
+            r.response_status                  AS "response_status?"
+        FROM http_analytics ha
+        LEFT JOIN fusillade.requests r          ON r.id  = ha.fusillade_request_id
+        LEFT JOIN fusillade.request_templates rt ON rt.id = r.template_id
+        WHERE ha.timestamp >= $1
+          AND ha.timestamp <= $2
+          AND ($3::uuid IS NULL OR ha.user_id = $3)
+          AND ($4::text IS NULL OR ha.uri LIKE $4)
+          AND ($5::text IS NULL OR ha.model = $5)
+          -- Only rows that were billed: attributed, successful, and priced. A NULL
+          -- total_cost is a free model, where no charge was ever expected.
+          AND ha.user_id IS NOT NULL
+          AND ha.status_code BETWEEN 200 AND 299
+        ORDER BY ha.id
+        LIMIT $6
+        "#,
+        filter.start,
+        filter.end,
+        filter.user_id,
+        filter.uri_pattern,
+        filter.model,
+        filter.limit,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| {
+            // A replay needs a response body above all; without one there is nothing to
+            // re-read. The status comes from fusillade rather than http_analytics because
+            // it is the upstream's, which is what the body belongs to.
+            let exchange = r.response_body.map(|body| {
+                let request_body = r.request_body.map(|b| b.into_bytes());
+                StoredExchange {
+                    endpoint: r.uri.clone(),
+                    streamed: StoredExchange::streamed_from_body(request_body.as_deref()),
+                    request_body,
+                    response_body: Some(body.into_bytes()),
+                    status_code: r.response_status.unwrap_or(r.status_code.unwrap_or(0) as i16) as u16,
+                }
+            });
+
+            CorpusRow {
+                analytics_id: r.analytics_id,
+                user_id: r.user_id,
+                model: r.model,
+                timestamp: r.timestamp,
+                fusillade_request_id: r.fusillade_request_id,
+                fusillade_batch_id: r.fusillade_batch_id,
+                stored_prompt_tokens: r.prompt_tokens,
+                stored_completion_tokens: r.completion_tokens,
+                stored_reasoning_tokens: r.reasoning_tokens,
+                stored_total_tokens: r.total_tokens,
+                stored_cache_read: r.cache_read,
+                stored_cache_creation_5m: r.cache_creation_5m,
+                stored_cache_creation_1h: r.cache_creation_1h,
+                stored_cache_creation_24h: r.cache_creation_24h,
+                stored_total_cost: r.total_cost,
+                input_price_per_token: r.input_price_per_token,
+                output_price_per_token: r.output_price_per_token,
+                exchange,
+            }
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recompute::cache_fields::CreationTier;
+    use crate::recompute::recompute_corpus;
+    use crate::test::utils::setup_fusillade_pool;
+    use sqlx::PgPool;
+
+    /// Seed one already-billed request with its stored payload, as the live path would have
+    /// left it. Returns the analytics row id.
+    #[allow(clippy::too_many_arguments)]
+    async fn seed(
+        pool: &PgPool,
+        uri: &str,
+        response_body: &str,
+        prompt: i64,
+        completion: i64,
+        cache_read: i64,
+        cache_creation_5m: i64,
+        cost: Decimal,
+    ) -> (Uuid, i64) {
+        let user_id = Uuid::new_v4();
+        sqlx::query!(
+            "INSERT INTO users (id, username, email, is_admin, auth_source) VALUES ($1,$2,$3,false,'test')",
+            user_id,
+            format!("u_{}", user_id.simple()),
+            format!("{}@example.com", user_id.simple()),
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let template_id = Uuid::new_v4();
+        sqlx::query!(
+            "INSERT INTO fusillade.request_templates (id, endpoint, method, path, model, api_key, body)
+             VALUES ($1,'http://x','POST',$2,'m','k',$3)",
+            template_id,
+            uri,
+            r#"{"model":"m","messages":[{"role":"user","content":"hi"}]}"#,
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let request_id = Uuid::new_v4();
+        sqlx::query!(
+            // created_by, not batch_id: `requests_attribution_xor` requires exactly one, and
+            // these are realtime rows - the same shape as the incident corpus.
+            "INSERT INTO fusillade.requests (id, template_id, state, model, response_status, response_body,
+                                             claimed_at, started_at, completed_at, created_by)
+             VALUES ($1,$2,'completed','m',200,$3,NOW(),NOW(),NOW(),$4)",
+            request_id,
+            template_id,
+            response_body,
+            user_id.to_string(),
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let analytics_id = sqlx::query_scalar!(
+            "INSERT INTO http_analytics
+               (instance_id, correlation_id, timestamp, method, uri, model, status_code, user_id,
+                prompt_tokens, completion_tokens, total_tokens, cache_read_input_tokens,
+                cache_creation_5m_input_tokens, cache_creation_input_tokens,
+                total_cost, input_price_per_token, output_price_per_token, fusillade_request_id)
+             VALUES ($1,1,NOW(),'POST',$2,'m',200,$3,$4,$5,$6,$7,$8,$8,$9,0.000001,0.000002,$10)
+             RETURNING id",
+            Uuid::new_v4(),
+            uri,
+            user_id,
+            prompt,
+            completion,
+            prompt + completion,
+            cache_read,
+            cache_creation_5m,
+            cost,
+            request_id,
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+
+        (user_id, analytics_id)
+    }
+
+    fn filter_for(user_id: Uuid) -> CorpusFilter {
+        CorpusFilter {
+            start: Utc::now() - chrono::Duration::hours(1),
+            end: Utc::now() + chrono::Duration::hours(1),
+            user_id: Some(user_id),
+            uri_pattern: None,
+            model: None,
+            limit: 100,
+        }
+    }
+
+    /// The property the whole feature rests on, end to end against a real database: pointed
+    /// at traffic with nothing wrong with it, the recompute proposes no change.
+    #[sqlx::test]
+    async fn healthy_traffic_recomputes_to_zero_delta(pool: PgPool) {
+        // The corpus query joins the fusillade schema, which #[sqlx::test] does not create.
+        setup_fusillade_pool(&pool).await;
+        // prompt 1000 @ 1e-6 + completion 100 @ 2e-6 = 0.0012, no caching.
+        let (user_id, _) = seed(
+            &pool,
+            "/chat/completions",
+            r#"{"id":"c","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"x"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1000,"completion_tokens":100,"total_tokens":1100}}"#,
+            1000,
+            100,
+            0,
+            0,
+            Decimal::from_str_exact("0.0012").unwrap(),
+        )
+        .await;
+
+        let report = recompute_corpus(&pool, &filter_for(user_id), CreationTier::FiveMinute)
+            .await
+            .unwrap();
+
+        assert_eq!(report.summary.rows_total, 1);
+        assert_eq!(report.summary.rows_changed, 0, "healthy traffic must propose no change");
+        assert_eq!(report.summary.rows_unchanged, 1);
+        assert_eq!(report.summary.net_correction, Decimal::ZERO);
+    }
+
+    /// The August incident, end to end: analytics stored Anthropic's `input_tokens` verbatim
+    /// and dropped creation entirely. The recompute must recover the total, recover the
+    /// creation from the FLAT field, and flag that the tier was assigned rather than read.
+    #[sqlx::test]
+    async fn anthropic_incident_row_is_detected_and_corrected(pool: PgPool) {
+        setup_fusillade_pool(&pool).await;
+        let (user_id, analytics_id) = seed(
+            &pool,
+            "/messages?beta=true",
+            r#"{"id":"msg_1","type":"message","role":"assistant","model":"m","content":[],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":565,"output_tokens":658,"cache_read_input_tokens":17631,"cache_creation_input_tokens":538}}"#,
+            565,   // what the bug stored
+            658,   // completion was correct
+            17631, // cache_read was correct
+            0,     // creation was dropped
+            Decimal::from_str_exact("0.000447942276").unwrap(),
+        )
+        .await;
+
+        let report = recompute_corpus(&pool, &filter_for(user_id), CreationTier::FiveMinute)
+            .await
+            .unwrap();
+
+        assert_eq!(report.summary.rows_changed, 1);
+        let row = report.rows.iter().find(|r| r.analytics_id == analytics_id).unwrap();
+        let rec = row.recomputed.as_ref().expect("row is replayable");
+
+        assert_eq!(rec.prompt_tokens, 18_734, "565 + 17631 + 538");
+        assert_eq!(rec.completion_tokens, 658, "completion was already right");
+        assert_eq!(rec.cache_read, 17_631, "the split is carried through, not invented");
+        assert_eq!(rec.cache_creation_5m, 538, "recovered from the FLAT field");
+        assert!(row.cache_tier_inferred, "the body never stated a tier");
+        assert!(report.summary.net_correction > Decimal::ZERO, "an undercharge");
+    }
+
+    /// A request with no stored body cannot be checked at all. It must be reported as such
+    /// rather than dropped, and must not be counted as a change.
+    #[sqlx::test]
+    async fn a_row_without_a_body_is_reported_as_columns_only(pool: PgPool) {
+        setup_fusillade_pool(&pool).await;
+        let user_id = Uuid::new_v4();
+        sqlx::query!(
+            "INSERT INTO users (id, username, email, is_admin, auth_source) VALUES ($1,$2,$3,false,'test')",
+            user_id,
+            format!("u_{}", user_id.simple()),
+            format!("{}@example.com", user_id.simple()),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query!(
+            "INSERT INTO http_analytics (instance_id, correlation_id, timestamp, method, uri, model,
+                status_code, user_id, prompt_tokens, completion_tokens, total_cost)
+             VALUES ($1,1,NOW(),'POST','/chat/completions','m',200,$2,10,5,0.0001)",
+            Uuid::new_v4(),
+            user_id,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let report = recompute_corpus(&pool, &filter_for(user_id), CreationTier::FiveMinute)
+            .await
+            .unwrap();
+
+        assert_eq!(report.summary.rows_total, 1);
+        assert_eq!(report.summary.rows_columns_only, 1);
+        assert_eq!(report.summary.rows_changed, 0, "unverifiable is not the same as changed");
+        assert_eq!(
+            report.summary.net_correction,
+            Decimal::ZERO,
+            "an unchecked row must not move the net correction"
+        );
+    }
+}


### PR DESCRIPTION
`GET /admin/api/v1/usage-recompute`. Replays a corpus of already-billed requests through the live serializer, re-prices them, and returns stored vs recomputed usage per request.

**Read-only by construction** — the handler is given `state.db.read()` and holds no write handle, so it cannot mutate even by mistake. Applying a correction is a separate human-run sequence, documented in the internal `usage-recompute-repair` runbook.

Stacked on #1491 (reasoning/total), which the report shape depends on. **Merge together with #1494**: prod verification found that the multiplier inference this PR shipped with re-prices dwctl-cached rows wrongly, and #1494 carries the fix (resolving the `model_cache_tariffs` version valid at the request's pricing time, exactly as the live batcher does) plus the endpoint's integration tests. This PR is kept as-authored to preserve review history; the stack is the unit that ships.

## Shape

- **`source.rs`** — one bounded scan joining `http_analytics` to the fusillade bodies. Deliberately *not* per-row lookups: that pattern saturated the Neon pageserver during the July remediation and had to be killed after 14 minutes.
- **`report.rs`** — the JSON document: every usage field on both sides, plus `Evidence` (`BodyFrame` / `ColumnsOnly` / `NotReplayable`).
- **`recompute_corpus`** — source → engine → pricing → report.
- **handler** — validates the predicate (window ≤ 31 days, limit ≤ 25k) and rejects an unknown `flat_creation_tier` rather than silently defaulting.

## Three decisions worth your attention

**Re-pricing uses the per-token rates stored on the analytics row**, not a freshly-resolved tariff. Re-resolving would silently re-base a correction onto pricing that changed *after* the request was served.

**Cache multipliers were inferred from the row's own evidence in this PR — superseded in #1494.** Measured against healthy prod traffic, the inference invented multipliers (config defaults: read ×0.1, write ×1.25) where the live tariff was read ×0.8, write ×1.0, reporting a negative "correction" on healthy rows. The tariff ledger is temporal, so #1494 resolves the version valid at the request's pricing time instead — the exact multipliers the live path billed with.

**Un-replayable rows contribute their *stored* figures to the recomputed totals**, so `net_correction` is the real delta rather than one inflated by rows nobody could verify. They're reported as `ColumnsOnly`/`NotReplayable` rather than dropped — a corpus with silent omissions is worse than one that says what it couldn't do.

## Tests

Three at corpus level against a real database:

- **healthy traffic → `rows_changed = 0`, `net_correction = 0`** — the property the whole feature rests on, now exercised through the real query rather than a synthetic fixture
- the August incident end to end: 565 → 18,734, creation recovered from the **flat** field, `cache_tier_inferred` set
- a body-less row reported as `ColumnsOnly`, not dropped, and not counted as a change

Handler-level integration tests (permission gate, predicate validation, both incident shapes over HTTP) are on #1494 with the fixes they exercise.

## Housekeeping

Drops the module-wide `allow(dead_code)` now the engine has a real consumer. Only `fold_render` keeps a scoped one — the tokenizer path still has no caller, and its tests encode the precedence rules that are the hard part.
