### PR TITLE
fix(dwctl): export malloc_conf under jemalloc's prefixed symbol name

### DIFF
--- a/dwctl/src/main.rs
+++ b/dwctl/src/main.rs
@@ -30,11 +30,23 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 //
 // `#[used]` is load-bearing: nothing in this crate reads the static, so without
 // it the symbol is dropped before linking and jemalloc silently keeps its
-// defaults. Verified by checking the symbol is present in the built binary.
+// defaults.
+//
+// The symbol name is equally load-bearing. tikv-jemalloc-sys builds jemalloc
+// with `--with-jemalloc-prefix=_rjem_` unless the
+// `unprefixed_malloc_on_supported_platforms` feature is on, so the global it
+// reads its options from is `_rjem_malloc_conf` (and the environment variable
+// is `_RJEM_MALLOC_CONF`). Exporting plain `malloc_conf` links fine and is
+// silently ignored: 10.16.0 shipped that way and ran with
+// `background_thread:false, dirty_decay_ms:10000, muzzy_decay_ms:0`.
+//
+// Verify against the built image rather than the symbol table:
+//   _RJEM_MALLOC_CONF=stats_print:true /app/dwctl --help 2>&1 | grep -E "background_thread|decay_ms"
+// must print `opt.background_thread: true` and 5000 for both decay values.
 #[cfg(target_os = "linux")]
 #[used]
 #[allow(non_upper_case_globals)]
-#[unsafe(export_name = "malloc_conf")]
+#[unsafe(export_name = "_rjem_malloc_conf")]
 pub static malloc_conf: &[u8] = b"background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
 
 /// Wait for shutdown signal (SIGTERM or Ctrl+C)


### PR DESCRIPTION
Follow-up to #1523. jemalloc is linked in 10.16.0 (549 `_rjem_*` symbols in the binary; 10.14.2 has none) but the options static is exported as plain `malloc_conf`, and tikv-jemalloc-sys builds jemalloc with `--with-jemalloc-prefix=_rjem_` by default, so the global jemalloc actually reads is `_rjem_malloc_conf`. The static links, survives `#[used]`, and is silently ignored.

Evidence from the published `control-layer:10.16.0` image:

- `_RJEM_MALLOC_CONF=stats_print:true /app/dwctl --help` → `opt.background_thread: false`, `opt.dirty_decay_ms: 10000`, `opt.muzzy_decay_ms: 0` (jemalloc defaults, not the 5000/5000 in the source)
- `MALLOC_CONF=stats_print:true` → nothing printed at all (unprefixed env var is not read either)
- `_RJEM_MALLOC_CONF=stats_print:true,background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000` → all three take effect
- the staging `fusillade-batch` pod on 10.16.0 has 8 threads and none named `jemalloc_bg_thd`

Consequence: the "pod holding memory while deliberately idle after the gate engages" case that #1523 describes is still unfixed in 10.16.0 — purging only happens as a side effect of allocation activity. The gate-reference half of #1523 is unaffected.

This PR renames the export and replaces the "verified by checking the symbol is present" note with the image-level check that would have caught it. Staging is being given the equivalent `_RJEM_MALLOC_CONF` env override in the meantime so the drive-high / drain-down test can run tonight (doublewordai/internal PR to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)