### PR TITLE
feat(onwards): count gateway failures by reason and upstream status

### DIFF
--- a/fusillade/src/daemon/mod.rs
+++ b/fusillade/src/daemon/mod.rs
@@ -163,7 +163,7 @@ fn is_downstream_overload(reason: &FailureReason) -> bool {
     }
 }
 
-fn emit_concurrency_decrease(model: &str, adjustment: ConcurrencyAdjustment) {
+fn emit_concurrency_decrease(model: &str, adjustment: ConcurrencyAdjustment, status: &str) {
     counter!("fusillade_adaptive_concurrency_decreases_total", "model" => model.to_owned())
         .increment(1);
     gauge!("fusillade_adaptive_concurrency_limit", "model" => model.to_owned())
@@ -172,7 +172,9 @@ fn emit_concurrency_decrease(model: &str, adjustment: ConcurrencyAdjustment) {
         model,
         previous_limit = adjustment.previous_limit,
         new_limit = adjustment.new_limit,
-        status = 529,
+        // Carried from the failure rather than assumed: more than one status
+        // now cuts the limit, so hard-coding one would misreport the others.
+        status,
         "Reduced model concurrency after downstream overload"
     );
 }
@@ -1427,7 +1429,11 @@ where
                                 && let Some(adjustment) = adaptive_concurrency
                                     .record_overload(&capacity_model_clone, generation)
                             {
-                                emit_concurrency_decrease(&capacity_model_clone, adjustment);
+                                emit_concurrency_decrease(
+                                    &capacity_model_clone,
+                                    adjustment,
+                                    &failed.state.reason.status_code_label(),
+                                );
                             }
                             let retry_attempt = failed.state.retry_attempt;
                             let reason_label = failed.state.reason.metric_label();

--- a/fusillade/src/daemon/mod.rs
+++ b/fusillade/src/daemon/mod.rs
@@ -143,6 +143,18 @@ fn is_downstream_overload(reason: &FailureReason) -> bool {
     match reason {
         FailureReason::RetriableHttpStatus { status: 529, .. }
         | FailureReason::NonRetriableHttpStatus { status: 529, .. } => true,
+        // 503 means the gateway could not place the request with any provider:
+        // the pool was empty, or every attempt failed. Either way there is no
+        // capacity to dispatch into right now, so continuing at the current
+        // limit just burns attempts against nothing.
+        //
+        // Included despite not being a saturation signal, because the increase
+        // side grows on demand and a failed request still fills a slot: a model
+        // whose capacity has gone away keeps filling every slot it is offered
+        // and ratchets its limit up throughout the outage. Cutting is what stops
+        // that, and the limit re-grows multiplicatively once capacity returns.
+        FailureReason::RetriableHttpStatus { status: 503, .. }
+        | FailureReason::NonRetriableHttpStatus { status: 503, .. } => true,
         FailureReason::RetriableHttpStatus { status: 429, body }
         | FailureReason::NonRetriableHttpStatus { status: 429, body } => {
             body.contains(ONWARDS_CONCURRENCY_LIMIT_CODE)
@@ -2346,6 +2358,26 @@ mod tests {
         }
     }
 
+    /// A 503 is the gateway reporting it could not place the request with any
+    /// provider. It is not saturation, but it must still cut: a failed request
+    /// fills a slot, so a model whose capacity has gone away keeps filling every
+    /// slot it is offered and ratchets its limit up for the whole outage.
+    #[test]
+    fn gateway_503_is_an_overload_signal() {
+        for reason in [
+            FailureReason::RetriableHttpStatus {
+                status: 503,
+                body: String::new(),
+            },
+            FailureReason::NonRetriableHttpStatus {
+                status: 503,
+                body: String::new(),
+            },
+        ] {
+            assert!(is_downstream_overload(&reason), "{reason:?}");
+        }
+    }
+
     /// Everything else must leave the limit alone. A bare 429 is a provider rate
     /// limit, usually tokens per minute, which fewer concurrent requests does not
     /// necessarily reduce; timeouts and resets happened to a request the model had
@@ -2359,10 +2391,6 @@ mod tests {
             },
             FailureReason::RetriableHttpStatus {
                 status: 429,
-                body: String::new(),
-            },
-            FailureReason::RetriableHttpStatus {
-                status: 503,
                 body: String::new(),
             },
             FailureReason::NetworkError {

--- a/onwards/src/handlers.rs
+++ b/onwards/src/handlers.rs
@@ -595,6 +595,7 @@ pub async fn target_message_handler<T: HttpClient>(
             "model" => model_name.to_string(),
         )
         .increment(1);
+        record_response_status(503);
         return Err(OnwardsErrorResponse::service_unavailable());
     }
 

--- a/onwards/src/handlers.rs
+++ b/onwards/src/handlers.rs
@@ -585,6 +585,16 @@ pub async fn target_message_handler<T: HttpClient>(
     // This runs after routing rules so that redirects get a chance to replace the pool.
     if pool.is_empty() {
         debug!("Pool for model '{}' has no providers", model_name);
+        // Counted, not just logged: this is a debug line on a hot path, so under
+        // load it is exactly the signal a log pipeline sheds, and the 503 it
+        // produces is indistinguishable downstream from every other 503.
+        metrics::counter!(
+            "onwards_upstream_failed_total",
+            "reason" => "no_providers",
+            "status" => "503",
+            "model" => model_name.to_string(),
+        )
+        .increment(1);
         return Err(OnwardsErrorResponse::service_unavailable());
     }
 
@@ -1540,16 +1550,44 @@ pub async fn target_message_handler<T: HttpClient>(
         // We tried at least one provider but all failed
         let final_error = last_error
             .unwrap_or_else(|| OnwardsErrorResponse::model_not_found(model_name.as_str()));
-        record_response_status(final_error.status.as_u16());
+        // `status` carries the PRE-sanitization status of the last attempt, which
+        // the response itself discards: a 529 and a 500 both leave here as 503,
+        // so without this the caller cannot tell saturation from failure. This is
+        // the single exit where a candidate error actually becomes the response,
+        // so counting here counts outcomes rather than attempts.
+        let status = final_error.status.as_u16();
+        metrics::counter!(
+            "onwards_upstream_failed_total",
+            "reason" => "retries_exhausted",
+            "status" => status.to_string(),
+            "model" => model_name.to_string(),
+        )
+        .increment(1);
+        record_response_status(status);
         Err(final_error)
     } else if !pool.is_empty() {
         // Pool has providers but select_iter() yielded nothing — all at capacity
+        metrics::counter!(
+            "onwards_upstream_failed_total",
+            "reason" => "all_at_capacity",
+            "status" => "429",
+            "model" => model_name.to_string(),
+        )
+        .increment(1);
         record_response_status(429);
         Err(OnwardsErrorResponse::concurrency_limited())
     } else {
         // Empty pool (shouldn't normally happen, targets resolved earlier)
         let err = OnwardsErrorResponse::model_not_found(model_name.as_str());
-        record_response_status(err.status.as_u16());
+        let status = err.status.as_u16();
+        metrics::counter!(
+            "onwards_upstream_failed_total",
+            "reason" => "empty_pool_late",
+            "status" => status.to_string(),
+            "model" => model_name.to_string(),
+        )
+        .increment(1);
+        record_response_status(status);
         Err(err)
     }
     }

--- a/onwards/src/handlers.rs
+++ b/onwards/src/handlers.rs
@@ -671,6 +671,12 @@ pub async fn target_message_handler<T: HttpClient>(
 
     // Track last error for fallback scenarios
     let mut last_error: Option<OnwardsErrorResponse> = None;
+    // The status the UPSTREAM returned on the most recent attempt, before any
+    // sanitization. `last_error` cannot serve this purpose: by the time an
+    // attempt is recorded there it has already been mapped onto a gateway
+    // response, so an upstream 529 and an upstream 500 are both 503 and the
+    // distinction that matters for backpressure is gone.
+    let mut last_upstream_status: Option<u16> = None;
 
     // Iterate through providers (with fallback support).
     // select_iter() uses weighted least connections: picks the provider with the
@@ -959,6 +965,7 @@ pub async fn target_message_handler<T: HttpClient>(
         };
 
         let status = response.status().as_u16();
+        last_upstream_status = Some(status);
         upstream_span.record("http.response.status_code", status);
         tracing::Span::current().record("http.response.status_code", status);
 
@@ -1242,6 +1249,9 @@ pub async fn target_message_handler<T: HttpClient>(
                 );
                 upstream_span.record("http.response.status_code", embedded);
                 tracing::Span::current().record("http.response.status_code", embedded);
+                // A 200 carrying an embedded error IS that error for our
+                // purposes, so it overrides the 200 recorded above.
+                last_upstream_status = Some(embedded);
 
                 let retryable = pool.should_fallback_on_status(embedded)
                     || (embedded == 429 && pool.should_fallback_on_rate_limit());
@@ -1559,7 +1569,11 @@ pub async fn target_message_handler<T: HttpClient>(
         metrics::counter!(
             "onwards_upstream_failed_total",
             "reason" => "retries_exhausted",
-            "status" => status.to_string(),
+            // The upstream's own status on the final attempt, NOT the gateway
+            // response above: both a 529 and a 500 sanitize to 503, and only
+            // the former is backpressure. Falls back to the response status
+            // when no attempt got far enough to see one.
+            "status" => last_upstream_status.unwrap_or(status).to_string(),
             "model" => model_name.to_string(),
         )
         .increment(1);


### PR DESCRIPTION
## Why

The gateway collapses several unrelated conditions into one sanitized status.
A caller receiving it cannot tell an empty routing table from exhausted retries,
and cannot tell upstream saturation from upstream failure. When that status
arrives in volume, working out which of those actually happened means reading
debug logs on a hot path, which are exactly the lines a log pipeline sheds under
load. The measurable candidates can come in far below the observed total with no
way to close the gap.

Separately, the adaptive concurrency controller did not treat that status as a
reason to cut. Growth is driven by demand rather than success, and a request
that fails immediately still fills a slot, so a model whose capacity has gone
away keeps filling every slot it is offered and ratchets its limit upward for
the whole outage. That is the one-way ratchet the controller's design notes warn
about, reached through an availability failure rather than through missing
backpressure.

## What changed

**A counter, `onwards_upstream_failed_total`**, following the existing
`onwards_*_total` convention. Labels are `reason`, `status`, and `model`, with
one increment per exit that produces a failure response: no providers,
retries exhausted, all providers at capacity, and the late empty-pool arm.

The `status` label on the exhausted arm carries the **pre-sanitization** status
of the final attempt. That is the fact the response discards, and recording it
makes the distinction visible without changing what any caller sees, so the
sanitization guarantee is untouched.

Instrumentation sits at the exits where a candidate error actually becomes the
response, not at the sites that construct one. Two of those sites return a
candidate used only if later attempts also fail; counting there would count
attempts rather than outcomes and inflate the very number this exists to
measure.

**The controller now cuts on that status.** This reverses a deliberate earlier
decision, so the case moved out of the test asserting it does not cut and into a
new test covering both failure variants. The reasoning is recorded in the code:
it is not a saturation signal, but cutting is what stops the ratchet, and the
limit re-grows multiplicatively once capacity returns.

## Risk

A model that flaps will have its limit driven toward its floor and held there
while it keeps failing. That is the intended behaviour, but it will look
alarming on the limit graph and is worth expecting rather than discovering.

The counter is additive and affects no control flow.

## Verification

`sum by (reason, status) (rate(onwards_upstream_failed_total[5m]))` separates
the causes directly. A dominant no-providers reason points at routing config
going transiently empty during replica changes; a dominant exhausted reason with
5xx statuses points at the backend erroring under load. These need different
fixes, which is why distinguishing them matters.

For the controller change, the decrease counter should move during an
availability outage, and the limit should fall rather than climb while a model
is unreachable.

## Tests

`cargo check` and `cargo clippy` clean on both crates, with the pre-existing
warning count unchanged. Daemon unit tests pass. The full suite needs a
database and is left to CI.
