### PR TITLE
fix(fusillade): stop the memory gate ratcheting in-flight work to zero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "tempfile",
  "test-log",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -6742,6 +6743,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,13 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Backend build stage
 FROM chef AS builder
 
-# Install build dependencies including Node.js
+# Install build dependencies including Node.js.
+# `make` is required by tikv-jemalloc-sys, which builds jemalloc from its C
+# sources via autotools rather than shipping a prebuilt library.
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
+    make \
     curl \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -188,3 +188,6 @@ criterion = { version = "0.8", features = ["async_tokio"] }
 tempfile = "3.0"
 wiremock = "0.6"
 serde_urlencoded = "0.7"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemallocator = "0.7.0"

--- a/dwctl/src/main.rs
+++ b/dwctl/src/main.rs
@@ -1,6 +1,42 @@
 use clap::Parser;
 use dwctl::{Application, Config, telemetry};
 
+// jemalloc, for its decay behaviour rather than its allocation speed.
+//
+// glibc's allocator keeps freed memory on its free lists and only returns
+// contiguous top-of-heap on an explicit trim, so a process with bursty
+// allocation holds a working set close to its historical peak indefinitely.
+// The cgroup limit is enforced on that working set and the OOM killer acts on
+// it, so retained-but-unused memory is indistinguishable from live memory to
+// the kernel: a pod can sit near its limit while most of what it holds is free.
+//
+// That also breaks the batch daemon's memory gate, whose low mark is only
+// reachable if the reading falls when work completes. Under glibc it does not,
+// which leaves the gate unable to reopen on the memory signal alone.
+//
+// jemalloc returns dirty pages to the OS on a decay timer without the
+// application asking, so the reading tracks live usage. Linux only: this is
+// about the glibc behaviour above, and the default allocator is fine elsewhere.
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+// `background_thread` is the part that matters here, not the decay interval.
+// By default jemalloc purges as a side effect of allocator activity, and the
+// state this exists to fix is a pod holding memory while it is DELIBERATELY
+// idle: once the memory gate suspends claiming there is little allocation
+// happening to drive a purge, so the working set would stay high exactly when
+// it needs to fall. A background thread purges on a timer regardless.
+//
+// `#[used]` is load-bearing: nothing in this crate reads the static, so without
+// it the symbol is dropped before linking and jemalloc silently keeps its
+// defaults. Verified by checking the symbol is present in the built binary.
+#[cfg(target_os = "linux")]
+#[used]
+#[allow(non_upper_case_globals)]
+#[unsafe(export_name = "malloc_conf")]
+pub static malloc_conf: &[u8] = b"background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
+
 /// Wait for shutdown signal (SIGTERM or Ctrl+C)
 async fn shutdown_signal() {
     use tokio::signal;

--- a/fusillade/src/daemon/memory_gate.rs
+++ b/fusillade/src/daemon/memory_gate.rs
@@ -118,9 +118,17 @@ pub(super) struct MemoryGate {
     /// the per-pod ceiling, measured rather than assumed, and it is what a
     /// replica count should be derived from.
     peak_in_flight_at_gate: AtomicU64,
-    /// In-flight at the most recent engagement, and the fraction of it that
-    /// in-flight must fall to before claiming resumes regardless of the memory
-    /// reading. See `should_block` for why a memory-only release cannot work.
+    /// In-flight at the START of the current pressure episode, and the fraction
+    /// of it that in-flight must fall to before claiming resumes regardless of
+    /// the memory reading. See `should_block` for why a memory-only release
+    /// cannot work.
+    ///
+    /// Held for the whole episode rather than rewritten on each engagement. The
+    /// memory reading does not fall when work completes, so releasing on drain
+    /// is immediately followed by re-engagement; re-baselining there would adopt
+    /// the freshly-drained level as the new reference and require halving THAT,
+    /// so each cycle would admit half as much as the last and in-flight would
+    /// decay geometrically toward zero. Zero means no episode is in progress.
     in_flight_when_engaged: AtomicU64,
     release_in_flight_fraction: f64,
 }
@@ -211,11 +219,23 @@ impl MemoryGate {
         self.engaged.store(engaged, Ordering::Relaxed);
         gauge!("fusillade_memory_gate_engaged").set(u8::from(engaged));
 
+        // The episode ends only when usage genuinely recovers past the low mark.
+        // A release driven by the drain condition is not a recovery: the reading
+        // is still high and the gate will re-engage on the next cycle.
+        if !engaged && used <= self.low {
+            self.in_flight_when_engaged.store(0, Ordering::Relaxed);
+        }
+
         if engaged && !was_engaged {
             counter!("fusillade_memory_gate_engagements_total").increment(1);
             let in_flight = in_flight as u64;
-            self.in_flight_when_engaged
-                .store(in_flight, Ordering::Relaxed);
+            // Only the first engagement of an episode sets the reference.
+            let _ = self.in_flight_when_engaged.compare_exchange(
+                0,
+                in_flight,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
             self.peak_in_flight_at_gate
                 .fetch_max(in_flight, Ordering::Relaxed);
             gauge!("fusillade_in_flight_at_gate").set(in_flight as f64);
@@ -334,6 +354,30 @@ mod tests {
         assert!(
             !gate.should_block(499),
             "released once in-flight halved, despite usage never falling"
+        );
+    }
+
+    /// The production failure this guards against: usage stays above the HIGH
+    /// mark, so every drain-driven release is followed immediately by
+    /// re-engagement. If the reference were re-read there, each cycle would
+    /// admit half as much as the last and in-flight would decay toward zero.
+    /// Holding it for the episode keeps the release level fixed instead.
+    #[test]
+    fn re_engaging_does_not_lower_the_release_level() {
+        let gate = MemoryGate::new(0.75, 0.65, 0.5, FixedSource::new(vec![at(0.9)])).unwrap();
+
+        assert!(gate.should_block(1000), "engages at 1000 in flight");
+        assert!(!gate.should_block(500), "releases once halved");
+        // Usage is still above the high mark, so this re-engages. The reference
+        // must stay 1000, not become 500.
+        assert!(gate.should_block(520), "re-engages while usage is high");
+        assert!(
+            !gate.should_block(500),
+            "still releases at half of the ORIGINAL level, not half of 500"
+        );
+        assert!(
+            gate.should_block(260),
+            "re-engages again without having ratcheted the level down"
         );
     }
 


### PR DESCRIPTION
Two changes to how the batch daemon behaves under memory pressure. The first is
a live defect; the second removes the condition that makes the first reachable.

## 1. The gate ratcheted in-flight work to zero

The memory gate recorded the in-flight level it should drain to on **every**
engagement, not on the first of a pressure episode.

That is fine if a release means recovery. It does not. The memory reading does
not fall when work completes, so a drain-driven release is followed immediately
by re-engagement on the next cycle - and re-engagement then adopted the
freshly-drained level as its new reference, requiring that to halve in turn.
Each cycle admitted half as much as the last, so in-flight decayed
geometrically and throughput collapsed toward zero while the pod looked healthy.

Observed in production as a sequence of engagements at steadily falling
in-flight levels, ending in near-total loss of dispatch. The only recovery was a
restart, which is not a thing that can happen unattended.

The reference is now set once per episode and cleared only when usage genuinely
recovers below the low mark. The regression test reproduces the decay and fails
against the previous behaviour.

## 2. The allocator is why the low mark is unreachable

The gate is designed around two marks: stop at the high one, resume under the
low one. The resume has never been reachable, because the default allocator
keeps freed memory on its free lists rather than returning it. The working set
therefore behaves as a high-water mark - completing work does not lower it - so
the only usable exit was the in-flight drain above, which is what put the whole
burden on the mechanism that then misbehaved.

This also understates real headroom. The cgroup limit is enforced on the working
set and the OOM killer acts on it, so retained-but-unused memory is
indistinguishable from live memory to the kernel: the pod is treated as near its
limit while most of what it holds is free.

Switches to jemalloc on Linux with a background purge thread. `background_thread`
is the load-bearing part rather than the decay interval: purging is otherwise
driven by allocator activity, and the state this exists to fix is a pod holding
memory precisely *because* the gate has suspended claiming. A background thread
purges on a timer regardless.

`#[used]` on the config symbol is also load-bearing. Nothing in the crate reads
it, so without it the symbol is dropped before linking and the settings are
silently ignored - jemalloc linked, defaults in force, no background thread.
Confirmed present in the built binary.

## Testing

Unit tests cover the ratchet directly, including that the release level does not
fall across re-engagement. Verified the new test fails against the old code
rather than merely passing against the new.

**Not yet validated end to end.** The allocator change needs one run under real
load: send a batch and watch the working set as in-flight drains. If it falls
with the work, this is correct. If it stays pinned, the retained memory is not
reclaimable and the diagnosis is wrong. Worth doing in staging before this
reaches production.

## Interim mitigation

The high fraction has been raised in production as a stopgap so the gate stops
engaging during normal operation. That should be reverted to its intended value
once this is deployed and confirmed.
