### PR TITLE
fix(fusillade): retry successful responses with reasoning but no fina…

### DIFF
--- a/fusillade/src/daemon/config.rs
+++ b/fusillade/src/daemon/config.rs
@@ -8,12 +8,73 @@ use crate::http::HttpResponse;
 /// Predicate function to determine if a response should be retried.
 pub type ShouldRetryFn = Arc<dyn Fn(&HttpResponse) -> bool + Send + Sync>;
 
-/// Default retry predicate: retry on server errors, rate limits, timeouts, and not found.
+/// Default retry predicate: retry on server errors, rate limits, timeouts, and not
+/// found, plus successful chat completions that carry reasoning but no final answer.
 pub fn default_should_retry(response: &HttpResponse) -> bool {
-    response.status >= 500
+    if response.status >= 500
         || response.status == 429
         || response.status == 408
         || response.status == 404
+    {
+        return true;
+    }
+    (200..300).contains(&response.status) && is_reasoning_without_answer(&response.body)
+}
+
+/// A completed chat response whose message holds chain-of-thought but no answer:
+/// the engine emitted an end-of-sequence token mid-reasoning, so the whole output
+/// was filed as reasoning and `content` never arrived. The response looks
+/// successful (2xx, `finish_reason: "stop"`) but is useless to the caller, so it
+/// is classified as a failure and retried.
+///
+/// Detection must read the body, not usage counts: some engine builds omit the
+/// reasoning split from the usage frame (`reasoning_tokens: 0` despite real
+/// reasoning), so token-based predicates miss them.
+///
+/// `finish_reason: "length"` is deliberately excluded — hitting a token cap is a
+/// valid outcome under caller-controlled parameters, and retrying it can re-arm
+/// arbitrarily large generations.
+fn is_reasoning_without_answer(body: &str) -> bool {
+    // Non-reasoning responses can never match; skip parsing their bodies.
+    if !body.contains("\"reasoning") {
+        return false;
+    }
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    let Some(choices) = v.get("choices").and_then(|c| c.as_array()) else {
+        return false;
+    };
+    choices.iter().any(|choice| {
+        if choice.get("finish_reason").and_then(|f| f.as_str()) != Some("stop") {
+            return false;
+        }
+        let Some(message) = choice.get("message") else {
+            return false;
+        };
+        // A tool invocation is a complete answer with legitimately empty content.
+        let has_tool_calls = message
+            .get("tool_calls")
+            .and_then(|t| t.as_array())
+            .is_some_and(|t| !t.is_empty())
+            || message.get("function_call").is_some_and(|f| !f.is_null());
+        if has_tool_calls {
+            return false;
+        }
+        let has_reasoning = ["reasoning_content", "reasoning"].iter().any(|key| {
+            message
+                .get(key)
+                .and_then(|r| r.as_str())
+                .is_some_and(|r| !r.is_empty())
+        });
+        let no_answer = match message.get("content") {
+            None | Some(serde_json::Value::Null) => true,
+            Some(serde_json::Value::String(s)) => s.is_empty(),
+            // Structured content parts are an answer even when unusual.
+            Some(_) => false,
+        };
+        has_reasoning && no_answer
+    })
 }
 
 fn default_should_retry_fn() -> ShouldRetryFn {
@@ -704,6 +765,91 @@ mod tests {
 
         for status in [200, 400, 401, 403, 422, 498, 499] {
             assert!(!default_should_retry(&response(status, "")));
+        }
+    }
+
+    /// Builds a 2xx chat-completion body with the given message fields spliced in.
+    fn chat_completion(finish_reason: &str, message_fields: &str) -> String {
+        format!(
+            r#"{{"id":"cmpl-1","object":"chat.completion","choices":[{{"index":0,"finish_reason":"{finish_reason}","message":{{"role":"assistant"{message_fields}}}}}],"usage":{{"prompt_tokens":10,"completion_tokens":5}}}}"#
+        )
+    }
+
+    #[test]
+    fn reasoning_without_answer_is_retriable() {
+        // The premature end-of-sequence shape: reasoning present, content never
+        // arrived (absent, null, or empty) — regardless of which reasoning field
+        // the serving stack uses.
+        for message in [
+            r#","reasoning_content":"We need to assess the headnotes...""#,
+            r#","reasoning_content":"We need to assess...","content":null"#,
+            r#","reasoning_content":"We need to assess...","content":"""#,
+            r#","reasoning":"We need to assess...""#,
+        ] {
+            let body = chat_completion("stop", message);
+            assert!(
+                default_should_retry(&response(200, &body)),
+                "expected retry for {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn reasoning_with_answer_is_not_retriable() {
+        let body = chat_completion(
+            "stop",
+            r#","reasoning_content":"We need to assess...","content":"Headnote 1: ...""#,
+        );
+        assert!(!default_should_retry(&response(200, &body)));
+    }
+
+    #[test]
+    fn tool_calls_with_empty_content_are_not_retriable() {
+        // Tool invocations legitimately return no content alongside reasoning.
+        for message in [
+            r#","reasoning_content":"I should call the tool...","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"f","arguments":"{}"}}]"#,
+            r#","reasoning_content":"I should call the tool...","function_call":{"name":"f","arguments":"{}"}"#,
+        ] {
+            let body = chat_completion("stop", message);
+            assert!(
+                !default_should_retry(&response(200, &body)),
+                "expected no retry for {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn length_capped_reasoning_is_not_retriable() {
+        // Exhausting the caller's token budget mid-reasoning is the caller's
+        // signal to handle (finish_reason "length"), not a retriable fault.
+        let body = chat_completion("length", r#","reasoning_content":"We need to assess...""#);
+        assert!(!default_should_retry(&response(200, &body)));
+    }
+
+    #[test]
+    fn empty_content_without_reasoning_is_not_retriable() {
+        let body = chat_completion("stop", r#","content":"""#);
+        assert!(!default_should_retry(&response(200, &body)));
+    }
+
+    #[test]
+    fn structured_content_counts_as_an_answer() {
+        let body = chat_completion(
+            "stop",
+            r#","reasoning_content":"We need to assess...","content":[{"type":"text","text":"answer"}]"#,
+        );
+        assert!(!default_should_retry(&response(200, &body)));
+    }
+
+    #[test]
+    fn unparseable_or_non_chat_bodies_are_not_retriable() {
+        for body in [
+            "not json at all",
+            r#"{"reasoning_content":"orphaned"}"#,
+            r#"{"object":"list","data":[],"note":"reasoning"}"#,
+            r#"data: {"choices":[{"delta":{"reasoning_content":"sse frame"}}]}"#,
+        ] {
+            assert!(!default_should_retry(&response(200, body)));
         }
     }
 


### PR DESCRIPTION
…l answer

Under load, reasoning models occasionally emit an end-of-sequence token mid-reasoning: the response completes as a 2xx with finish_reason "stop", everything the model produced filed under reasoning_content, and no content field. The response looks successful but carries no answer, so it reached batch output files as-is.

Classify that shape as retriable in the default predicate. Detection reads the response body rather than usage counts, because some engine builds omit the reasoning split from the usage frame (reasoning_tokens: 0 despite real reasoning). Tool-call responses (legitimately empty content) and finish_reason "length" (caller-controlled token budget, retrying can re-arm arbitrarily large generations) are deliberately excluded.

Retriable 200s surface in fusillade_http_status_retriable_total with status="200", which is the signal to watch after deploy.