### PR TITLE
fix(fusillade): correct the memory gate's reading and remove its in-flight exit

### DIFF
--- a/fusillade/src/daemon/config.rs
+++ b/fusillade/src/daemon/config.rs
@@ -167,18 +167,6 @@ pub struct DaemonConfig {
     /// claim cycle while usage sits on the boundary.
     #[serde(default = "default_memory_gate_low_fraction")]
     pub memory_gate_low_fraction: f64,
-    /// Fraction of the in-flight count at engagement that in-flight must fall
-    /// to before claiming resumes, whatever the memory reading says.
-    ///
-    /// The low mark alone cannot release the gate. Freed memory goes back to the
-    /// allocator rather than the OS, so the cgroup working set behaves as a
-    /// high-water mark: it does not fall when requests complete, and the
-    /// remaining in-flight work pushes it up. Since the gate engages by reaching
-    /// the high mark, the reading pins at or above it, leaving no reachable low
-    /// mark below and no useful one above. In-flight is the one quantity certain
-    /// to fall once claiming stops, so it is what guarantees an exit.
-    #[serde(default = "default_release_in_flight_fraction")]
-    pub memory_gate_release_in_flight_fraction: f64,
     #[serde(skip, default = "default_model_escalations")]
     pub model_escalations: Arc<dashmap::DashMap<String, ModelEscalationConfig>>,
     #[serde(default)]
@@ -433,10 +421,6 @@ fn default_memory_gate_low_fraction() -> f64 {
 /// always recovers well before a full drain. If memory is still over the high
 /// mark when it resumes, the next cycle re-engages, so the cost of releasing too
 /// early is one claim batch.
-fn default_release_in_flight_fraction() -> f64 {
-    0.5
-}
-
 fn default_adaptive_growth_factor() -> f64 {
     1.5
 }
@@ -512,7 +496,6 @@ impl Default for DaemonConfig {
             adaptive_cut_factor: default_adaptive_cut_factor(),
             memory_gate_high_fraction: 0.0,
             memory_gate_low_fraction: default_memory_gate_low_fraction(),
-            memory_gate_release_in_flight_fraction: default_release_in_flight_fraction(),
             model_escalations: default_model_escalations(),
             inject_deadline_priority: false,
             background_concurrency_limit: 0,

--- a/fusillade/src/daemon/memory_gate.rs
+++ b/fusillade/src/daemon/memory_gate.rs
@@ -118,19 +118,6 @@ pub(super) struct MemoryGate {
     /// the per-pod ceiling, measured rather than assumed, and it is what a
     /// replica count should be derived from.
     peak_in_flight_at_gate: AtomicU64,
-    /// In-flight at the START of the current pressure episode, and the fraction
-    /// of it that in-flight must fall to before claiming resumes regardless of
-    /// the memory reading. See `should_block` for why a memory-only release
-    /// cannot work.
-    ///
-    /// Held for the whole episode rather than rewritten on each engagement. The
-    /// memory reading does not fall when work completes, so releasing on drain
-    /// is immediately followed by re-engagement; re-baselining there would adopt
-    /// the freshly-drained level as the new reference and require halving THAT,
-    /// so each cycle would admit half as much as the last and in-flight would
-    /// decay geometrically toward zero. Zero means no episode is in progress.
-    in_flight_when_engaged: AtomicU64,
-    release_in_flight_fraction: f64,
 }
 
 impl MemoryGate {
@@ -140,7 +127,6 @@ impl MemoryGate {
     pub(super) fn new(
         high: f64,
         low: f64,
-        release_in_flight_fraction: f64,
         source: Box<dyn MemorySource>,
     ) -> Option<Self> {
         if high <= 0.0 || high > 1.0 || low <= 0.0 || low >= high {
@@ -149,7 +135,6 @@ impl MemoryGate {
         // Out-of-range values would silently disable the in-flight release and
         // reintroduce the deadlock, so clamp rather than reject: a bad number
         // here should not take the gate's only reliable exit away.
-        let release_in_flight_fraction = release_in_flight_fraction.clamp(0.0, 1.0);
         Some(Self {
             source,
             high,
@@ -157,35 +142,26 @@ impl MemoryGate {
             engaged: AtomicBool::new(false),
             warned_unavailable: AtomicBool::new(false),
             peak_in_flight_at_gate: AtomicU64::new(0),
-            in_flight_when_engaged: AtomicU64::new(0),
-            release_in_flight_fraction,
         })
     }
 
     /// Whether claiming should be suppressed this cycle.
     ///
-    /// Engaging is decided purely on the memory reading: that is what the OOM
-    /// killer acts on, so being conservative there is correct.
+    /// Plain hysteresis: engage at `high`, hold until the reading falls back
+    /// under `low`. Engaging is decided purely on the memory reading because
+    /// that is what the OOM killer acts on, so being conservative there is
+    /// correct.
     ///
-    /// Releasing cannot be, and this is the subtle part. Freed memory returns to
-    /// the allocator rather than to the OS, so the cgroup working set is a
-    /// high-water mark rather than a level: completing a request does not lower
-    /// it. On a load rig, thousands of completions after the gate engaged
-    /// returned almost none of the memory they had taken, while the in-flight
-    /// requests that remained kept accumulating and pushed the reading *up*.
+    /// This depends on the reading actually falling as work completes, which in
+    /// turn depends on the allocator returning freed memory to the OS. Under an
+    /// allocator that keeps it on free lists the working set behaves as a
+    /// high-water mark, the low mark is unreachable, and this gate never
+    /// reopens. If that ever regresses, the symptom is a pod that stops claiming
+    /// and stays stopped until it restarts.
     ///
-    /// That rules out fixing this by moving the low mark. The gate engages
-    /// because the reading hit `high`, and retention pins it there, so the cap
-    /// on the reading is at or above `high` by construction. Any low mark below
-    /// `high` is unreachable; any low mark above it releases immediately and
-    /// makes the gate a no-op. No valid value exists between them.
-    ///
-    /// So claiming also resumes once in-flight has fallen to
-    /// `release_in_flight_fraction` of what it was when the gate engaged.
-    /// In-flight is the one signal guaranteed to fall while claiming is
-    /// suppressed. If memory really is still high the next cycle re-engages, so
-    /// the worst case is admitting one claim batch, which bounds the overshoot
-    /// and degrades to a duty cycle instead of a stall.
+    /// `in_flight` is retained for the ceiling gauge below, which is the
+    /// measured per-pod concurrency limit and the number a replica count should
+    /// be derived from.
     pub(super) fn should_block(&self, in_flight: usize) -> bool {
         let Some(reading) = self.source.read() else {
             if !self.warned_unavailable.swap(true, Ordering::Relaxed) {
@@ -201,41 +177,29 @@ impl MemoryGate {
         gauge!("fusillade_memory_working_set_ratio").set(used);
 
         let was_engaged = self.engaged.load(Ordering::Relaxed);
+        // Hysteresis, and nothing else: hold above the low mark, engage at the
+        // high mark. This works only because freed memory now returns to the OS,
+        // so the reading falls as work completes and the low mark is reachable.
+        //
+        // It previously was not, which is why a drain-based exit existed here:
+        // the allocator kept freed memory on its free lists, the reading behaved
+        // as a high-water mark, and without a second exit the gate never
+        // reopened. That exit released once in-flight had fallen to a fraction
+        // of its level at engagement, which meant the pod resumed at a level set
+        // by whatever happened to be in flight at one arbitrary instant, and
+        // stayed there until demand dropped away. It bounded a stall at the cost
+        // of pinning throughput to a number nobody chose.
         let engaged = if was_engaged {
-            let engaged_at = self.in_flight_when_engaged.load(Ordering::Relaxed);
-            // A zero fraction disables this exit, and so does engaging with
-            // nothing in flight: without a level to have fallen from there is no
-            // drain to measure, so fall back to the memory reading rather than
-            // treating an unknown as satisfied.
-            let drained_enough = self.release_in_flight_fraction > 0.0
-                && engaged_at > 0
-                && (in_flight as f64) <= (engaged_at as f64) * self.release_in_flight_fraction;
-            // Either exit will do: usage back under the low mark, or enough of
-            // the work that was in flight at engagement has completed.
-            used > self.low && !drained_enough
+            used > self.low
         } else {
             used >= self.high
         };
         self.engaged.store(engaged, Ordering::Relaxed);
         gauge!("fusillade_memory_gate_engaged").set(u8::from(engaged));
 
-        // The episode ends only when usage genuinely recovers past the low mark.
-        // A release driven by the drain condition is not a recovery: the reading
-        // is still high and the gate will re-engage on the next cycle.
-        if !engaged && used <= self.low {
-            self.in_flight_when_engaged.store(0, Ordering::Relaxed);
-        }
-
         if engaged && !was_engaged {
             counter!("fusillade_memory_gate_engagements_total").increment(1);
             let in_flight = in_flight as u64;
-            // Only the first engagement of an episode sets the reference.
-            let _ = self.in_flight_when_engaged.compare_exchange(
-                0,
-                in_flight,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            );
             self.peak_in_flight_at_gate
                 .fetch_max(in_flight, Ordering::Relaxed);
             gauge!("fusillade_in_flight_at_gate").set(in_flight as f64);
@@ -298,13 +262,13 @@ mod tests {
 
     #[test]
     fn stays_open_below_the_high_mark() {
-        let gate = MemoryGate::new(0.75, 0.65, 0.0, FixedSource::new(vec![at(0.5)])).unwrap();
+        let gate = MemoryGate::new(0.75, 0.65, FixedSource::new(vec![at(0.5)])).unwrap();
         assert!(!gate.should_block(100));
     }
 
     #[test]
     fn engages_at_the_high_mark() {
-        let gate = MemoryGate::new(0.75, 0.65, 0.0, FixedSource::new(vec![at(0.8)])).unwrap();
+        let gate = MemoryGate::new(0.75, 0.65, FixedSource::new(vec![at(0.8)])).unwrap();
         assert!(gate.should_block(100));
     }
 
@@ -315,7 +279,6 @@ mod tests {
         let gate = MemoryGate::new(
             0.75,
             0.65,
-            0.0,
             FixedSource::new(vec![at(0.8), at(0.7), at(0.7)]),
         )
         .unwrap();
@@ -331,7 +294,6 @@ mod tests {
         let gate = MemoryGate::new(
             0.75,
             0.65,
-            0.0,
             FixedSource::new(vec![at(0.8), at(0.6), at(0.6)]),
         )
         .unwrap();
@@ -339,108 +301,17 @@ mod tests {
         assert!(!gate.should_block(100), "released once under the low mark");
     }
 
-    /// The case the low mark cannot handle: usage stays pinned above it because
-    /// freed memory sits in the allocator rather than going back to the OS. Only
-    /// the in-flight fall gets the gate open again.
-    #[test]
-    fn releases_once_enough_in_flight_has_drained() {
-        let gate = MemoryGate::new(0.75, 0.65, 0.5, FixedSource::new(vec![at(0.9)])).unwrap();
 
-        assert!(gate.should_block(1000), "engages at the high mark");
-        assert!(
-            gate.should_block(600),
-            "still held: usage pinned high and only 40% drained"
-        );
-        assert!(
-            !gate.should_block(499),
-            "released once in-flight halved, despite usage never falling"
-        );
-    }
 
-    /// The production failure this guards against: usage stays above the HIGH
-    /// mark, so every drain-driven release is followed immediately by
-    /// re-engagement. If the reference were re-read there, each cycle would
-    /// admit half as much as the last and in-flight would decay toward zero.
-    /// Holding it for the episode keeps the release level fixed instead.
-    #[test]
-    fn re_engaging_does_not_lower_the_release_level() {
-        let gate = MemoryGate::new(0.75, 0.65, 0.5, FixedSource::new(vec![at(0.9)])).unwrap();
 
-        assert!(gate.should_block(1000), "engages at 1000 in flight");
-        assert!(!gate.should_block(500), "releases once halved");
-        // Usage is still above the high mark, so this re-engages. The reference
-        // must stay 1000, not become 500.
-        assert!(gate.should_block(520), "re-engages while usage is high");
-        assert!(
-            !gate.should_block(500),
-            "still releases at half of the ORIGINAL level, not half of 500"
-        );
-        assert!(
-            gate.should_block(260),
-            "re-engages again without having ratcheted the level down"
-        );
-    }
 
-    /// The fraction is a floor on how long the hold lasts, not a licence to
-    /// release early: a pod that is still saturated keeps claiming suppressed.
-    #[test]
-    fn does_not_release_while_in_flight_holds_up() {
-        let gate = MemoryGate::new(0.75, 0.65, 0.5, FixedSource::new(vec![at(0.9)])).unwrap();
 
-        assert!(gate.should_block(1000));
-        for still_in_flight in [999, 900, 700, 501] {
-            assert!(
-                gate.should_block(still_in_flight),
-                "held at {still_in_flight} in flight"
-            );
-        }
-    }
-
-    /// A zero fraction disables the in-flight exit, leaving the memory-only
-    /// behaviour the earlier tests describe.
-    #[test]
-    fn a_zero_fraction_leaves_only_the_memory_release() {
-        let gate = MemoryGate::new(0.75, 0.65, 0.0, FixedSource::new(vec![at(0.9)])).unwrap();
-
-        assert!(gate.should_block(1000));
-        assert!(
-            gate.should_block(1),
-            "no in-flight exit when the fraction is zero"
-        );
-        assert!(
-            gate.should_block(0),
-            "not even at zero in flight: the fraction is what disables it"
-        );
-    }
-
-    /// "Fallen to" the fraction includes landing exactly on it.
-    #[test]
-    fn releases_exactly_at_the_threshold() {
-        let gate = MemoryGate::new(0.75, 0.65, 0.5, FixedSource::new(vec![at(0.9)])).unwrap();
-
-        assert!(gate.should_block(1000));
-        assert!(!gate.should_block(500), "500 is half of 1000");
-    }
-
-    /// Engaging with nothing in flight leaves no drain to measure. Treating that
-    /// as satisfied would release on the next cycle however high usage was, so
-    /// the memory reading has to stay in charge.
-    #[test]
-    fn engaging_with_nothing_in_flight_does_not_release_on_its_own() {
-        let gate = MemoryGate::new(0.75, 0.65, 0.5, FixedSource::new(vec![at(0.9)])).unwrap();
-
-        assert!(gate.should_block(0), "engages on usage alone");
-        assert!(
-            gate.should_block(0),
-            "still held: usage is high and there was never any work to drain"
-        );
-    }
 
     /// A daemon outside a limited cgroup (local runs, tests) must not have its
     /// claiming suppressed by a source it cannot read.
     #[test]
     fn an_unreadable_source_never_blocks() {
-        let gate = MemoryGate::new(0.75, 0.65, 0.0, Box::new(NoSource)).unwrap();
+        let gate = MemoryGate::new(0.75, 0.65, Box::new(NoSource)).unwrap();
         assert!(!gate.should_block(100));
         assert!(!gate.should_block(100));
     }
@@ -449,19 +320,19 @@ mod tests {
     fn disabled_or_nonsensical_thresholds_produce_no_gate() {
         let src = || FixedSource::new(vec![at(0.9)]);
         assert!(
-            MemoryGate::new(0.0, 0.0, 0.0, src()).is_none(),
+            MemoryGate::new(0.0, 0.0, src()).is_none(),
             "zero disables"
         );
         assert!(
-            MemoryGate::new(0.65, 0.75, 0.0, src()).is_none(),
+            MemoryGate::new(0.65, 0.75, src()).is_none(),
             "low above high"
         );
         assert!(
-            MemoryGate::new(0.75, 0.75, 0.0, src()).is_none(),
+            MemoryGate::new(0.75, 0.75, src()).is_none(),
             "equal marks flap"
         );
         assert!(
-            MemoryGate::new(1.5, 0.5, 0.0, src()).is_none(),
+            MemoryGate::new(1.5, 0.5, src()).is_none(),
             "high above the limit"
         );
     }
@@ -473,7 +344,6 @@ mod tests {
         let gate = MemoryGate::new(
             0.75,
             0.65,
-            0.0,
             FixedSource::new(vec![at(0.8), at(0.5), at(0.9)]),
         )
         .unwrap();
@@ -491,7 +361,7 @@ mod tests {
             working_set: 400,
             limit: 1000,
         };
-        let gate = MemoryGate::new(0.75, 0.65, 0.0, FixedSource::new(vec![reading])).unwrap();
+        let gate = MemoryGate::new(0.75, 0.65, FixedSource::new(vec![reading])).unwrap();
         assert!(!gate.should_block(100));
     }
 }

--- a/fusillade/src/daemon/memory_gate.rs
+++ b/fusillade/src/daemon/memory_gate.rs
@@ -124,11 +124,7 @@ impl MemoryGate {
     /// Build a gate. Returns `None` when disabled (`high` of zero) or when the
     /// thresholds are not a usable pair, in which case claiming is never
     /// suppressed.
-    pub(super) fn new(
-        high: f64,
-        low: f64,
-        source: Box<dyn MemorySource>,
-    ) -> Option<Self> {
+    pub(super) fn new(high: f64, low: f64, source: Box<dyn MemorySource>) -> Option<Self> {
         if high <= 0.0 || high > 1.0 || low <= 0.0 || low >= high {
             return None;
         }
@@ -301,12 +297,6 @@ mod tests {
         assert!(!gate.should_block(100), "released once under the low mark");
     }
 
-
-
-
-
-
-
     /// A daemon outside a limited cgroup (local runs, tests) must not have its
     /// claiming suppressed by a source it cannot read.
     #[test]
@@ -319,10 +309,7 @@ mod tests {
     #[test]
     fn disabled_or_nonsensical_thresholds_produce_no_gate() {
         let src = || FixedSource::new(vec![at(0.9)]);
-        assert!(
-            MemoryGate::new(0.0, 0.0, src()).is_none(),
-            "zero disables"
-        );
+        assert!(MemoryGate::new(0.0, 0.0, src()).is_none(), "zero disables");
         assert!(
             MemoryGate::new(0.65, 0.75, src()).is_none(),
             "low above high"

--- a/fusillade/src/daemon/memory_gate.rs
+++ b/fusillade/src/daemon/memory_gate.rs
@@ -16,11 +16,9 @@
 //! Two thresholds rather than one: without hysteresis the gate would sit on the
 //! boundary flipping every claim cycle.
 //!
-//! The low mark cannot be the only way out, though. Freed memory goes back to
-//! the allocator rather than to the OS, so the reading behaves as a high-water
-//! mark and does not fall when requests complete - which leaves no low mark that
-//! is both reachable and useful. Claiming therefore also resumes once enough of
-//! the work that was in flight at engagement has drained. See `should_block`.
+//! Both marks are only as good as the reading they are compared against, and
+//! the reading has to count what the OOM killer counts. See [`MemoryReading`]
+//! for what that excludes and why the exclusion is bounded.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
@@ -32,6 +30,10 @@ pub(super) struct MemoryReading {
     /// Working set in bytes: usage less reclaimable page cache, which is what
     /// the OOM killer effectively acts on and what `container_memory_working_set_bytes`
     /// reports. Raw usage would include cache and trip the gate on file IO.
+    ///
+    /// The exclusion is clamped to the page cache the cgroup actually holds.
+    /// See [`CgroupMemorySource::working_set`] - unclamped, it can hide
+    /// anonymous memory that still counts against the limit.
     pub working_set: u64,
     /// The cgroup limit in bytes.
     pub limit: u64,
@@ -66,32 +68,46 @@ impl CgroupMemorySource {
         })
     }
 
+    /// Usage less the page cache the cgroup is actually holding.
+    ///
+    /// The subtraction is clamped to `file` because `inactive_file` can exceed
+    /// it. Pages released with `MADV_FREE` stay charged to the cgroup, but the
+    /// kernel parks them on the inactive file LRU, so an allocator that frees
+    /// that way reports gigabytes of `inactive_file` in a process holding no
+    /// page cache at all. Subtracting it unclamped hides anonymous memory that
+    /// the OOM killer still counts, and the gate reads far below where the
+    /// process really is.
+    fn working_set(current: u64, inactive_file: u64, file: u64) -> u64 {
+        current.saturating_sub(inactive_file.min(file))
+    }
+
     fn read_v2() -> Option<MemoryReading> {
+        const STAT: &str = "/sys/fs/cgroup/memory.stat";
         let limit_raw = std::fs::read_to_string("/sys/fs/cgroup/memory.max").ok()?;
         let limit = match limit_raw.trim() {
             "max" => return None,
             other => other.parse::<u64>().ok()?,
         };
         let current = Self::read_u64("/sys/fs/cgroup/memory.current")?;
-        let inactive_file =
-            Self::read_stat_key("/sys/fs/cgroup/memory.stat", "inactive_file").unwrap_or(0);
+        let inactive_file = Self::read_stat_key(STAT, "inactive_file").unwrap_or(0);
+        let file = Self::read_stat_key(STAT, "file").unwrap_or(0);
         Some(MemoryReading {
-            working_set: current.saturating_sub(inactive_file),
+            working_set: Self::working_set(current, inactive_file, file),
             limit,
         })
     }
 
     fn read_v1() -> Option<MemoryReading> {
+        const STAT: &str = "/sys/fs/cgroup/memory/memory.stat";
         let limit = Self::read_u64("/sys/fs/cgroup/memory/memory.limit_in_bytes")?;
         if limit >= Self::UNLIMITED_ABOVE {
             return None;
         }
         let usage = Self::read_u64("/sys/fs/cgroup/memory/memory.usage_in_bytes")?;
-        let inactive_file =
-            Self::read_stat_key("/sys/fs/cgroup/memory/memory.stat", "total_inactive_file")
-                .unwrap_or(0);
+        let inactive_file = Self::read_stat_key(STAT, "total_inactive_file").unwrap_or(0);
+        let file = Self::read_stat_key(STAT, "total_cache").unwrap_or(0);
         Some(MemoryReading {
-            working_set: usage.saturating_sub(inactive_file),
+            working_set: Self::working_set(usage, inactive_file, file),
             limit,
         })
     }
@@ -128,9 +144,6 @@ impl MemoryGate {
         if high <= 0.0 || high > 1.0 || low <= 0.0 || low >= high {
             return None;
         }
-        // Out-of-range values would silently disable the in-flight release and
-        // reintroduce the deadlock, so clamp rather than reject: a bad number
-        // here should not take the gate's only reliable exit away.
         Some(Self {
             source,
             high,
@@ -338,6 +351,36 @@ mod tests {
         gate.should_block(10);
         gate.should_block(1200);
         assert_eq!(gate.peak_in_flight_at_gate.load(Ordering::Relaxed), 4000);
+    }
+
+    /// Real page cache is excluded, which is the point of reading a working set
+    /// rather than raw usage.
+    #[test]
+    fn cache_is_excluded_from_the_working_set() {
+        assert_eq!(
+            CgroupMemorySource::working_set(1000, 300, 400),
+            700,
+            "the inactive part of a real cache is not the process's memory"
+        );
+    }
+
+    /// `inactive_file` counts pages freed with `MADV_FREE`, which are anonymous
+    /// and still charged to the cgroup. Subtracting more than the cgroup's page
+    /// cache would hide memory the OOM killer acts on: a process holding no
+    /// cache at all reported gigabytes of `inactive_file` and read ~30 points
+    /// below its true position, so the gate never engaged before the kill.
+    #[test]
+    fn lazily_freed_anonymous_pages_are_not_mistaken_for_cache() {
+        assert_eq!(
+            CgroupMemorySource::working_set(1000, 300, 0),
+            1000,
+            "no page cache means nothing to exclude"
+        );
+        assert_eq!(
+            CgroupMemorySource::working_set(1000, 300, 100),
+            900,
+            "only the cache that exists is excluded"
+        );
     }
 
     /// Working set excludes reclaimable page cache; a process whose raw usage is

--- a/fusillade/src/daemon/mod.rs
+++ b/fusillade/src/daemon/mod.rs
@@ -518,7 +518,6 @@ where
         let memory_gate = MemoryGate::new(
             config.memory_gate_high_fraction,
             config.memory_gate_low_fraction,
-            config.memory_gate_release_in_flight_fraction,
             Box::new(CgroupMemorySource),
         )
         .map(Arc::new);


### PR DESCRIPTION
Two fixes to the memory gate: it was reading a number well below the process's
real position, and it had a second exit that reopened it at an arbitrary level.
Either one alone lets a pod be killed while the gate reports headroom.

## 1. The reading excluded memory that counts

The gate read `memory.current` less `inactive_file`, on the assumption that
`inactive_file` is page cache and page cache is reclaimable. That assumption
breaks under an allocator that releases pages with `MADV_FREE`. Those pages are
anonymous and stay charged to the cgroup, but the kernel parks them on the
inactive file LRU, so they land in `inactive_file` and get subtracted.

A process holding no page cache at all can therefore report several gigabytes of
`inactive_file`, and the gate reads tens of points of the limit below where the
process actually is. The high mark is never crossed, the gate never engages, and
the container is killed at a reading that looks comfortable.

This is not hypothetical: the divergence between raw usage and the working set
is identically zero on every build using the previous allocator, across days and
across clusters, and appears only on builds using the new one, growing steadily
under sustained load.

The fix is to clamp the exclusion to the page cache the cgroup reports. With no
cache there is nothing to exclude and the reading is the charge the OOM killer
acts on. A process doing real file IO still gets its cache excluded, which is
what reading a working set was for.

## 2. The in-flight exit

The gate is meant to be plain hysteresis: stop claiming at the high mark, resume
under the low mark. The resume never worked under the previous allocator, which
kept freed memory on its free lists rather than returning it to the OS. The
reading behaved as a high-water mark: completing a request did not lower it, so
it stayed pinned above the low mark and the gate never reopened. A pod that
engaged stopped claiming until it was restarted.

The workaround was a second exit that released once in-flight had fallen to a
fraction of its level at engagement. In-flight is the one quantity guaranteed to
fall while claiming is suppressed, so it reliably reopened the gate.

It should go because it reopened the gate at an arbitrary level and held there.
The release threshold was half of whatever happened to be in flight at the
single instant the reading crossed the mark, so the pod settled at a throughput
nobody chose, determined by timing rather than by capacity, and stayed there
until demand fell away.

It also could not be reasoned about. Sizing the headroom above the mark requires
knowing how much memory the already-admitted work will still consume, and that
is a property of the requests rather than of the system: it depends on how much
each one generates, which has varied by orders of magnitude between workloads.
Any fixed fraction is fitted to one workload and wrong for the next.

Worse, it interacts badly with a reading that is too low. An understated reading
means the gate engages late or not at all; the in-flight exit then reopens it
during the overshoot and admits more work on top.

## What changes

- The exclusion of page cache from the reading is clamped to the cache that
  exists.
- The in-flight release, the stored engagement level, and the configuration
  knob are gone.
- Release is now `used > low`, matching the documented design.
- The tests describing the removed behaviour are deleted rather than adapted;
  the contract they covered no longer exists. Two tests cover the clamp.
- The in-flight argument is retained for the ceiling gauge, which is the
  measured per-pod concurrency limit.

## Evidence for removing the in-flight exit

Removing it is safe only if the low mark is reachable, which means freed memory
must actually return to the OS rather than sit in a state that still counts
against the limit.

Measured on a load rig, reading the cgroup charge directly rather than the gauge
this PR corrects. In-flight was driven up until the charge was near the
container limit, pending work was deleted so nothing further could be claimed,
and the drain was sampled every ten seconds.

The charge fell as in-flight drained, and kept falling afterwards, returning to
within a few percent of the pre-run idle level. The bulk came back within one
sampling interval; a residual tail came back a couple of minutes later on the
allocator's slower decay cycle. Both are well inside the timescale a low mark
needs.

The same run reproduced the reading fault. Under load, `inactive_file` climbed
by more than an order of magnitude while the cgroup's actual page cache never
moved, and the old reading understated the real charge by around ten points of
the limit. The gate engaged on a reading that had just crossed its high mark
while the process was already close to the limit. The corrected reading tracked
the real charge to within half a point throughout.

## Risk

If memory retention regresses, the gate stops claiming and stays stopped until
the pod restarts. That is the failure the in-flight exit was hiding, and it is
better surfaced than papered over: the symptom is unambiguous and the cause is
one allocator setting away.

The corrected reading is strictly higher than the old one, so the gate will
engage earlier and more often than it has been. That is the intended effect, but
it means the thresholds now bite at a real position rather than an optimistic
one, and throughput at a given setting will be lower than it appeared to be.
