### PR TITLE
feat(cache): cacheBreakpoint query param for automatic caching

### DIFF
--- a/dwctl/src/prompt_cache/layer.rs
+++ b/dwctl/src/prompt_cache/layer.rs
@@ -42,6 +42,7 @@ use super::index::{CacheResult, TierPolicy};
 use super::inject::{UsageEdit, inject_into_response_nonstreaming, scan_edit_sse, scrub_response_nonstreaming, strip_cache_control};
 use super::metrics as cache_metrics;
 use super::parse::{ParseError, validate_markers};
+use super::query::{self, Inject, InvalidBreakpointValue};
 use super::sse::SseBufferedStream;
 
 /// Bound on the index commit (off the response path). A slow/hung DB can't leak the
@@ -117,6 +118,25 @@ fn marker_rejection_response(e: &ParseError, policy: &TierPolicy) -> Response {
     (StatusCode::BAD_REQUEST, axum::Json(body)).into_response()
 }
 
+/// Structured 400 for an unrecognized `cacheBreakpoint` query-param value — strict, like the
+/// marker rejections above: a typo must not silently disable caching while the caller believes
+/// it's on. Names the supported value so the client can adjust.
+fn query_rejection_response(e: &InvalidBreakpointValue) -> Response {
+    cache_metrics::record_query_breakpoint("invalid");
+    let body = serde_json::json!({
+        "error": {
+            "message": format!(
+                "invalid {} value {:?}; supported values: \"lastUserMessage\"",
+                query::CACHE_BREAKPOINT_PARAM, e.0
+            ),
+            "type": "invalid_request_error",
+            "code": "invalid_cache_breakpoint",
+            "param": query::CACHE_BREAKPOINT_PARAM,
+        }
+    });
+    (StatusCode::BAD_REQUEST, axum::Json(body)).into_response()
+}
+
 pub async fn cache_middleware(State(state): State<CacheLayerState>, request: Request, next: Next) -> Response {
     if !is_cacheable(&request) {
         return next.run(request).await;
@@ -146,7 +166,42 @@ pub async fn cache_middleware(State(state): State<CacheLayerState>, request: Req
 
     // Parse the body once; reused both for marker validation and to extract `model` (no extra
     // deserialization). `None` if the body isn't JSON — onwards will surface that as a 400.
-    let parsed_body = serde_json::from_slice::<serde_json::Value>(&body_bytes).ok();
+    let mut parsed_body = serde_json::from_slice::<serde_json::Value>(&body_bytes).ok();
+
+    // `?cacheBreakpoint=lastUserMessage` (see `super::query`): translate the query param into the
+    // top-level automatic-caching marker BEFORE validation, so everything downstream — the 400s
+    // below, classify's hashing, the outbound marker strip — behaves exactly as if the client had
+    // sent the body field. The param itself is stripped from the URI either way: onwards forwards
+    // `path_and_query` verbatim, and it must not leak upstream. The re-serialize below is the one
+    // extra cost, and only on param-carrying requests (whose marker means the outbound sanitiser
+    // was going to rewrite the body anyway).
+    let mut body_bytes = body_bytes;
+    match query::breakpoint_marker(parts.uri.query()) {
+        Ok(None) => {}
+        Ok(Some(marker)) => {
+            parts.uri = query::strip_param(&parts.uri);
+            let outcome = match parsed_body.as_mut() {
+                Some(body) => match query::inject_marker(body, marker) {
+                    Inject::Applied => match serde_json::to_vec(body) {
+                        Ok(b) => {
+                            body_bytes = b.into();
+                            "applied"
+                        }
+                        // Serializing a `Value` we just parsed can't realistically fail; if it
+                        // ever does, forward the original body un-injected (no caching) rather
+                        // than failing the request.
+                        Err(_) => "reserialize_failed",
+                    },
+                    Inject::BodyFieldWins => "body_field_wins",
+                    Inject::NotAnObject => "not_an_object",
+                },
+                // Unparseable JSON: nothing to inject into; onwards will 400 the body itself.
+                None => "not_json",
+            };
+            cache_metrics::record_query_breakpoint(outcome);
+        }
+        Err(e) => return query_rejection_response(&e),
+    }
 
     // Reject disallowed/malformed cache_control markers synchronously, before forking + forwarding
     // — a 400 like a bad parameter, NOT a silent no-cache, so the client learns immediately and
@@ -1027,6 +1082,336 @@ mod tests {
         assert!(t.contains("\"cached_tokens\":0"), "provider hit zeroed in terminal frame: {t}");
         assert!(!t.contains("687"), "provider value gone: {t}");
         assert!(t.contains("\"content\":\"hi\""), "delta preserved: {t}");
+        assert!(t.contains("data: [DONE]"), "DONE preserved: {t}");
+    }
+
+    // ---- `?cacheBreakpoint=lastUserMessage` (query-param automatic caching) ----
+
+    /// A body with NO cache_control anywhere — the shape the proxy customer sends.
+    fn body_unmarked() -> serde_json::Value {
+        serde_json::json!({
+            "model": ALIAS,
+            "messages": [
+                {"role": "system", "content": "static system"},
+                {"role": "user", "content": "hi"}
+            ]
+        })
+    }
+
+    /// Tokenizer mocks sized for [`body_unmarked`]'s TWO blocks (the automatic breakpoint's write
+    /// span covers the whole request, unlike the single-marked-block mocks above).
+    async fn mount_tokenizer_two_segments(tok: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "models": [{"alias": ALIAS, "hf_repo": "o/m", "tokenizer_version": TOK_VER}]
+            })))
+            .mount(tok)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/tokenize"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "virtual_model": ALIAS, "tokenizer_version": TOK_VER,
+                "segment_counts": [1500, 10], "cumulative": [1500, 1510], "total": 1510
+            })))
+            .mount(tok)
+            .await;
+    }
+
+    #[sqlx::test]
+    async fn query_param_end_to_end_creates_then_reads(pool: PgPool) {
+        // The customer's whole flow: an unmarked body + the query param behaves exactly like
+        // top-level automatic caching — first request writes the full conversation prefix,
+        // an identical follow-up reads it.
+        let user = create_test_user(&pool, Role::StandardUser).await;
+        let key = create_test_api_key_for_user(&pool, user.id).await;
+        let endpoint = create_test_endpoint(&pool, "ep", user.id).await;
+        let id = create_test_model(&pool, "m", ALIAS, endpoint, user.id).await;
+        sqlx::query!(
+            r#"INSERT INTO model_cache_tariffs
+                 (deployed_model_id, write_multiplier_5m, write_multiplier_1h, write_multiplier_24h, min_prefix_tokens)
+               VALUES ($1, 1.25, 2.0, 2.5, 1024)"#,
+            id
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let tok = MockServer::start().await;
+        mount_tokenizer_two_segments(&tok).await;
+
+        let classifier = Classifier::new(
+            PrincipalResolver::new(pool.clone()),
+            ModelConfigResolver::new(pool.clone()),
+            TokenizerClient::new(tok.uri()),
+            Arc::new(PostgresIndex::new(pool.clone(), 1)),
+            all_tiers(),
+            TelemetryPolicy::default(),
+            false,
+        );
+        let app = Router::new()
+            .route("/v1/chat/completions", post(mock_upstream))
+            .layer(from_fn_with_state(
+                CacheLayerState::new(classifier, usize::MAX, Duration::from_secs(5)),
+                cache_middleware,
+            ));
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        let r1 = server
+            .post("/v1/chat/completions")
+            .add_query_param("cacheBreakpoint", "lastUserMessage")
+            .add_header("authorization", format!("Bearer {}", key.secret))
+            .json(&body_unmarked())
+            .await;
+        r1.assert_status_ok();
+        let v1: serde_json::Value = r1.json();
+        assert_eq!(v1["usage"]["cache_read_input_tokens"], 0);
+        assert_eq!(
+            v1["usage"]["cache_creation_input_tokens"], 1510,
+            "the whole conversation is the written prefix"
+        );
+
+        // The write lands at the LAST block's cumulative hash (markers never enter the hash, so
+        // the unmarked body parses to the same hashes).
+        let scope = IndexScope {
+            principal_id: user.id,
+            virtual_model: ALIAS.into(),
+            tokenizer_version: TOK_VER.into(),
+        };
+        let hash = parse_chat_completions(
+            &serde_json::to_vec(&body_unmarked()).unwrap(),
+            &all_tiers(),
+            &TelemetryPolicy::default(),
+        )
+        .unwrap()
+        .cumulative_hashes[1]
+            .clone();
+        let idx = PostgresIndex::new(pool.clone(), 1);
+        let mut committed = false;
+        for _ in 0..100 {
+            if !idx.lookup(&scope, std::slice::from_ref(&hash)).await.unwrap().is_empty() {
+                committed = true;
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(committed, "the query-param write should commit after a 2xx");
+
+        let r2 = server
+            .post("/v1/chat/completions")
+            .add_query_param("cacheBreakpoint", "lastUserMessage")
+            .add_header("authorization", format!("Bearer {}", key.secret))
+            .json(&body_unmarked())
+            .await;
+        let v2: serde_json::Value = r2.json();
+        assert_eq!(v2["usage"]["cache_read_input_tokens"], 1510, "second request reads the prefix");
+        assert_eq!(v2["usage"]["cache_creation_input_tokens"], 0);
+    }
+
+    /// Upstream stand-in that echoes what it received (URI query + whether the body still carried
+    /// any `cache_control`), so strip behavior is assertable end-to-end.
+    async fn mock_upstream_echoing(req: Request) -> Json<serde_json::Value> {
+        let (req_parts, body) = req.into_parts();
+        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        let body_has_cache_control = String::from_utf8_lossy(&bytes).contains("cache_control");
+        Json(serde_json::json!({
+            "id": "chatcmpl-1", "object": "chat.completion",
+            "choices": [{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+            "echo": {"query": req_parts.uri.query(), "body_has_cache_control": body_has_cache_control}
+        }))
+    }
+
+    #[sqlx::test]
+    async fn query_param_stripped_before_upstream_others_preserved(pool: PgPool) {
+        // Neither the param (onwards forwards path_and_query verbatim) nor the injected marker
+        // may leak upstream; unrelated query params must survive.
+        let classifier = Classifier::new(
+            PrincipalResolver::new(pool.clone()),
+            ModelConfigResolver::new(pool.clone()),
+            TokenizerClient::new("http://127.0.0.1:1"),
+            Arc::new(PostgresIndex::new(pool.clone(), 1)),
+            all_tiers(),
+            TelemetryPolicy::default(),
+            false,
+        );
+        let app = Router::new()
+            .route("/v1/chat/completions", post(mock_upstream_echoing))
+            .layer(from_fn_with_state(
+                CacheLayerState::new(classifier, usize::MAX, Duration::from_secs(5)),
+                cache_middleware,
+            ));
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        let r = server
+            .post("/v1/chat/completions")
+            .add_query_param("foo", "bar")
+            .add_query_param("cacheBreakpoint", "lastUserMessage")
+            .json(&body_unmarked())
+            .await;
+        r.assert_status_ok();
+        let v: serde_json::Value = r.json();
+        assert_eq!(v["echo"]["query"], "foo=bar", "param stripped, others preserved");
+        assert_eq!(v["echo"]["body_has_cache_control"], false, "injected marker stripped from the body");
+    }
+
+    #[sqlx::test]
+    async fn query_param_invalid_value_rejected_400(pool: PgPool) {
+        // Strict: a typo'd value is a 400 up front, never a silent no-cache.
+        let classifier = Classifier::new(
+            PrincipalResolver::new(pool.clone()),
+            ModelConfigResolver::new(pool.clone()),
+            TokenizerClient::new("http://127.0.0.1:1"),
+            Arc::new(PostgresIndex::new(pool.clone(), 1)),
+            all_tiers(),
+            TelemetryPolicy::default(),
+            false,
+        );
+        let app = Router::new()
+            .route("/v1/chat/completions", post(mock_upstream)) // must NOT be reached
+            .layer(from_fn_with_state(
+                CacheLayerState::new(classifier, usize::MAX, Duration::from_secs(5)),
+                cache_middleware,
+            ));
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        let r = server
+            .post("/v1/chat/completions")
+            .add_query_param("cacheBreakpoint", "lastusermessage")
+            .json(&body_unmarked())
+            .await;
+        r.assert_status(StatusCode::BAD_REQUEST);
+        let v: serde_json::Value = r.json();
+        assert_eq!(v["error"]["code"], "invalid_cache_breakpoint");
+        assert_eq!(v["error"]["param"], "cacheBreakpoint");
+        let msg = v["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("lastusermessage"), "names the rejected value: {msg}");
+        assert!(msg.contains("lastUserMessage"), "names the supported value: {msg}");
+    }
+
+    #[sqlx::test]
+    async fn query_param_composes_with_explicit_markers(pool: PgPool) {
+        let classifier = Classifier::new(
+            PrincipalResolver::new(pool.clone()),
+            ModelConfigResolver::new(pool.clone()),
+            TokenizerClient::new("http://127.0.0.1:1"),
+            Arc::new(PostgresIndex::new(pool.clone(), 1)),
+            all_tiers(),
+            TelemetryPolicy::default(),
+            false,
+        );
+        let app = Router::new()
+            .route("/v1/chat/completions", post(mock_upstream_echoing))
+            .layer(from_fn_with_state(
+                CacheLayerState::new(classifier, usize::MAX, Duration::from_secs(5)),
+                cache_middleware,
+            ));
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        // An explicit 5m marker on the LAST block conflicts with the injected 1h automatic
+        // marker → the existing automatic-caching 400, exactly as if the client had sent the
+        // top-level field itself.
+        let conflicting = serde_json::json!({
+            "model": ALIAS,
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "q", "cache_control": {"type": "ephemeral", "ttl": "5m"}}
+            ]}]
+        });
+        let r = server
+            .post("/v1/chat/completions")
+            .add_query_param("cacheBreakpoint", "lastUserMessage")
+            .json(&conflicting)
+            .await;
+        r.assert_status(StatusCode::BAD_REQUEST);
+        let v: serde_json::Value = r.json();
+        assert_eq!(v["error"]["code"], "invalid_cache_control");
+        assert!(v["error"]["message"].as_str().unwrap().contains("conflicts"));
+
+        // But a body that EXPLICITLY opted in at the top level wins over the param: top-level 5m
+        // + explicit 5m on the last block is the same-ttl no-op → 200. (If the param's 1h had
+        // overwritten the body field, this would be the conflict 400 above.)
+        let body_wins = serde_json::json!({
+            "model": ALIAS,
+            "cache_control": {"type": "ephemeral", "ttl": "5m"},
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "q", "cache_control": {"type": "ephemeral", "ttl": "5m"}}
+            ]}]
+        });
+        let r = server
+            .post("/v1/chat/completions")
+            .add_query_param("cacheBreakpoint", "lastUserMessage")
+            .json(&body_wins)
+            .await;
+        r.assert_status_ok();
+
+        // An earlier (non-last-block) explicit marker simply composes: system layer + moving
+        // frontier, two breakpoints, no error.
+        let composing = serde_json::json!({
+            "model": ALIAS,
+            "messages": [
+                {"role": "system", "content": [
+                    {"type": "text", "text": "sys", "cache_control": {"type": "ephemeral", "ttl": "1h"}}
+                ]},
+                {"role": "user", "content": "q"}
+            ]
+        });
+        let r = server
+            .post("/v1/chat/completions")
+            .add_query_param("cacheBreakpoint", "lastUserMessage")
+            .json(&composing)
+            .await;
+        r.assert_status_ok();
+    }
+
+    #[sqlx::test]
+    async fn query_param_streaming_injects_terminal_frame(pool: PgPool) {
+        // Streaming + param: the deferred classify path sees the injected marker and edits the
+        // terminal usage frame, same as body-field automatic caching.
+        let user = create_test_user(&pool, Role::StandardUser).await;
+        let key = create_test_api_key_for_user(&pool, user.id).await;
+        let endpoint = create_test_endpoint(&pool, "ep", user.id).await;
+        let id = create_test_model(&pool, "m", ALIAS, endpoint, user.id).await;
+        sqlx::query!(
+            r#"INSERT INTO model_cache_tariffs
+                 (deployed_model_id, write_multiplier_5m, write_multiplier_1h, write_multiplier_24h, min_prefix_tokens)
+               VALUES ($1, 1.25, 2.0, 2.5, 1024)"#,
+            id
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let tok = MockServer::start().await;
+        mount_tokenizer_two_segments(&tok).await;
+
+        let classifier = Classifier::new(
+            PrincipalResolver::new(pool.clone()),
+            ModelConfigResolver::new(pool.clone()),
+            TokenizerClient::new(tok.uri()),
+            Arc::new(PostgresIndex::new(pool.clone(), 1)),
+            all_tiers(),
+            TelemetryPolicy::default(),
+            false,
+        );
+        let app = Router::new()
+            .route("/v1/chat/completions", post(mock_upstream_streaming))
+            .layer(from_fn_with_state(
+                CacheLayerState::new(classifier, usize::MAX, Duration::from_secs(5)),
+                cache_middleware,
+            ));
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        let mut body = body_unmarked();
+        body["stream"] = serde_json::json!(true);
+        let r = server
+            .post("/v1/chat/completions")
+            .add_query_param("cacheBreakpoint", "lastUserMessage")
+            .add_header("authorization", format!("Bearer {}", key.secret))
+            .json(&body)
+            .await;
+        r.assert_status_ok();
+        let t = r.text();
+        assert!(t.contains("\"cache_creation_input_tokens\":1510"), "creation injected: {t}");
         assert!(t.contains("data: [DONE]"), "DONE preserved: {t}");
     }
 }

--- a/dwctl/src/prompt_cache/metrics.rs
+++ b/dwctl/src/prompt_cache/metrics.rs
@@ -197,3 +197,14 @@ pub fn record_body_read_failed() {
 pub fn record_markers_rejected(reason: &'static str) {
     counter!("dwctl_cache_markers_rejected_total", "reason" => reason).increment(1);
 }
+
+/// A `cacheBreakpoint` query param was seen on a cacheable request (see `super::query` — the
+/// out-of-band form of the top-level automatic-caching marker). `outcome` ∈ `applied` (marker
+/// injected into the body) | `body_field_wins` (body already had a non-null top-level
+/// `cache_control`; explicit wins) | `invalid` (unrecognized value → 400) | `not_json` /
+/// `not_an_object` (nowhere to inject; onwards rejects the body downstream) |
+/// `reserialize_failed` (defensive: forwarded un-injected). Adoption/rollout signal for the
+/// param, distinct from `marker_requests` which counts the injected marker as body adoption.
+pub fn record_query_breakpoint(outcome: &'static str) {
+    counter!("dwctl_cache_query_breakpoint_total", "outcome" => outcome).increment(1);
+}

--- a/dwctl/src/prompt_cache/mod.rs
+++ b/dwctl/src/prompt_cache/mod.rs
@@ -19,6 +19,7 @@ pub mod model_config;
 pub mod parse;
 pub mod postgres;
 pub mod principal;
+pub mod query;
 pub mod sse;
 pub mod stats;
 pub mod tokenizer;

--- a/dwctl/src/prompt_cache/parse.rs
+++ b/dwctl/src/prompt_cache/parse.rs
@@ -1747,4 +1747,188 @@ mod tests {
         // turn2's own breakpoint has moved forward to its last block.
         assert_eq!(turn2.breakpoints[0].block_index, 3);
     }
+
+    #[test]
+    fn automatic_marker_lands_on_trailing_tool_call() {
+        // A request ending in an assistant tool-call turn: the LAST tool_call is the last block,
+        // so that's where automatic caching marks — the whole request (text + both calls) is the
+        // cached prefix.
+        let p = parse(serde_json::json!({
+            "cache_control": {"type": "ephemeral"},
+            "messages": [
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": [{"type": "text", "text": "calling"}], "tool_calls": [
+                    {"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}},
+                    {"id": "c2", "type": "function", "function": {"name": "g", "arguments": "{}"}}
+                ]}
+            ]
+        }));
+        assert_eq!(p.blocks.len(), 4, "user + assistant text + 2 tool_calls");
+        assert_eq!(p.breakpoints.len(), 1);
+        assert_eq!(p.breakpoints[0].block_index, 3, "the LAST tool_call");
+        assert_eq!(
+            p.breakpoints[0].prefix,
+            PrefixSpec {
+                tools_kept: 0,
+                full_messages: 2,
+                partial: None
+            },
+            "the prefix is both messages whole"
+        );
+    }
+
+    #[test]
+    fn automatic_marker_lands_on_trailing_tool_result() {
+        // A request ending with a tool result (the shape mid tool-loop, where the "last user
+        // message" naming is loosest): automatic marks the tool block — a larger prefix than the
+        // literal last user message, which is the right cache boundary.
+        let p = parse(serde_json::json!({
+            "cache_control": {"type": "ephemeral"},
+            "messages": [
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": null, "tool_calls": [
+                    {"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+                ]},
+                {"role": "tool", "tool_call_id": "c1", "content": "tool output"}
+            ]
+        }));
+        assert_eq!(p.blocks.len(), 3, "user + tool_call + tool result");
+        assert_eq!(p.blocks[2].role, "tool");
+        assert_eq!(p.breakpoints[0].block_index, 2);
+        assert_eq!(p.breakpoints[0].prefix.full_messages, 3);
+    }
+
+    #[test]
+    fn automatic_marker_on_trailing_image_block() {
+        // Image last: the image block is a real block (it participates in the prefix hash via its
+        // URL/base64 bytes) with empty write-side text — the marker lands on it, keeping the cache
+        // chain alive across image turns. Image tokens themselves are never discounted (they fall
+        // into the uncached tail; "image-token caching is deferred" at the top of this module).
+        let p = parse(serde_json::json!({
+            "cache_control": {"type": "ephemeral"},
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "text", "text": "what is this?"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+                ]}
+            ]
+        }));
+        assert_eq!(p.blocks.len(), 2);
+        assert_eq!(p.blocks[1].text, "", "image blocks carry no write-side text");
+        assert_eq!(p.breakpoints[0].block_index, 1, "marker on the image block");
+        // Same image, different encoding bytes → different prefix (the URL string is the content).
+        let other = parse(serde_json::json!({
+            "cache_control": {"type": "ephemeral"},
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "text", "text": "what is this?"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,BBBB"}}
+                ]}
+            ]
+        }));
+        assert_ne!(p.cumulative_hashes[1], other.cumulative_hashes[1]);
+    }
+
+    #[test]
+    fn automatic_with_trailing_blockless_message_marks_last_real_block() {
+        // KNOWN SKEW, pinned: a trailing message that contributes no blocks (null/absent content,
+        // no tool_calls) leaves the automatic marker on the LAST REAL block — but the breakpoint's
+        // prefix still counts ALL messages, so exact counting includes the phantom message's
+        // template scaffolding (a few tokens) in the stored prefix count while the hash boundary
+        // sits earlier. Bounded: at worst a few tokens shift between the creation/uncached buckets
+        // this turn and inflate the read by the same next turn; the billing caps floor it at zero.
+        let p = parse(serde_json::json!({
+            "cache_control": {"type": "ephemeral"},
+            "messages": [
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": null}
+            ]
+        }));
+        assert_eq!(p.blocks.len(), 1, "the null-content assistant adds no block");
+        assert_eq!(p.breakpoints[0].block_index, 0, "marker on the last REAL block");
+        assert_eq!(p.breakpoints[0].prefix.full_messages, 2, "prefix spec counts the phantom message");
+
+        // Same for a trailing empty content array.
+        let p = parse(serde_json::json!({
+            "cache_control": {"type": "ephemeral"},
+            "messages": [
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": []}
+            ]
+        }));
+        assert_eq!(p.blocks.len(), 1);
+        assert_eq!(p.breakpoints[0].block_index, 0);
+
+        // An empty-STRING content is a real (empty text) block, not the blockless shape.
+        let p = parse(serde_json::json!({
+            "cache_control": {"type": "ephemeral"},
+            "messages": [
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": ""}
+            ]
+        }));
+        assert_eq!(p.blocks.len(), 2, "empty-string prefill is a block");
+        assert_eq!(p.breakpoints[0].block_index, 1);
+    }
+
+    #[test]
+    fn automatic_with_telemetry_last_block_marks_prior_block() {
+        // Strip mode with a trailing telemetry-only system message: the telemetry block is
+        // excluded from the cache view, so automatic marks the last REAL block — same prefix-spec
+        // family as the blockless case above (full_messages counts the telemetry-only message; in
+        // strip mode the forwarded body loses the block, so the render view matches what's sent).
+        let p = parse_with(
+            serde_json::json!({
+                "cache_control": {"type": "ephemeral"},
+                "messages": [
+                    {"role": "user", "content": "q"},
+                    {"role": "system", "content": [
+                        {"type": "text", "text": "x-anthropic-billing-header: cch=zzz"}
+                    ]}
+                ]
+            }),
+            &telemetry(),
+        );
+        assert_eq!(p.blocks.len(), 1, "telemetry block excluded from the cache view");
+        assert_eq!(p.breakpoints[0].block_index, 0);
+    }
+
+    #[test]
+    fn automatic_tool_loop_growth_reads_prior_turn() {
+        // The growing-conversation property through a TOOL loop (not just plain turns): turn 2
+        // appends the assistant tool-call, the tool result, and a new user message; its cumulative
+        // hash at turn 1's breakpoint block is unchanged, so turn 2 reads what turn 1 wrote.
+        let turn1 = parse(serde_json::json!({
+            "cache_control": {"type": "ephemeral"},
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "q"}
+            ]
+        }));
+        let turn2 = parse(serde_json::json!({
+            "cache_control": {"type": "ephemeral"},
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": null, "tool_calls": [
+                    {"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+                ]},
+                {"role": "tool", "tool_call_id": "c1", "content": "result"},
+                {"role": "user", "content": "next"}
+            ]
+        }));
+        assert_eq!(turn1.breakpoints[0].block_index, 1);
+        assert_eq!(
+            turn1.cumulative_hashes[1], turn2.cumulative_hashes[1],
+            "turn 2 reads turn 1's write"
+        );
+        assert_eq!(turn2.blocks.len(), 5, "sys + user + tool_call + tool + user");
+        assert_eq!(turn2.breakpoints[0].block_index, 4, "marker moved to the new frontier");
+        // Well within the 20-block walk-back window: 3 new blocks per tool-loop turn.
+        let candidates = turn2.read_candidates(&turn2.breakpoints[0]);
+        assert!(
+            candidates.contains(&turn1.cumulative_hashes[1]),
+            "prior write reachable by walk-back"
+        );
+    }
 }

--- a/dwctl/src/prompt_cache/query.rs
+++ b/dwctl/src/prompt_cache/query.rs
@@ -8,8 +8,10 @@
 //! stripping all see exactly what they'd see had the client sent the field itself — one code path.
 //!
 //! Rules:
-//! - The param name and values are matched byte-exact (they're unreserved ASCII, so
-//!   percent-encoding never produces a different byte sequence for them).
+//! - The param name and values are matched byte-exact — no percent-decoding is performed, so
+//!   encoded forms (e.g. `last%55serMessage`) are treated as distinct and therefore unsupported.
+//!   No real client percent-encodes unreserved ASCII unprompted; an encoded value gets the
+//!   strict 400 below, an encoded param NAME is simply an unknown (ignored) param.
 //! - An unrecognized value is a 400 ([`layer`](super::layer) builds the response): a typo must
 //!   not silently disable caching while the caller believes it's on.
 //! - A non-null top-level `cache_control` already in the body wins and the param is ignored —

--- a/dwctl/src/prompt_cache/query.rs
+++ b/dwctl/src/prompt_cache/query.rs
@@ -1,0 +1,204 @@
+//! The `cacheBreakpoint` query parameter — automatic caching for clients that can't touch the body.
+//!
+//! Some integrators (proxy layers forwarding their own customers' OpenAI-shaped traffic) can't
+//! inject fields into request bodies, so they can't opt into automatic caching via the top-level
+//! `cache_control` marker. `?cacheBreakpoint=lastUserMessage` on `/chat/completions` is the
+//! out-of-band equivalent: the cache layer translates it into the top-level marker (1h tier)
+//! before anything else looks at the body, so validation, classification, and outbound marker
+//! stripping all see exactly what they'd see had the client sent the field itself — one code path.
+//!
+//! Rules:
+//! - The param name and values are matched byte-exact (they're unreserved ASCII, so
+//!   percent-encoding never produces a different byte sequence for them).
+//! - An unrecognized value is a 400 ([`layer`](super::layer) builds the response): a typo must
+//!   not silently disable caching while the caller believes it's on.
+//! - A non-null top-level `cache_control` already in the body wins and the param is ignored —
+//!   an end client that explicitly opted in *through* a param-appending proxy keeps its explicit
+//!   behavior. (A `null` body field is "no marker", per `parse`, so the param applies.)
+//! - The param is stripped from the forwarded URI: onwards forwards `path_and_query` verbatim
+//!   to providers, and the param must not leak upstream.
+//! - Value → tier: `lastUserMessage` → `1h`. The tier is explicit in the injected marker (not
+//!   the policy default) per the product decision; a deployment that disables the 1h tier will
+//!   reject param-carrying requests at marker validation, like any other 1h marker.
+//!
+//! Requests on non-cacheable routes (e.g. `/v1/embeddings`) bypass the cache layer entirely, so
+//! the param passes through to the provider there — harmless (OpenAI-compatible servers ignore
+//! unknown query params), but only `/chat/completions` honours it.
+
+use axum::http::Uri;
+use axum::http::uri::PathAndQuery;
+use serde_json::{Value, json};
+
+/// The query parameter name, on `/chat/completions` only.
+pub const CACHE_BREAKPOINT_PARAM: &str = "cacheBreakpoint";
+
+/// The one supported value: mark the last cacheable block of the request (Anthropic automatic-
+/// caching semantics — for turn-based chat that's the latest user message; for a request ending
+/// in tool results it's the last tool block, i.e. a strictly larger prefix).
+const LAST_USER_MESSAGE: &str = "lastUserMessage";
+
+/// The marker injected for [`LAST_USER_MESSAGE`]. Explicit `1h` tier (not the policy default).
+fn last_user_message_marker() -> Value {
+    json!({"type": "ephemeral", "ttl": "1h"})
+}
+
+/// The param was present but its value isn't supported (the caller turns this into a 400).
+#[derive(Debug, PartialEq, Eq)]
+pub struct InvalidBreakpointValue(pub String);
+
+/// Extract the `cacheBreakpoint` marker from a raw query string. `Ok(None)` when the param is
+/// absent; `Ok(Some(marker))` for a supported value; `Err` otherwise (including an empty or
+/// missing value — strictness is the point). First occurrence wins if duplicated.
+pub fn breakpoint_marker(query: Option<&str>) -> Result<Option<Value>, InvalidBreakpointValue> {
+    let Some(query) = query else { return Ok(None) };
+    for pair in query.split('&') {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        if key != CACHE_BREAKPOINT_PARAM {
+            continue;
+        }
+        return match value {
+            LAST_USER_MESSAGE => Ok(Some(last_user_message_marker())),
+            other => Err(InvalidBreakpointValue(other.to_string())),
+        };
+    }
+    Ok(None)
+}
+
+/// What [`inject_marker`] did with the body.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Inject {
+    /// The marker was inserted as the body's top-level `cache_control`.
+    Applied,
+    /// The body already carries a non-null top-level `cache_control` — explicit wins, param ignored.
+    BodyFieldWins,
+    /// The body isn't a JSON object (onwards will reject it downstream); nothing to inject into.
+    NotAnObject,
+}
+
+/// Insert the marker as the body's top-level `cache_control`, unless an explicit non-null one is
+/// already there. An explicit `null` is "no marker" (matching `parse`) and is overwritten.
+pub fn inject_marker(body: &mut Value, marker: Value) -> Inject {
+    let Some(obj) = body.as_object_mut() else {
+        return Inject::NotAnObject;
+    };
+    match obj.get("cache_control") {
+        Some(cc) if !cc.is_null() => Inject::BodyFieldWins,
+        _ => {
+            obj.insert("cache_control".into(), marker);
+            Inject::Applied
+        }
+    }
+}
+
+/// Remove every `cacheBreakpoint` pair from the URI's query (other params are preserved in
+/// order; the `?` is dropped entirely if nothing remains). Must run before forwarding: onwards
+/// sends `path_and_query` verbatim upstream. Returns the URI unchanged when the param is absent.
+pub fn strip_param(uri: &Uri) -> Uri {
+    fn param_key(pair: &str) -> &str {
+        pair.split_once('=').map(|(k, _)| k).unwrap_or(pair)
+    }
+    let Some(query) = uri.query() else { return uri.clone() };
+    if !query.split('&').any(|p| param_key(p) == CACHE_BREAKPOINT_PARAM) {
+        return uri.clone();
+    }
+    let kept: Vec<&str> = query.split('&').filter(|p| param_key(p) != CACHE_BREAKPOINT_PARAM).collect();
+    let path_and_query = if kept.is_empty() {
+        uri.path().to_string()
+    } else {
+        format!("{}?{}", uri.path(), kept.join("&"))
+    };
+    // The path and the kept pairs are substrings of an already-valid URI, so this re-parse can't
+    // fail; if it somehow does, keep the original URI (an unknown upstream query param) rather
+    // than failing the request.
+    let mut parts = uri.clone().into_parts();
+    match path_and_query.parse::<PathAndQuery>() {
+        Ok(pq) => parts.path_and_query = Some(pq),
+        Err(_) => return uri.clone(),
+    }
+    Uri::from_parts(parts).unwrap_or_else(|_| uri.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_param_is_none() {
+        assert_eq!(breakpoint_marker(None), Ok(None));
+        assert_eq!(breakpoint_marker(Some("")), Ok(None));
+        assert_eq!(breakpoint_marker(Some("foo=bar&stream=true")), Ok(None));
+    }
+
+    #[test]
+    fn supported_value_yields_1h_marker() {
+        let marker = breakpoint_marker(Some("cacheBreakpoint=lastUserMessage")).unwrap().unwrap();
+        assert_eq!(marker, json!({"type": "ephemeral", "ttl": "1h"}));
+        // Position and neighbours don't matter.
+        let marker = breakpoint_marker(Some("a=b&cacheBreakpoint=lastUserMessage&c=d")).unwrap().unwrap();
+        assert_eq!(marker, json!({"type": "ephemeral", "ttl": "1h"}));
+    }
+
+    #[test]
+    fn unknown_or_empty_value_is_invalid() {
+        // Strict: a typo must be a 400, not a silent no-cache.
+        assert_eq!(
+            breakpoint_marker(Some("cacheBreakpoint=lastusermessage")),
+            Err(InvalidBreakpointValue("lastusermessage".into()))
+        );
+        assert_eq!(breakpoint_marker(Some("cacheBreakpoint=")), Err(InvalidBreakpointValue("".into())));
+        assert_eq!(breakpoint_marker(Some("cacheBreakpoint")), Err(InvalidBreakpointValue("".into())));
+    }
+
+    #[test]
+    fn first_occurrence_wins_and_name_is_case_sensitive() {
+        assert_eq!(
+            breakpoint_marker(Some("cacheBreakpoint=bogus&cacheBreakpoint=lastUserMessage")),
+            Err(InvalidBreakpointValue("bogus".into()))
+        );
+        // Different casing is a different (ignored) param, per query-string convention.
+        assert_eq!(breakpoint_marker(Some("cachebreakpoint=lastUserMessage")), Ok(None));
+    }
+
+    #[test]
+    fn inject_applies_and_explicit_body_field_wins() {
+        let mut body = json!({"model": "m", "messages": []});
+        assert_eq!(inject_marker(&mut body, last_user_message_marker()), Inject::Applied);
+        assert_eq!(body["cache_control"], json!({"type": "ephemeral", "ttl": "1h"}));
+
+        // Non-null body field wins, untouched.
+        let mut body = json!({"model": "m", "cache_control": {"type": "ephemeral", "ttl": "5m"}});
+        assert_eq!(inject_marker(&mut body, last_user_message_marker()), Inject::BodyFieldWins);
+        assert_eq!(body["cache_control"]["ttl"], "5m");
+
+        // A null body field is "no marker" (parse semantics) → the param applies.
+        let mut body = json!({"model": "m", "cache_control": null});
+        assert_eq!(inject_marker(&mut body, last_user_message_marker()), Inject::Applied);
+        assert_eq!(body["cache_control"]["ttl"], "1h");
+
+        // Non-object bodies have nowhere to inject.
+        let mut body = json!(["not", "an", "object"]);
+        assert_eq!(inject_marker(&mut body, last_user_message_marker()), Inject::NotAnObject);
+    }
+
+    #[test]
+    fn strip_removes_param_and_preserves_others() {
+        let uri: Uri = "/v1/chat/completions?foo=bar&cacheBreakpoint=lastUserMessage&baz=1"
+            .parse()
+            .unwrap();
+        assert_eq!(strip_param(&uri).to_string(), "/v1/chat/completions?foo=bar&baz=1");
+
+        // Only the param → the whole query goes (no trailing '?').
+        let uri: Uri = "/v1/chat/completions?cacheBreakpoint=lastUserMessage".parse().unwrap();
+        assert_eq!(strip_param(&uri).to_string(), "/v1/chat/completions");
+
+        // Duplicates are all removed.
+        let uri: Uri = "/v1/chat/completions?cacheBreakpoint=a&x=y&cacheBreakpoint=b".parse().unwrap();
+        assert_eq!(strip_param(&uri).to_string(), "/v1/chat/completions?x=y");
+
+        // Absent → unchanged (same instance semantics, incl. no query at all).
+        let uri: Uri = "/v1/chat/completions?foo=bar".parse().unwrap();
+        assert_eq!(strip_param(&uri).to_string(), "/v1/chat/completions?foo=bar");
+        let uri: Uri = "/v1/chat/completions".parse().unwrap();
+        assert_eq!(strip_param(&uri).to_string(), "/v1/chat/completions");
+    }
+}


### PR DESCRIPTION
?cacheBreakpoint=lastUserMessage on /chat/completions injects the top-level automatic-caching cache_control marker (1h tier) into the body before the cache layer's validation/classify/strip pipeline, for integrators that can't manipulate request bodies (proxy layers forwarding OpenAI-shaped traffic). One extra serialize on param-carrying requests only; the param is stripped from the forwarded URI (onwards sends path_and_query verbatim upstream).

An explicit non-null top-level cache_control in the body wins over the param; unrecognized values are a strict 400 (invalid_cache_breakpoint) so a typo never silently disables caching. New dwctl_cache_query_breakpoint_total metric tracks adoption/outcomes.

Also pins automatic-caching edge cases with tests: trailing tool calls/tool results/images, block-less trailing messages (known small counting skew, documented), telemetry-last blocks, and tool-loop growth read chains.