### PR TITLE
fix(dwctl): point unknown-API-key 401s at the regional-endpoints docs

### DIFF
--- a/dwctl/src/api/handlers/ai_models.rs
+++ b/dwctl/src/api/handlers/ai_models.rs
@@ -178,9 +178,11 @@ pub async fn list_ai_models<P: PoolProvider>(
     .map_err(|e| database_error("lookup_api_key", e))?;
 
     let Some(user_id) = user_id else {
+        // See INVALID_API_KEY_MESSAGE: a wrong-region key looks identical to an
+        // invalid one, so the copy nudges users to check their regional endpoint.
         return Err(openai_error(
             StatusCode::UNAUTHORIZED,
-            "Invalid API key",
+            crate::errors::INVALID_API_KEY_MESSAGE,
             "authentication_error",
             "invalid_api_key",
         ));

--- a/dwctl/src/auth/current_user.rs
+++ b/dwctl/src/auth/current_user.rs
@@ -719,12 +719,12 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
         } else {
             debug!("Authentication failed: invalid credentials");
             trace!("All authentication attempts failed ({}): {:?}", auth_errors.len(), auth_errors);
-            // Surface the most specific failure message rather than the generic
-            // "Authentication required" fallback. API-key auth is attempted (and
-            // therefore pushed) first, so an unknown bearer key surfaces its
-            // region-aware copy even when other credentials also failed.
-            let message = auth_errors.iter().find_map(|(_, e)| match e {
-                Error::Unauthenticated { message } => message.clone(),
+            // Surface the API-key failure copy (the region-aware invalid-key
+            // message) rather than the generic "Authentication required"
+            // fallback. Scoped to the API-key method so the other auth
+            // methods' responses stay byte-identical.
+            let message = auth_errors.iter().find_map(|(method, e)| match e {
+                Error::Unauthenticated { message } if *method == "API key" => message.clone(),
                 _ => None,
             });
             Err(Error::Unauthenticated { message })

--- a/dwctl/src/auth/current_user.rs
+++ b/dwctl/src/auth/current_user.rs
@@ -719,7 +719,15 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
         } else {
             debug!("Authentication failed: invalid credentials");
             trace!("All authentication attempts failed ({}): {:?}", auth_errors.len(), auth_errors);
-            Err(Error::Unauthenticated { message: None })
+            // Surface the most specific failure message rather than the generic
+            // "Authentication required" fallback. API-key auth is attempted (and
+            // therefore pushed) first, so an unknown bearer key surfaces its
+            // region-aware copy even when other credentials also failed.
+            let message = auth_errors.iter().find_map(|(_, e)| match e {
+                Error::Unauthenticated { message } => message.clone(),
+                _ => None,
+            });
+            Err(Error::Unauthenticated { message })
         }
     }
 }

--- a/dwctl/src/auth/current_user.rs
+++ b/dwctl/src/auth/current_user.rs
@@ -396,7 +396,7 @@ async fn try_api_key_auth(parts: &axum::http::request::Parts, db: &PgPool) -> Op
         Some(data) => data,
         None => {
             return Some(Err(Error::Unauthenticated {
-                message: Some("Invalid API key".to_string()),
+                message: Some(crate::errors::INVALID_API_KEY_MESSAGE.to_string()),
             }));
         }
     };

--- a/dwctl/src/errors.rs
+++ b/dwctl/src/errors.rs
@@ -75,6 +75,15 @@ use thiserror::Error as ThisError;
 /// when the database connection pool is exhausted.
 const POOL_EXHAUSTED_RETRY_AFTER_SECS: &str = "30";
 
+/// Message returned when a bearer API key is not recognised.
+///
+/// API keys are region-bound but carry no region prefix, so a key from the
+/// account's other-region endpoint is indistinguishable from an invalid one.
+/// The copy stays generic (no endpoint URLs enumerated) and points at the
+/// regional-endpoints docs page so users check their base URL before
+/// concluding the key itself is bad.
+pub const INVALID_API_KEY_MESSAGE: &str = "Invalid API key. API keys are region-bound: if you expected this key to work, check that your base URL matches the region the key was created in. See https://docs.doubleword.ai/inference-api/regional-endpoints";
+
 #[derive(ThisError, Debug)]
 pub enum Error {
     /// Authentication required but not provided

--- a/dwctl/src/openapi/ai.rs
+++ b/dwctl/src/openapi/ai.rs
@@ -332,7 +332,7 @@ Errors follow the OpenAI format with `error.message`, `error.type`, and `error.c
 ```json
 {
   \"error\": {
-    \"message\": \"Invalid API key\",
+    \"message\": \"Invalid API key. API keys are region-bound: if you expected this key to work, check that your base URL matches the region the key was created in. See https://docs.doubleword.ai/inference-api/regional-endpoints\",
     \"type\": \"authentication_error\",
     \"code\": \"invalid_api_key\"
   }

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -1905,6 +1905,32 @@ mod openapi_access_control {
             !text.contains("api.doubleword.ai"),
             "401 copy must not enumerate regional base URLs"
         );
+        assert!(
+            !text.contains("api.us.doubleword.ai"),
+            "401 copy must not enumerate regional base URLs"
+        );
+    }
+
+    #[sqlx::test]
+    async fn ai_spec_error_example_matches_live_copy(pool: PgPool) {
+        let (server, _bg) = make_app_with_admin_docs(pool.clone(), true).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+        let headers = add_auth_headers(&user);
+
+        let response = server
+            .get("/ai/openapi.json")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await;
+        assert_eq!(response.status_code().as_u16(), 200);
+
+        // The documented error example in the AI spec description is a separate
+        // string literal; keep it from drifting away from the live 401 copy.
+        let text = response.text();
+        assert!(
+            text.contains(crate::errors::INVALID_API_KEY_MESSAGE),
+            "AI OpenAPI description should embed the live invalid-API-key copy"
+        );
     }
 
     #[sqlx::test]

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -572,8 +572,14 @@ async fn ai_models_unknown_key_401_points_at_regional_endpoints_docs(pool: PgPoo
     // without enumerating regional API base URLs in the error body.
     let message = body["error"]["message"].as_str().unwrap();
     assert!(message.contains("https://docs.doubleword.ai/inference-api/regional-endpoints"));
-    assert!(!message.contains("api.doubleword.ai"), "401 copy must not enumerate regional base URLs");
-    assert!(!message.contains("api.us.doubleword.ai"), "401 copy must not enumerate regional base URLs");
+    assert!(
+        !message.contains("api.doubleword.ai"),
+        "401 copy must not enumerate regional base URLs"
+    );
+    assert!(
+        !message.contains("api.us.doubleword.ai"),
+        "401 copy must not enumerate regional base URLs"
+    );
 }
 
 async fn assert_usage_recorded(fixture: &StreamingFixture, expected_uri: &str, prompt_tokens: i64, completion_tokens: i64) {
@@ -1895,7 +1901,10 @@ mod openapi_access_control {
             text.contains(crate::errors::INVALID_API_KEY_MESSAGE),
             "unknown-key 401 should carry the regional-endpoints copy, got: {text}"
         );
-        assert!(!text.contains("api.doubleword.ai"), "401 copy must not enumerate regional base URLs");
+        assert!(
+            !text.contains("api.doubleword.ai"),
+            "401 copy must not enumerate regional base URLs"
+        );
     }
 
     #[sqlx::test]

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -549,6 +549,33 @@ async fn ai_models_supports_optional_group_and_realtime_filters(pool: PgPool) {
     assert_eq!(invalid_capabilities_response.status_code(), 400);
 }
 
+#[sqlx::test]
+async fn ai_models_unknown_key_401_points_at_regional_endpoints_docs(pool: PgPool) {
+    let config = crate::test::utils::create_test_config();
+    let app = crate::Application::new_with_pool(config, Some(pool.clone()), None)
+        .await
+        .expect("Failed to create application");
+    let (server, _bg_services) = app.into_test_server();
+
+    let response = server
+        .get("/ai/v1/models")
+        .add_header("authorization", "Bearer not-a-real-key")
+        .await;
+    assert_eq!(response.status_code(), 401);
+
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["error"]["type"], "authentication_error");
+    assert_eq!(body["error"]["code"], "invalid_api_key");
+    assert_eq!(body["error"]["message"], crate::errors::INVALID_API_KEY_MESSAGE);
+
+    // The copy stays generic: it must point at the regional-endpoints docs page
+    // without enumerating regional API base URLs in the error body.
+    let message = body["error"]["message"].as_str().unwrap();
+    assert!(message.contains("https://docs.doubleword.ai/inference-api/regional-endpoints"));
+    assert!(!message.contains("api.doubleword.ai"), "401 copy must not enumerate regional base URLs");
+    assert!(!message.contains("api.us.doubleword.ai"), "401 copy must not enumerate regional base URLs");
+}
+
 async fn assert_usage_recorded(fixture: &StreamingFixture, expected_uri: &str, prompt_tokens: i64, completion_tokens: i64) {
     let mut tries = 0;
     // The batcher flush folds the balance in the same transaction that
@@ -1848,6 +1875,27 @@ mod openapi_access_control {
         let (server, _bg) = make_app_with_admin_docs(pool, true).await;
         let response = server.get("/ai/openapi.json").await;
         assert_eq!(response.status_code().as_u16(), 401);
+    }
+
+    #[sqlx::test]
+    async fn unknown_bearer_key_401_points_at_regional_endpoints_docs(pool: PgPool) {
+        let (server, _bg) = make_app_with_admin_docs(pool, true).await;
+
+        // The CurrentUser extractor rejects unknown bearer keys for every
+        // dwctl-authenticated surface; the copy must nudge users to check
+        // their regional endpoint without enumerating base URLs.
+        let response = server
+            .get("/ai/openapi.json")
+            .add_header("authorization", "Bearer not-a-real-key")
+            .await;
+        assert_eq!(response.status_code().as_u16(), 401);
+
+        let text = response.text();
+        assert!(
+            text.contains(crate::errors::INVALID_API_KEY_MESSAGE),
+            "unknown-key 401 should carry the regional-endpoints copy, got: {text}"
+        );
+        assert!(!text.contains("api.doubleword.ai"), "401 copy must not enumerate regional base URLs");
     }
 
     #[sqlx::test]


### PR DESCRIPTION
## What

Rewrites the `Invalid API key` 401 copy so a key rejected because it was created in the other region no longer reads as "your key is broken". The message now suggests checking that the request's base URL matches the region the key was created in, and links the regional-endpoints docs page:

> Invalid API key. API keys are region-bound: if you expected this key to work, check that your base URL matches the region the key was created in. See https://docs.doubleword.ai/inference-api/regional-endpoints

Status code (401) and error schema (`authentication_error` / `invalid_api_key`) are unchanged.

## Where

- `dwctl/src/errors.rs`: new shared `INVALID_API_KEY_MESSAGE` constant so the copy cannot drift between surfaces.
- `dwctl/src/api/handlers/ai_models.rs`: the `GET /ai/v1/models` unknown-key 401 (the first endpoint people hit when smoke-testing a key).
- `dwctl/src/auth/current_user.rs`: the `CurrentUser` extractor's unknown-bearer-key rejection, which gates every other dwctl-authenticated surface. The extractor previously accumulated per-method auth errors but always returned a message-less generic 401 ("Authentication required"), so the specific copy never reached the client; it now propagates the first specific failure message (API-key auth is attempted first).
- `dwctl/src/openapi/ai.rs`: the documented error example, kept in sync with the live copy.

The realtime proxy path (onwards) is deliberately untouched: it rejects unknown keys with a 403 key-set miss, so changing it would not be a copy-only 401 change.

## Notes

The error body intentionally does **not** enumerate regional base URLs — it stays generic and defers to the docs page, which pairs each key with its base URL. The docs page ships in doublewordai/documentation#58 (held until release).

Tests assert the new copy on both surfaces and that no regional API base URL appears in the error body.

COR-585