### PR TITLE
fix(onwards): retry slow empty SSE streams

### DIFF
--- a/onwards/src/handlers.rs
+++ b/onwards/src/handlers.rs
@@ -1062,11 +1062,23 @@ pub async fn target_message_handler<T: HttpClient>(
                 // one. Holding the `200` headers until the first frame costs
                 // nothing in time-to-first-*token* (onwards must receive it to
                 // forward it anyway). The whole peek is bounded by a short fixed
-                // budget — NOT the request timeout, which governs header receipt —
-                // so a `200`-then-idle stream isn't withheld from the client; on
-                // timeout we forward whatever we have, unmodified (no retry).
+                // budget — NOT the request timeout, which governs header receipt.
+                // If that budget expires, keep control for a bounded second window
+                // until the next decisive event: terminal empty is retryable, while
+                // the first real content frame is reattached and forwarded without
+                // retry. If the upstream remains idle beyond that, forward the
+                // still-open stream instead of withholding headers indefinitely.
                 use futures_util::StreamExt;
+                #[cfg(not(test))]
                 const SSE_PEEK_BUDGET: std::time::Duration = std::time::Duration::from_secs(2);
+                #[cfg(test)]
+                const SSE_PEEK_BUDGET: std::time::Duration = std::time::Duration::from_millis(10);
+                #[cfg(not(test))]
+                const SSE_DECISIVE_WAIT_BUDGET: std::time::Duration =
+                    std::time::Duration::from_secs(30);
+                #[cfg(test)]
+                const SSE_DECISIVE_WAIT_BUDGET: std::time::Duration =
+                    std::time::Duration::from_millis(50);
                 const SSE_PEEK_MAX_EVENTS: usize = 4;
 
                 let (parts, body) = response.into_parts();
@@ -1110,9 +1122,44 @@ pub async fn target_message_handler<T: HttpClient>(
                         }
                     }
                 };
-                let timed_out = tokio::time::timeout(SSE_PEEK_BUDGET, peek).await.is_err();
-                if timed_out {
-                    debug!("Timed out peeking SSE lead frames; forwarding stream unmodified");
+                if tokio::time::timeout(SSE_PEEK_BUDGET, peek).await.is_err() {
+                    debug!("Timed out peeking SSE lead frames; waiting for first terminal frame");
+                    let decisive_wait = async {
+                        for _ in 0..SSE_PEEK_MAX_EVENTS {
+                            match events.next().await {
+                                Some(Ok(chunk)) => match classify_sse_event(&chunk) {
+                                    SseEventKind::Error(status) => {
+                                        embedded = Some(status);
+                                        peeked.push(Ok(chunk));
+                                        break;
+                                    }
+                                    SseEventKind::Data => {
+                                        saw_data = true;
+                                        peeked.push(Ok(chunk));
+                                        break;
+                                    }
+                                    SseEventKind::Comment => peeked.push(Ok(chunk)),
+                                },
+                                Some(Err(e)) => {
+                                    stream_ended = true;
+                                    peeked.push(Err(e));
+                                    break;
+                                }
+                                None => {
+                                    stream_ended = true;
+                                    break;
+                                }
+                            }
+                        };
+                    };
+                    if tokio::time::timeout(SSE_DECISIVE_WAIT_BUDGET, decisive_wait)
+                        .await
+                        .is_err()
+                    {
+                        debug!(
+                            "Timed out waiting for decisive SSE frame; forwarding stream unmodified"
+                        );
+                    }
                 }
                 // Forward the consumed frames followed by the remainder, so a clean
                 // (or slow) stream is intact; on a retry path below this `response`
@@ -1121,11 +1168,11 @@ pub async fn target_message_handler<T: HttpClient>(
                 response = Response::from_parts(parts, axum::body::Body::from_stream(rest));
                 if let Some(status) = embedded {
                     Scan2xx::Embedded(status)
-                } else if !timed_out && stream_ended && !saw_data {
+                } else if stream_ended && !saw_data {
                     // Stream closed/errored before any content frame: nothing was
-                    // forwarded, so retrying is safe. A *timeout* (stream still open,
-                    // just slow to first token) deliberately falls through to `Clean`
-                    // — that's the valid-but-slow case we must never retry.
+                    // forwarded, so retrying is safe. A valid-but-slow stream that
+                    // eventually produces content falls through to `Clean` with the
+                    // consumed frames reattached below.
                     Scan2xx::EmptyBody
                 } else {
                     Scan2xx::Clean

--- a/onwards/src/lib.rs
+++ b/onwards/src/lib.rs
@@ -721,6 +721,38 @@ pub mod test_utils {
             }
         }
 
+        pub fn new_delayed_streaming_sequence(
+            status: StatusCode,
+            responses: Vec<(std::time::Duration, Vec<String>)>,
+        ) -> Self {
+            let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            Self {
+                requests: Arc::new(Mutex::new(Vec::new())),
+                custom_headers: Arc::new(Mutex::new(Vec::new())),
+                response_builder: Arc::new(move || {
+                    use axum::body::Body;
+
+                    let idx = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    let (delay, chunks) = responses.get(idx).cloned().unwrap_or_default();
+
+                    let stream = async_stream::stream! {
+                        tokio::time::sleep(delay).await;
+                        for chunk in chunks {
+                            yield Ok::<_, std::io::Error>(chunk.into_bytes());
+                        }
+                    };
+
+                    axum::response::Response::builder()
+                        .status(status)
+                        .header("content-type", "text/event-stream")
+                        .header("cache-control", "no-cache")
+                        .header("connection", "keep-alive")
+                        .body(Body::from_stream(stream))
+                        .unwrap()
+                }),
+            }
+        }
+
         pub fn get_requests(&self) -> Vec<MockRequest> {
             self.requests.lock().unwrap().clone()
         }
@@ -1382,6 +1414,117 @@ mod tests {
             mock.get_requests().len(),
             2,
             "empty stream must trigger a retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_slow_streaming_empty_body_retries_then_succeeds() {
+        // Regression for a stream that stays idle past the SSE peek budget, then
+        // closes without any frames. It is still a terminal empty response and
+        // must not be forwarded as a bodyless 200.
+        let mock = MockHttpClient::new_delayed_streaming_sequence(
+            StatusCode::OK,
+            vec![
+                (std::time::Duration::from_millis(20), vec![]),
+                (
+                    std::time::Duration::ZERO,
+                    vec![OK_CONTENT_FRAME.to_string()],
+                ),
+            ],
+        );
+        let app_state =
+            AppState::with_client(fallback_targets("gpt-4", 2, vec![502]), mock.clone());
+        let server = TestServer::new(build_router(app_state)).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "gpt-4", "stream": true,
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), 200, "the retry's success is served");
+        assert!(
+            response.text().contains("hi"),
+            "client receives the healthy provider's content"
+        );
+        assert_eq!(
+            mock.get_requests().len(),
+            2,
+            "slow empty stream must trigger a retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_slow_streaming_content_is_not_retried() {
+        // A valid stream may be slow to first token. Once it produces data, the
+        // original stream must be forwarded intact without duplicate work.
+        let mock = MockHttpClient::new_delayed_streaming_sequence(
+            StatusCode::OK,
+            vec![(
+                std::time::Duration::from_millis(20),
+                vec![OK_CONTENT_FRAME.to_string()],
+            )],
+        );
+        let app_state =
+            AppState::with_client(fallback_targets("gpt-4", 2, vec![502]), mock.clone());
+        let server = TestServer::new(build_router(app_state)).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "gpt-4", "stream": true,
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), 200);
+        assert!(
+            response.text().contains("hi"),
+            "client receives the slow provider's content"
+        );
+        assert_eq!(
+            mock.get_requests().len(),
+            1,
+            "slow content must not trigger a retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_idle_stream_after_decisive_wait_is_forwarded_not_retried() {
+        // If an upstream opens an SSE response and then stays idle past both the
+        // initial peek and bounded decisive wait, the handler must not withhold
+        // response headers indefinitely. The still-open stream is forwarded and
+        // any later content is delivered from the original provider.
+        let mock = MockHttpClient::new_delayed_streaming_sequence(
+            StatusCode::OK,
+            vec![(
+                std::time::Duration::from_millis(75),
+                vec![OK_CONTENT_FRAME.to_string()],
+            )],
+        );
+        let app_state =
+            AppState::with_client(fallback_targets("gpt-4", 2, vec![502]), mock.clone());
+        let server = TestServer::new(build_router(app_state)).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "gpt-4", "stream": true,
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), 200);
+        assert!(
+            response.text().contains("hi"),
+            "client receives the original provider's delayed content"
+        );
+        assert_eq!(
+            mock.get_requests().len(),
+            1,
+            "idle-but-open stream must not retry before a terminal empty is observed"
         );
     }
 


### PR DESCRIPTION
## Problem

Onwards tries to detect anomalous streaming `200 OK` responses before forwarding them to the client. This includes the case where an upstream opens an SSE response but then terminates without sending any content frames. That path should be treated like a retryable upstream failure, because forwarding it gives the caller a successful status with an empty body.

The existing fast-empty case was covered, but a slow-empty stream could slip through. If the stream stayed idle past the SSE peek budget, the handler classified it as clean immediately. If that stream later closed without content, it was too late to retry because the handler had already returned the `200` response body to the client.

That is the bug this PR fixes: a stream can be both slow to first frame and ultimately empty. Timeout alone is not enough information to call it healthy.

## Fix

After the initial SSE peek budget expires, keep control for a bounded second window until the next decisive event:

- first real data frame: reattach the consumed frame and forward the stream without retry
- embedded error frame: handle it through the existing embedded-error retry path
- stream termination before data: classify as `EmptyBody` and retry as a synthetic upstream 502
- no event before the second wait expires: forward the still-open stream as clean so headers are not withheld indefinitely

This preserves the original protection against retrying valid slow streams while restoring the invariant that promptly terminal bodyless streaming `200`s should not reach the client.

## Tests

Added delayed streaming mock support and three regressions:

- slow stream that closes empty after the peek budget retries and returns fallback content
- slow stream that eventually emits content is forwarded once and is not retried
- idle-open stream past the bounded decisive wait is forwarded and not retried

I also confirmed the slow-empty test fails with the old `!timed_out` guard restored.

## Verification

- `cargo fmt -p onwards`
- `cargo test -p onwards streaming_empty -- --nocapture`
- `cargo test -p onwards test_idle_stream_after_decisive_wait_is_forwarded_not_retried -- --nocapture`
- `cargo test -p onwards test_slow_streaming_content_is_not_retried -- --nocapture`
- Earlier full run in the same workspace: `cargo test -p onwards` passed 480 unit tests and 12 doctests

## Production Probe

Ran bounded production streaming probes against `google/gemma-4-31B-it`. One burst produced slow first-token responses above the 2s peek budget, but no live empty-200 response was observed. The deterministic unit test covers the reported slow-then-empty failure mode directly.