### PR TITLE
test(dwctl): pin the client stream and make the marker test real

### DIFF
--- a/dwctl/src/inference/engine/dispatch_processor.rs
+++ b/dwctl/src/inference/engine/dispatch_processor.rs
@@ -81,6 +81,11 @@ impl DispatchProcessor {
         self
     }
 
+    /// Whether a dispatch to this path is marked for streaming and reassembly.
+    fn should_mark(&self, path: &str) -> bool {
+        self.streamable_endpoints.iter().any(|e| e == path)
+    }
+
     /// Wire in the keystore so ZDR request bodies are decrypted before dispatch.
     pub fn with_keystore(mut self, keystore: Option<crate::keystore::Keystore>) -> Self {
         self.keystore = keystore;
@@ -337,7 +342,7 @@ where
         // request never reaches this processor, so marking here is exactly the
         // signal the edge needs - and without it a streaming client on a
         // configured path has its stream collapsed into a single body.
-        if self.streamable_endpoints.iter().any(|e| e == &request.data.path) {
+        if self.should_mark(&request.data.path) {
             request
                 .data
                 .batch_metadata
@@ -360,31 +365,28 @@ mod tests {
     /// Nothing else distinguishes a daemon dispatch from a client's own request
     /// there, so this is the producing half of that contract; the edge's half is
     /// tested in `crate::inference::outbound_request`.
-    fn mark(processor: &DispatchProcessor, path: &str) -> Option<String> {
-        let mut metadata = std::collections::HashMap::new();
-        if processor.streamable_endpoints.iter().any(|e| e == path) {
-            metadata.insert(crate::inference::outbound_request::STREAM_MARKER_KEY.to_string(), "1".to_string());
-        }
-        metadata.get(crate::inference::outbound_request::STREAM_MARKER_KEY).cloned()
+    ///
+    /// These call the same predicate `process` does rather than restating the
+    /// condition: a test that re-implements what it checks passes whether or not
+    /// the production path ever runs it.
+    fn processor() -> DispatchProcessor {
+        DispatchProcessor::new().with_streamable_endpoints(vec!["/v1/chat/completions".to_string()])
     }
 
     #[test]
     fn a_streamable_path_is_marked() {
-        let processor = DispatchProcessor::new().with_streamable_endpoints(vec!["/v1/chat/completions".to_string()]);
-        assert_eq!(mark(&processor, "/v1/chat/completions").as_deref(), Some("1"));
+        assert!(processor().should_mark("/v1/chat/completions"));
     }
 
     #[test]
     fn a_path_that_is_not_streamable_is_left_unmarked() {
-        let processor = DispatchProcessor::new().with_streamable_endpoints(vec!["/v1/chat/completions".to_string()]);
-        assert_eq!(mark(&processor, "/v1/embeddings"), None);
+        assert!(!processor().should_mark("/v1/embeddings"));
     }
 
     /// With nothing configured the daemon marks nothing, so the edge reassembles
     /// nothing. A misconfiguration costs usage reporting, never a client's stream.
     #[test]
     fn no_configuration_marks_nothing() {
-        let processor = DispatchProcessor::new();
-        assert_eq!(mark(&processor, "/v1/chat/completions"), None);
+        assert!(!DispatchProcessor::new().should_mark("/v1/chat/completions"));
     }
 }

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -621,6 +621,61 @@ async fn cleanup_fixture(fixture: StreamingFixture) {
     fixture.bg_services.shutdown().await;
 }
 
+/// A client asking for a stream must receive one, through the whole app.
+///
+/// This is the regression that shipped: the edge decided to reassemble from a
+/// header it stamps on every inbound request, so a client's `stream: true` came
+/// back as one `chat.completion` object. Nothing at this level covered it - both
+/// streaming fixtures sent the daemon's headers, so both took the daemon's path.
+#[sqlx::test]
+#[test_log::test]
+async fn test_e2e_ai_proxy_client_stream_is_not_reassembled(pool: PgPool) {
+    let mock_server = wiremock::MockServer::start().await;
+    let sse_response = "data: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1677652288,\"model\":\"gpt-3.5-turbo\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hello!\"}}],\"usage\":null}\n\ndata: [DONE]\n\n";
+
+    wiremock::Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(body_partial_json(serde_json::json!({ "stream": true })))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw(sse_response, "text/event-stream"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let fixture = setup_streaming_fixture(&pool, format!("{}/v1", mock_server.uri()), "gpt-3.5-turbo", "test-model").await;
+
+    // No daemon headers at all: this is a client, and the client asked to stream.
+    let inference_response = fixture
+        .server
+        .post("/ai/v1/chat/completions")
+        .add_header("authorization", format!("Bearer {}", fixture.api_key))
+        .json(&serde_json::json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello from E2E test"}],
+            "stream": true
+        }))
+        .await;
+
+    assert_eq!(inference_response.status_code().as_u16(), 200);
+    let content_type = inference_response
+        .headers()
+        .get("content-type")
+        .map_or("", |v| v.to_str().unwrap_or_default())
+        .to_string();
+    assert!(
+        content_type.starts_with("text/event-stream"),
+        "a client that asked to stream must not be handed an assembled body, got {content_type:?}"
+    );
+    assert!(
+        inference_response.text().starts_with("data:"),
+        "the frames themselves must reach the client"
+    );
+
+    cleanup_fixture(fixture).await;
+}
+
 #[sqlx::test]
 #[test_log::test]
 async fn test_e2e_ai_proxy_streaming_chat_completions_with_fusillade_header(pool: PgPool) {


### PR DESCRIPTION
Two gaps raised in review on #1538.

## The dispatch-processor tests were a tautology

They re-implemented the marking condition inside the test rather than calling
it, so they passed whether or not `process` ever inserted the mark. The
condition is now `should_mark`, used by both `process` and the tests.

## No end-to-end test for a plain client stream

That is the case that regressed, and nothing at this level covered it. Both
streaming fixtures sent the daemon's headers, so both took the daemon's path,
and the client case existed only in a unit test built from hand-made request
parts. The bug lived exactly in the gap between the two.

The new test uses the existing `setup_streaming_fixture`, sends no daemon
headers, and asserts the response is `text/event-stream` and that the frames
reach the caller. It fails against 11.0.0, where the same request came back as
a single `chat.completion` object.

## Note

The local database was down when this was pushed, so the new test is verified
by compile and by CI rather than by a local run.