### PR TITLE
fix(fusillade): give the memory gate an exit that can actually be reached

### DIFF
--- a/fusillade/src/daemon/config.rs
+++ b/fusillade/src/daemon/config.rs
@@ -149,11 +149,15 @@ pub struct DaemonConfig {
     /// vary by more than an order of magnitude between workloads, so no count is
     /// safe across all of them. This bounds the thing that actually kills the
     /// process, by measuring it rather than predicting it: above the mark the
-    /// daemon claims nothing, in-flight drains as
-    /// requests finish, and claiming resumes below
-    /// `memory_gate_low_fraction`. Nothing upstream signals local memory
-    /// pressure, so with `adaptive_concurrency` on this is the only control that
-    /// corresponds to running out of memory.
+    /// daemon claims nothing and in-flight drains as requests finish. Nothing
+    /// upstream signals local memory pressure, so with `adaptive_concurrency` on
+    /// this is the only control that corresponds to running out of memory.
+    ///
+    /// Claiming resumes on either of two conditions: usage falling below
+    /// `memory_gate_low_fraction`, or in-flight falling to
+    /// `memory_gate_release_in_flight_fraction` of what it was when the gate
+    /// engaged. The second exists because the first is not always reachable -
+    /// see that field for why.
     #[serde(default)]
     pub memory_gate_high_fraction: f64,
     /// Fraction of the memory limit below which claiming resumes. Must be above
@@ -173,7 +177,7 @@ pub struct DaemonConfig {
     /// the high mark, the reading pins at or above it, leaving no reachable low
     /// mark below and no useful one above. In-flight is the one quantity certain
     /// to fall once claiming stops, so it is what guarantees an exit.
-    #[serde(default = "default_memory_gate_release_in_flight_fraction")]
+    #[serde(default = "default_release_in_flight_fraction")]
     pub memory_gate_release_in_flight_fraction: f64,
     #[serde(skip, default = "default_model_escalations")]
     pub model_escalations: Arc<dashmap::DashMap<String, ModelEscalationConfig>>,
@@ -429,7 +433,7 @@ fn default_memory_gate_low_fraction() -> f64 {
 /// always recovers well before a full drain. If memory is still over the high
 /// mark when it resumes, the next cycle re-engages, so the cost of releasing too
 /// early is one claim batch.
-fn default_memory_gate_release_in_flight_fraction() -> f64 {
+fn default_release_in_flight_fraction() -> f64 {
     0.5
 }
 
@@ -508,8 +512,7 @@ impl Default for DaemonConfig {
             adaptive_cut_factor: default_adaptive_cut_factor(),
             memory_gate_high_fraction: 0.0,
             memory_gate_low_fraction: default_memory_gate_low_fraction(),
-            memory_gate_release_in_flight_fraction: default_memory_gate_release_in_flight_fraction(
-            ),
+            memory_gate_release_in_flight_fraction: default_release_in_flight_fraction(),
             model_escalations: default_model_escalations(),
             inject_deadline_priority: false,
             background_concurrency_limit: 0,

--- a/fusillade/src/daemon/config.rs
+++ b/fusillade/src/daemon/config.rs
@@ -163,6 +163,18 @@ pub struct DaemonConfig {
     /// claim cycle while usage sits on the boundary.
     #[serde(default = "default_memory_gate_low_fraction")]
     pub memory_gate_low_fraction: f64,
+    /// Fraction of the in-flight count at engagement that in-flight must fall
+    /// to before claiming resumes, whatever the memory reading says.
+    ///
+    /// The low mark alone cannot release the gate. Freed memory goes back to the
+    /// allocator rather than the OS, so the cgroup working set behaves as a
+    /// high-water mark: it does not fall when requests complete, and the
+    /// remaining in-flight work pushes it up. Since the gate engages by reaching
+    /// the high mark, the reading pins at or above it, leaving no reachable low
+    /// mark below and no useful one above. In-flight is the one quantity certain
+    /// to fall once claiming stops, so it is what guarantees an exit.
+    #[serde(default = "default_memory_gate_release_in_flight_fraction")]
+    pub memory_gate_release_in_flight_fraction: f64,
     #[serde(skip, default = "default_model_escalations")]
     pub model_escalations: Arc<dashmap::DashMap<String, ModelEscalationConfig>>,
     #[serde(default)]
@@ -412,6 +424,15 @@ fn default_memory_gate_low_fraction() -> f64 {
     0.65
 }
 
+/// Half the work in flight at engagement. Low enough that a genuinely loaded pod
+/// holds for a meaningful stretch rather than flapping, high enough that it
+/// always recovers well before a full drain. If memory is still over the high
+/// mark when it resumes, the next cycle re-engages, so the cost of releasing too
+/// early is one claim batch.
+fn default_memory_gate_release_in_flight_fraction() -> f64 {
+    0.5
+}
+
 fn default_adaptive_growth_factor() -> f64 {
     1.5
 }
@@ -487,6 +508,8 @@ impl Default for DaemonConfig {
             adaptive_cut_factor: default_adaptive_cut_factor(),
             memory_gate_high_fraction: 0.0,
             memory_gate_low_fraction: default_memory_gate_low_fraction(),
+            memory_gate_release_in_flight_fraction: default_memory_gate_release_in_flight_fraction(
+            ),
             model_escalations: default_model_escalations(),
             inject_deadline_priority: false,
             background_concurrency_limit: 0,

--- a/fusillade/src/daemon/memory_gate.rs
+++ b/fusillade/src/daemon/memory_gate.rs
@@ -15,6 +15,12 @@
 //!
 //! Two thresholds rather than one: without hysteresis the gate would sit on the
 //! boundary flipping every claim cycle.
+//!
+//! The low mark cannot be the only way out, though. Freed memory goes back to
+//! the allocator rather than to the OS, so the reading behaves as a high-water
+//! mark and does not fall when requests complete - which leaves no low mark that
+//! is both reachable and useful. Claiming therefore also resumes once enough of
+//! the work that was in flight at engagement has drained. See `should_block`.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
@@ -112,16 +118,30 @@ pub(super) struct MemoryGate {
     /// the per-pod ceiling, measured rather than assumed, and it is what a
     /// replica count should be derived from.
     peak_in_flight_at_gate: AtomicU64,
+    /// In-flight at the most recent engagement, and the fraction of it that
+    /// in-flight must fall to before claiming resumes regardless of the memory
+    /// reading. See `should_block` for why a memory-only release cannot work.
+    in_flight_when_engaged: AtomicU64,
+    release_in_flight_fraction: f64,
 }
 
 impl MemoryGate {
     /// Build a gate. Returns `None` when disabled (`high` of zero) or when the
     /// thresholds are not a usable pair, in which case claiming is never
     /// suppressed.
-    pub(super) fn new(high: f64, low: f64, source: Box<dyn MemorySource>) -> Option<Self> {
+    pub(super) fn new(
+        high: f64,
+        low: f64,
+        release_in_flight_fraction: f64,
+        source: Box<dyn MemorySource>,
+    ) -> Option<Self> {
         if high <= 0.0 || high > 1.0 || low <= 0.0 || low >= high {
             return None;
         }
+        // Out-of-range values would silently disable the in-flight release and
+        // reintroduce the deadlock, so clamp rather than reject: a bad number
+        // here should not take the gate's only reliable exit away.
+        let release_in_flight_fraction = release_in_flight_fraction.clamp(0.0, 1.0);
         Some(Self {
             source,
             high,
@@ -129,13 +149,35 @@ impl MemoryGate {
             engaged: AtomicBool::new(false),
             warned_unavailable: AtomicBool::new(false),
             peak_in_flight_at_gate: AtomicU64::new(0),
+            in_flight_when_engaged: AtomicU64::new(0),
+            release_in_flight_fraction,
         })
     }
 
     /// Whether claiming should be suppressed this cycle.
     ///
-    /// `in_flight` is recorded when the gate first engages so the ceiling can be
-    /// read off a dashboard; it does not affect the decision.
+    /// Engaging is decided purely on the memory reading: that is what the OOM
+    /// killer acts on, so being conservative there is correct.
+    ///
+    /// Releasing cannot be, and this is the subtle part. Freed memory returns to
+    /// the allocator rather than to the OS, so the cgroup working set is a
+    /// high-water mark rather than a level: completing a request does not lower
+    /// it. On a load rig, thousands of completions after the gate engaged
+    /// returned almost none of the memory they had taken, while the in-flight
+    /// requests that remained kept accumulating and pushed the reading *up*.
+    ///
+    /// That rules out fixing this by moving the low mark. The gate engages
+    /// because the reading hit `high`, and retention pins it there, so the cap
+    /// on the reading is at or above `high` by construction. Any low mark below
+    /// `high` is unreachable; any low mark above it releases immediately and
+    /// makes the gate a no-op. No valid value exists between them.
+    ///
+    /// So claiming also resumes once in-flight has fallen to
+    /// `release_in_flight_fraction` of what it was when the gate engaged.
+    /// In-flight is the one signal guaranteed to fall while claiming is
+    /// suppressed. If memory really is still high the next cycle re-engages, so
+    /// the worst case is admitting one claim batch, which bounds the overshoot
+    /// and degrades to a duty cycle instead of a stall.
     pub(super) fn should_block(&self, in_flight: usize) -> bool {
         let Some(reading) = self.source.read() else {
             if !self.warned_unavailable.swap(true, Ordering::Relaxed) {
@@ -152,8 +194,12 @@ impl MemoryGate {
 
         let was_engaged = self.engaged.load(Ordering::Relaxed);
         let engaged = if was_engaged {
-            // Stay engaged until usage falls back under the low mark.
-            used > self.low
+            let engaged_at = self.in_flight_when_engaged.load(Ordering::Relaxed);
+            let drained_enough = engaged_at == 0
+                || (in_flight as f64) < (engaged_at as f64) * self.release_in_flight_fraction;
+            // Either exit will do: usage back under the low mark, or enough of
+            // the work that was in flight at engagement has completed.
+            used > self.low && !drained_enough
         } else {
             used >= self.high
         };
@@ -163,6 +209,8 @@ impl MemoryGate {
         if engaged && !was_engaged {
             counter!("fusillade_memory_gate_engagements_total").increment(1);
             let in_flight = in_flight as u64;
+            self.in_flight_when_engaged
+                .store(in_flight, Ordering::Relaxed);
             self.peak_in_flight_at_gate
                 .fetch_max(in_flight, Ordering::Relaxed);
             gauge!("fusillade_in_flight_at_gate").set(in_flight as f64);
@@ -225,13 +273,13 @@ mod tests {
 
     #[test]
     fn stays_open_below_the_high_mark() {
-        let gate = MemoryGate::new(0.75, 0.65, FixedSource::new(vec![at(0.5)])).unwrap();
+        let gate = MemoryGate::new(0.75, 0.65, 0.0, FixedSource::new(vec![at(0.5)])).unwrap();
         assert!(!gate.should_block(100));
     }
 
     #[test]
     fn engages_at_the_high_mark() {
-        let gate = MemoryGate::new(0.75, 0.65, FixedSource::new(vec![at(0.8)])).unwrap();
+        let gate = MemoryGate::new(0.75, 0.65, 0.0, FixedSource::new(vec![at(0.8)])).unwrap();
         assert!(gate.should_block(100));
     }
 
@@ -242,6 +290,7 @@ mod tests {
         let gate = MemoryGate::new(
             0.75,
             0.65,
+            0.0,
             FixedSource::new(vec![at(0.8), at(0.7), at(0.7)]),
         )
         .unwrap();
@@ -257,6 +306,7 @@ mod tests {
         let gate = MemoryGate::new(
             0.75,
             0.65,
+            0.0,
             FixedSource::new(vec![at(0.8), at(0.6), at(0.6)]),
         )
         .unwrap();
@@ -264,11 +314,57 @@ mod tests {
         assert!(!gate.should_block(100), "released once under the low mark");
     }
 
+    /// The case the low mark cannot handle: usage stays pinned above it because
+    /// freed memory sits in the allocator rather than going back to the OS. Only
+    /// the in-flight fall gets the gate open again.
+    #[test]
+    fn releases_once_enough_in_flight_has_drained() {
+        let gate = MemoryGate::new(0.75, 0.65, 0.5, FixedSource::new(vec![at(0.9)])).unwrap();
+
+        assert!(gate.should_block(1000), "engages at the high mark");
+        assert!(
+            gate.should_block(600),
+            "still held: usage pinned high and only 40% drained"
+        );
+        assert!(
+            !gate.should_block(499),
+            "released once in-flight halved, despite usage never falling"
+        );
+    }
+
+    /// The fraction is a floor on how long the hold lasts, not a licence to
+    /// release early: a pod that is still saturated keeps claiming suppressed.
+    #[test]
+    fn does_not_release_while_in_flight_holds_up() {
+        let gate = MemoryGate::new(0.75, 0.65, 0.5, FixedSource::new(vec![at(0.9)])).unwrap();
+
+        assert!(gate.should_block(1000));
+        for still_in_flight in [999, 900, 700, 501] {
+            assert!(
+                gate.should_block(still_in_flight),
+                "held at {still_in_flight} in flight"
+            );
+        }
+    }
+
+    /// A zero fraction disables the in-flight exit, leaving the memory-only
+    /// behaviour the earlier tests describe.
+    #[test]
+    fn a_zero_fraction_leaves_only_the_memory_release() {
+        let gate = MemoryGate::new(0.75, 0.65, 0.0, FixedSource::new(vec![at(0.9)])).unwrap();
+
+        assert!(gate.should_block(1000));
+        assert!(
+            gate.should_block(1),
+            "no in-flight exit when the fraction is zero"
+        );
+    }
+
     /// A daemon outside a limited cgroup (local runs, tests) must not have its
     /// claiming suppressed by a source it cannot read.
     #[test]
     fn an_unreadable_source_never_blocks() {
-        let gate = MemoryGate::new(0.75, 0.65, Box::new(NoSource)).unwrap();
+        let gate = MemoryGate::new(0.75, 0.65, 0.0, Box::new(NoSource)).unwrap();
         assert!(!gate.should_block(100));
         assert!(!gate.should_block(100));
     }
@@ -276,17 +372,20 @@ mod tests {
     #[test]
     fn disabled_or_nonsensical_thresholds_produce_no_gate() {
         let src = || FixedSource::new(vec![at(0.9)]);
-        assert!(MemoryGate::new(0.0, 0.0, src()).is_none(), "zero disables");
         assert!(
-            MemoryGate::new(0.65, 0.75, src()).is_none(),
+            MemoryGate::new(0.0, 0.0, 0.0, src()).is_none(),
+            "zero disables"
+        );
+        assert!(
+            MemoryGate::new(0.65, 0.75, 0.0, src()).is_none(),
             "low above high"
         );
         assert!(
-            MemoryGate::new(0.75, 0.75, src()).is_none(),
+            MemoryGate::new(0.75, 0.75, 0.0, src()).is_none(),
             "equal marks flap"
         );
         assert!(
-            MemoryGate::new(1.5, 0.5, src()).is_none(),
+            MemoryGate::new(1.5, 0.5, 0.0, src()).is_none(),
             "high above the limit"
         );
     }
@@ -298,6 +397,7 @@ mod tests {
         let gate = MemoryGate::new(
             0.75,
             0.65,
+            0.0,
             FixedSource::new(vec![at(0.8), at(0.5), at(0.9)]),
         )
         .unwrap();
@@ -315,7 +415,7 @@ mod tests {
             working_set: 400,
             limit: 1000,
         };
-        let gate = MemoryGate::new(0.75, 0.65, FixedSource::new(vec![reading])).unwrap();
+        let gate = MemoryGate::new(0.75, 0.65, 0.0, FixedSource::new(vec![reading])).unwrap();
         assert!(!gate.should_block(100));
     }
 }

--- a/fusillade/src/daemon/memory_gate.rs
+++ b/fusillade/src/daemon/memory_gate.rs
@@ -195,8 +195,13 @@ impl MemoryGate {
         let was_engaged = self.engaged.load(Ordering::Relaxed);
         let engaged = if was_engaged {
             let engaged_at = self.in_flight_when_engaged.load(Ordering::Relaxed);
-            let drained_enough = engaged_at == 0
-                || (in_flight as f64) < (engaged_at as f64) * self.release_in_flight_fraction;
+            // A zero fraction disables this exit, and so does engaging with
+            // nothing in flight: without a level to have fallen from there is no
+            // drain to measure, so fall back to the memory reading rather than
+            // treating an unknown as satisfied.
+            let drained_enough = self.release_in_flight_fraction > 0.0
+                && engaged_at > 0
+                && (in_flight as f64) <= (engaged_at as f64) * self.release_in_flight_fraction;
             // Either exit will do: usage back under the low mark, or enough of
             // the work that was in flight at engagement has completed.
             used > self.low && !drained_enough
@@ -357,6 +362,33 @@ mod tests {
         assert!(
             gate.should_block(1),
             "no in-flight exit when the fraction is zero"
+        );
+        assert!(
+            gate.should_block(0),
+            "not even at zero in flight: the fraction is what disables it"
+        );
+    }
+
+    /// "Fallen to" the fraction includes landing exactly on it.
+    #[test]
+    fn releases_exactly_at_the_threshold() {
+        let gate = MemoryGate::new(0.75, 0.65, 0.5, FixedSource::new(vec![at(0.9)])).unwrap();
+
+        assert!(gate.should_block(1000));
+        assert!(!gate.should_block(500), "500 is half of 1000");
+    }
+
+    /// Engaging with nothing in flight leaves no drain to measure. Treating that
+    /// as satisfied would release on the next cycle however high usage was, so
+    /// the memory reading has to stay in charge.
+    #[test]
+    fn engaging_with_nothing_in_flight_does_not_release_on_its_own() {
+        let gate = MemoryGate::new(0.75, 0.65, 0.5, FixedSource::new(vec![at(0.9)])).unwrap();
+
+        assert!(gate.should_block(0), "engages on usage alone");
+        assert!(
+            gate.should_block(0),
+            "still held: usage is high and there was never any work to drain"
         );
     }
 

--- a/fusillade/src/daemon/mod.rs
+++ b/fusillade/src/daemon/mod.rs
@@ -504,6 +504,7 @@ where
         let memory_gate = MemoryGate::new(
             config.memory_gate_high_fraction,
             config.memory_gate_low_fraction,
+            config.memory_gate_release_in_flight_fraction,
             Box::new(CgroupMemorySource),
         )
         .map(Arc::new);


### PR DESCRIPTION

The memory gate stops claiming above `memory_gate_high_fraction` and is meant to
resume below `memory_gate_low_fraction`. The resume never happens. Once engaged
the gate stays shut until the process is restarted, with claiming suppressed the
whole time.

## Why the low mark cannot work

Freed memory goes back to the allocator's free lists rather than to the OS. The
cgroup working set, which is what the gate reads, therefore behaves as a
high-water mark rather than a level: completing a request does not lower it. On a
load rig, thousands of completions after the gate engaged returned almost none of
the memory they had taken.

Worse, the reading drifts upward while the gate is shut. Suppressing claims stops
new work arriving, but the requests already dispatched keep streaming and keep
accumulating, and the gate cannot shed those.

That rules out fixing this by moving the low mark, and it is worth being precise
about why, because "just lower the threshold" is the obvious first instinct:

- The gate engages because the reading reached the high mark, and retention pins
  it there. So the ceiling on the reading is at or above the high mark by
  construction.
- Any low mark below the high mark is therefore unreachable.
- Any low mark above the high mark releases on the cycle after it engages, making
  the gate a no-op.

There is no value in between. The two-mark design needs a metric that falls when
the condition clears, and this one does not.

Confirmed on a rig by calling `malloc_trim(0)` against the live process while the
gate was engaged: memory dropped immediately and substantially. The memory was
reclaimable the whole time; glibc simply was not returning it.

## The change

Claiming also resumes once in-flight has fallen to
`memory_gate_release_in_flight_fraction` of what it was when the gate engaged.
Default 0.5, and a value of zero restores the previous memory-only behaviour.

In-flight is the one quantity guaranteed to fall while claiming is suppressed,
which is exactly the property the release condition needs and the cgroup reading
lacks.

Engaging is unchanged and still reads the cgroup working set alone. That is what
the OOM killer acts on, so being conservative there is correct. The asymmetry is
deliberate: pessimistic about entering the hold, accurate about leaving it.

## Why this is safe

If memory really is still high when claiming resumes, the next cycle re-engages.
The worst case is admitting one claim batch before the gate shuts again, which
bounds the overshoot and turns the failure mode into a duty cycle rather than a
stall. That is strictly better than suppressing claims indefinitely while a
backlog sits idle.

The fraction is clamped to `0.0..=1.0` rather than rejected, so a bad config
value cannot silently remove the only reliable exit.

## Alternatives considered

**Calling `malloc_trim` on engagement.** Works, and is what proved the diagnosis,
but as a fix it is worse: a stop-the-world pause proportional to heap size, page
faults re-faulting memory that is about to be reused, a `libc` dependency, and
one call is not enough because the reading climbs again immediately. It remains
worth considering separately as housekeeping, to stop the floor ratcheting across
a process lifetime.

**Subtracting the allocator's free bytes from the reading**, via `mallinfo2`, so
the gate measures genuinely-in-use memory. This is the more correct model of
pressure and is probably where this should end up. It was not taken here because
it adds a `libc` dependency and an unmeasured cost on the claim path, and free
bytes are not the same as usable bytes under fragmentation. The in-flight release
fixes the actual defect without those open questions.

**Limiting glibc arenas.** Measurably lowers peak footprint and is worth setting
independently, but it changes how much the process holds, not whether `free()`
returns anything. It has no effect on the release.

## Tests

Three added, covering release once enough in-flight has drained despite usage
never falling, no release while in-flight holds up, and a zero fraction leaving
the memory-only path intact. Existing gate tests pass unchanged.
