### PR TITLE
fix(proxy): failover realtime 529s to fallback providers, preserve batch 529 backoff signal

### DIFF
--- a/dwctl/src/api/models/deployments/mod.rs
+++ b/dwctl/src/api/models/deployments/mod.rs
@@ -309,7 +309,7 @@ pub struct CompositeModelCreate {
     /// Whether to trigger fallback on rate limit responses (defaults to true)
     #[serde(default = "default_true")]
     pub fallback_on_rate_limit: bool,
-    /// HTTP status codes that trigger fallback (defaults to [499, 500, 502, 503, 504]).
+    /// HTTP status codes that trigger fallback (defaults to [429, 499, 500, 502, 503, 504, 529]).
     /// Rate-limit responses are controlled separately by `fallback_on_rate_limit`,
     /// which defaults to true.
     #[serde(default = "default_fallback_statuses")]
@@ -368,7 +368,7 @@ fn default_true() -> bool {
 }
 
 fn default_fallback_statuses() -> Vec<i32> {
-    vec![499, 500, 502, 503, 504]
+    vec![429, 499, 500, 502, 503, 504, 529]
 }
 
 fn default_backoff_initial_ms() -> i32 {

--- a/dwctl/src/db/handlers/deployments.rs
+++ b/dwctl/src/db/handlers/deployments.rs
@@ -247,7 +247,7 @@ impl From<(Option<ModelType>, DeployedModel)> for DeploymentDBResponse {
             lb_strategy,
             fallback_enabled: m.fallback_enabled.unwrap_or(true),
             fallback_on_rate_limit: m.fallback_on_rate_limit.unwrap_or(true),
-            fallback_on_status: m.fallback_on_status.unwrap_or_else(|| vec![429, 499, 500, 502, 503, 504]),
+            fallback_on_status: m.fallback_on_status.unwrap_or_else(|| vec![429, 499, 500, 502, 503, 504, 529]),
             fallback_with_replacement: m.fallback_with_replacement.unwrap_or(false),
             fallback_max_attempts: m.fallback_max_attempts,
             backoff_enabled: m.backoff_enabled,

--- a/dwctl/src/sync/onwards_config/mod.rs
+++ b/dwctl/src/sync/onwards_config/mod.rs
@@ -729,7 +729,7 @@ async fn load_composite_models_from_db(db: &PgPool, escalation_models: &[String]
                 lb_strategy,
                 fallback_enabled: row.fallback_enabled.unwrap_or(true),
                 fallback_on_rate_limit: row.fallback_on_rate_limit.unwrap_or(true),
-                fallback_on_status: row.fallback_on_status.unwrap_or_else(|| vec![429, 499, 500, 502, 503, 504]),
+                fallback_on_status: row.fallback_on_status.unwrap_or_else(|| vec![429, 499, 500, 502, 503, 504, 529]),
                 fallback_with_replacement: row.fallback_with_replacement.unwrap_or(false),
                 fallback_max_attempts: row.fallback_max_attempts,
                 backoff_enabled: row.backoff_enabled,
@@ -1450,7 +1450,7 @@ pub async fn load_targets_from_db(
                 routing_rules: Vec::new(), // Populated from separate query below
                 fallback_enabled: row.fallback_enabled.unwrap_or(true),
                 fallback_on_rate_limit: row.fallback_on_rate_limit.unwrap_or(true),
-                fallback_on_status: row.fallback_on_status.clone().unwrap_or_else(|| vec![429, 499, 500, 502, 503, 504]),
+                fallback_on_status: row.fallback_on_status.clone().unwrap_or_else(|| vec![429, 499, 500, 502, 503, 504, 529]),
                 fallback_with_replacement: row.fallback_with_replacement.unwrap_or(false),
                 fallback_max_attempts: row.fallback_max_attempts,
                 backoff_enabled: row.backoff_enabled,

--- a/onwards/src/handlers.rs
+++ b/onwards/src/handlers.rs
@@ -659,6 +659,16 @@ pub async fn target_message_handler<T: HttpClient>(
     let original_headers = req.headers().clone();
     let method = req.method().clone();
 
+    // Fusillade daemon loopback requests carry x-fusillade-request-id.
+    // These are batch/flex/background requests dispatched by the daemon back
+    // through the full dwctl stack. Fusillade's adaptive concurrency controller
+    // relies on receiving the raw 529 from the upstream to back off — if we
+    // fell over to an alternative provider on 529, that signal would never
+    // reach the daemon, breaking its overload backoff. So for fusillade
+    // loopback traffic we suppress 529 fallback and let it pass through.
+    let is_fusillade_loopback = original_headers
+        .contains_key("x-fusillade-request-id");
+
     // Track last error for fallback scenarios
     let mut last_error: Option<OnwardsErrorResponse> = None;
 
@@ -952,8 +962,12 @@ pub async fn target_message_handler<T: HttpClient>(
         upstream_span.record("http.response.status_code", status);
         tracing::Span::current().record("http.response.status_code", status);
 
-        // Check if we should fallback based on status code
-        if pool.should_fallback_on_status(status) {
+        // Check if we should fallback based on status code.
+        // Suppress 529 fallback for fusillade daemon loopback requests: the
+        // daemon needs the raw 529 to drive its adaptive concurrency backoff.
+        let should_fallback = pool.should_fallback_on_status(status)
+            && !(status == 529 && is_fusillade_loopback);
+        if should_fallback {
             debug!(
                 "Provider returned fallback status {}, trying next: {:?}",
                 status, target.url


### PR DESCRIPTION
## Problem

Realtime requests receiving HTTP 529 (overloaded) from upstream providers were passed straight back to the client instead of failing over to fallback providers (e.g. OpenRouter). This is because 529 was not included in the default `fallback_on_status` list — only `[429, 499, 500, 502, 503, 504]`.

Meanwhile, batch/flex requests routed through fusillade **must** continue receiving 529s, as fusillade uses 529 as its adaptive concurrency backoff signal (Josh confirmed 429 is semantically wrong here — it's not a user rate-limiting issue).

## Context

Investigation of INC-1139 (edge 5xx rate) revealed:
- Almost all 5xx were 529s (zero 502s/500s/503s)
- Root cause: `deepseek-ai/DeepSeek-V4-Flash` (275 req/hr demand, 0 replicas) and `zai-org/GLM-5.2-FP8` (71 req/hr, 0 replicas) had no in-house capacity
- 529s concentrated on batch path (`fusillade-batch`: ~39,877 cumulative); realtime path had very few (`fusillade-request`: 530 cumulative, ~75x fewer) thanks to priority displacement
- But those 530 529s did reach realtime users, and there was no failover

## Changes

### 1. Add 529 to default fallback status codes
**Files:** `dwctl/src/api/models/deployments/mod.rs`, `dwctl/src/db/handlers/deployments.rs`, `dwctl/src/sync/onwards_config/mod.rs`

Default `fallback_on_status` goes from `[429, 499, 500, 502, 503, 504]` to `[429, 499, 500, 502, 503, 504, 529]`. Any realtime request that gets a 529 from the primary provider will now fall over to the next configured provider.

### 2. Suppress 529 fallback for fusillade loopback requests
**File:** `onwards/src/handlers.rs`

When onwards receives a request carrying the `x-fusillade-request-id` header (already used by the inference middleware to identify daemon/batch requests), 529 is **not** treated as a fallback trigger. The raw 529 is passed back to fusillade unchanged, preserving its adaptive concurrency backoff signal.

The `x-fusillade-request-id` header was already being checked at line 95 of `dwctl/src/inference/middleware.rs` to skip the middleware for daemon requests, so this reuses an existing signal.

## Verification

- Both `onwards` and `dwctl` crates compile clean
- `cargo clippy` — no new warnings from these changes