### PR TITLE
feat(prefix_chain): content-free prompt-structure capture to ClickHouse

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -498,35 +498,19 @@ cache:
 # completions pool, splicing the result into the client's still-open stream with
 # merged billing. Per-model activation is DATA, not config: a model rescues only
 # when its composite carries a completions pool with an enabled member.
-# ClickHouse warehouse connection, shared by every feature that writes analytics
-# records directly to ClickHouse (none in local dev). Absent = no such feature may be
-# enabled; present = must be complete, or startup fails. Table names and flush cadence
-# live on the writing feature's own section. In deployments the password comes from a
-# Kubernetes secret as DWCTL_CLICKHOUSE__PASSWORD.
+# ClickHouse warehouse connection (unused in local dev). Required by prefix_chain.
 # clickhouse:
-#   endpoint_url: "https://<service>.eu-west-2.aws.clickhouse.cloud:8443"
+#   endpoint_url: "https://<service>.<region>.aws.clickhouse.cloud:8443"
 #   database: "clay"
 #   user: "dwctl"
 #   password: ""
-#   request_timeout: 30s
 
-# Prefix-chain capture (workload profiling). Per chat-completions request, a chain of
-# keyed hashes of the prompt's content blocks plus per-block token counts, written to
-# ClickHouse. No content is stored. Needs the `clickhouse` section and cache.tokenizer_url.
-# Semantics: `enabled: false` is the only off state. `models: null` captures every model;
-# a non-empty list captures exactly those aliases; an empty list is a startup error.
+# Prefix-chain capture: per chat-completions request, keyed hashes of the prompt's
+# content blocks plus per-block token counts, written to ClickHouse. No content.
 prefix_chain:
   enabled: false
-  models: null
-  # 32 bytes, hex (64 chars). From a Kubernetes secret as DWCTL_PREFIX_CHAIN__HMAC_KEY.
-  hmac_key: ""
-  key_version: 1
-  table: "prompt_chains"
-  flush_interval: 5s
-  max_batch_rows: 5000
-  queue_capacity: 20000
-  retry_delay: 500ms
-  max_in_flight: 256
+  models: null # null: every model; a non-empty list: exactly those aliases
+  hmac_key: "" # 32 bytes, hex; from a secret as DWCTL_PREFIX_CHAIN__HMAC_KEY
 
 continuation:
   # Global kill switch. When false (default), the layer is not added to the

--- a/config.yaml
+++ b/config.yaml
@@ -510,6 +510,23 @@ cache:
 #   password: ""
 #   request_timeout: 30s
 
+# Prefix-chain capture (workload profiling). Per chat-completions request, a chain of
+# keyed hashes of the prompt's content blocks plus per-block token counts, written to
+# ClickHouse. No content is stored. Needs the `clickhouse` section and cache.tokenizer_url.
+# Semantics: `enabled: false` is the only off state. `models: null` captures every model;
+# a non-empty list captures exactly those aliases; an empty list is a startup error.
+prefix_chain:
+  enabled: false
+  models: null
+  # 32 bytes, hex (64 chars). From a Kubernetes secret as DWCTL_PREFIX_CHAIN__HMAC_KEY.
+  hmac_key: ""
+  key_version: 1
+  table: "prompt_chains"
+  flush_interval: 5s
+  max_batch_rows: 5000
+  queue_capacity: 20000
+  retry_delay: 500ms
+
 continuation:
   # Global kill switch. When false (default), the layer is not added to the
   # stack and the request path is byte-identical to a build without it.

--- a/config.yaml
+++ b/config.yaml
@@ -526,6 +526,7 @@ prefix_chain:
   max_batch_rows: 5000
   queue_capacity: 20000
   retry_delay: 500ms
+  max_in_flight: 256
 
 continuation:
   # Global kill switch. When false (default), the layer is not added to the

--- a/dwctl/src/clickhouse/mod.rs
+++ b/dwctl/src/clickhouse/mod.rs
@@ -34,9 +34,8 @@ fn default_database() -> String {
     "clay".to_string()
 }
 
-fn default_request_timeout() -> Duration {
-    Duration::from_secs(30)
-}
+/// Per-insert HTTP timeout. ClickHouse Cloud services can idle and take seconds to wake.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// The top-level `clickhouse` config section: connection and credential only.
 ///
@@ -56,10 +55,6 @@ pub struct ClickhouseConfig {
     pub user: String,
     /// Password. `DWCTL_CLICKHOUSE__PASSWORD` in deployments.
     pub password: String,
-    /// Per-insert HTTP timeout. ClickHouse Cloud services can idle and take seconds to
-    /// wake, so keep this generous; the sink is off the request path anyway.
-    #[serde(default = "default_request_timeout", with = "humantime_serde")]
-    pub request_timeout: Duration,
 }
 
 impl fmt::Debug for ClickhouseConfig {
@@ -69,7 +64,6 @@ impl fmt::Debug for ClickhouseConfig {
             .field("database", &self.database)
             .field("user", &self.user)
             .field("password", &"<redacted>")
-            .field("request_timeout", &self.request_timeout)
             .finish()
     }
 }
@@ -91,9 +85,6 @@ impl ClickhouseConfig {
         }
         if self.password.is_empty() {
             return Err("clickhouse.password is empty (set DWCTL_CLICKHOUSE__PASSWORD)".to_string());
-        }
-        if self.request_timeout.is_zero() {
-            return Err("clickhouse.request_timeout must be > 0".to_string());
         }
         if url.password().is_some() || !url.username().is_empty() {
             return Err("clickhouse.endpoint_url must not embed credentials; use clickhouse.user and clickhouse.password".to_string());
@@ -166,7 +157,7 @@ impl ClickHouseClient {
         config.validate().map_err(ClickHouseError::Config)?;
         let endpoint = Url::parse(config.endpoint_url.trim()).map_err(|e| ClickHouseError::Config(e.to_string()))?;
         let http = reqwest::Client::builder()
-            .timeout(config.request_timeout)
+            .timeout(REQUEST_TIMEOUT)
             .build()
             .map_err(ClickHouseError::Transport)?;
         Ok(Self {
@@ -247,7 +238,6 @@ mod tests {
             database: default_database(),
             user: "dwctl".to_string(),
             password: "pw".to_string(),
-            request_timeout: default_request_timeout(),
         }
     }
 
@@ -283,13 +273,6 @@ mod tests {
         assert!(!s.contains("s3cret") && !s.contains("alice"), "{s}");
         assert!(c.validate().unwrap_err().contains("embed credentials"));
         assert_eq!(redact_url("not a url"), "<unparseable url>");
-    }
-
-    #[test]
-    fn zero_timeout_is_rejected() {
-        let mut c = config();
-        c.request_timeout = Duration::ZERO;
-        assert!(c.validate().unwrap_err().contains("request_timeout"));
     }
 
     #[test]

--- a/dwctl/src/clickhouse/mod.rs
+++ b/dwctl/src/clickhouse/mod.rs
@@ -1,17 +1,12 @@
-//! ClickHouse Cloud: the shared warehouse connection and a generic best-effort sink.
+//! ClickHouse: the shared warehouse connection and a generic best-effort sink.
 //!
-//! The warehouse (`clay`) is fed mostly by the Neon → ClickHouse CDC pipe. A few
-//! high-volume, derived, analytics-only records are written directly from dwctl instead,
-//! because they are variable-length, never read back by dwctl, and would only add WAL
-//! and storage to the billing database on their way through. This module is the one
-//! connection those writers share ([`ClickHouseClient`], built from the top-level
-//! `clickhouse` config section) and the sink they hang off ([`sink::ClickHouseSink`]).
+//! [`ClickHouseClient`] is built from the top-level `clickhouse` config section and is
+//! shared by every feature that writes analytics records directly to the warehouse;
+//! [`sink::ClickHouseSink`] is the batched writer they hang off.
 //!
-//! Best effort by design. Nothing on the request path waits on it. A full queue drops
-//! the newest rows, a failed insert is retried once and then dropped, and every drop is
-//! counted (`dwctl_clickhouse_dropped_rows_total`). There is no spill and no replay: a
-//! warehouse outage loses that window's records, which is the agreed trade for these
-//! records (2026-09-02).
+//! Best effort by design. Nothing on the request path waits on it. A full queue drops the
+//! newest rows, a failed insert is retried once and then dropped, and every drop is
+//! counted (`dwctl_clickhouse_dropped_rows_total`). There is no spill and no replay.
 //!
 //! Rows land in batches: one `INSERT ... FORMAT JSONEachRow` per flush, gzip-compressed.
 //! ClickHouse's cost is per insert statement (each creates a part), not per row, so the

--- a/dwctl/src/clickhouse/sink.rs
+++ b/dwctl/src/clickhouse/sink.rs
@@ -258,7 +258,6 @@ mod tests {
             database: "clay".into(),
             user: "dwctl".into(),
             password: "pw".into(),
-            request_timeout: Duration::from_secs(5),
         })
         .unwrap()
     }

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -215,6 +215,11 @@ pub struct Config {
     /// on the writing feature's own section. See [`crate::clickhouse::ClickhouseConfig`].
     #[serde(default)]
     pub clickhouse: Option<crate::clickhouse::ClickhouseConfig>,
+    /// Prefix-chain capture for workload profiling: content-free records of prompt
+    /// structure per chat-completions request, written to ClickHouse. Off by default.
+    /// See [`crate::prefix_chain::PrefixChainConfig`].
+    #[serde(default)]
+    pub prefix_chain: crate::prefix_chain::PrefixChainConfig,
     /// Mid-stream continuation (stream resume): the on/off flag, per-origin gates,
     /// and resume-behavior knobs. See [`ContinuationConfig`].
     #[serde(default)]
@@ -2838,6 +2843,7 @@ impl Default for Config {
             openapi: OpenApiConfig::default(),
             cache: CacheConfig::default(),
             clickhouse: None,
+            prefix_chain: crate::prefix_chain::PrefixChainConfig::default(),
             continuation: ContinuationConfig::default(),
         }
     }
@@ -3182,6 +3188,13 @@ impl Config {
             }
         }
 
+        // Prefix-chain capture, when on, needs the warehouse connection, tokenizer-svc and a
+        // usable key — every missing piece is a startup error, never a sink that records nothing.
+        if let Err(e) = self.prefix_chain.validate(self.clickhouse.as_ref(), &self.cache.tokenizer_url) {
+            return Err(Error::Internal {
+                operation: format!("Config validation: {e}"),
+            });
+        }
         // A present `clickhouse` section must be usable: a bad endpoint or a missing
         // password is a startup error, not a sink that fails every insert forever.
         if let Some(ch) = &self.clickhouse

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -3195,16 +3195,6 @@ impl Config {
                 operation: format!("Config validation: {e}"),
             });
         }
-        // Capture rides on the analytics handler; without analytics it would advertise a
-        // sink that never sees a request, which is exactly the silent no-op the section's
-        // semantics rule out.
-        if self.prefix_chain.enabled && !self.enable_analytics {
-            return Err(Error::Internal {
-                operation:
-                    "Config validation: prefix_chain.enabled is true but enable_analytics is false; capture runs in the analytics handler"
-                        .to_string(),
-            });
-        }
         // A present `clickhouse` section must be usable: a bad endpoint or a missing
         // password is a startup error, not a sink that fails every insert forever.
         if let Some(ch) = &self.clickhouse

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -3195,6 +3195,16 @@ impl Config {
                 operation: format!("Config validation: {e}"),
             });
         }
+        // Capture rides on the analytics handler; without analytics it would advertise a
+        // sink that never sees a request, which is exactly the silent no-op the section's
+        // semantics rule out.
+        if self.prefix_chain.enabled && !self.enable_analytics {
+            return Err(Error::Internal {
+                operation:
+                    "Config validation: prefix_chain.enabled is true but enable_analytics is false; capture runs in the analytics handler"
+                        .to_string(),
+            });
+        }
         // A present `clickhouse` section must be usable: a bad endpoint or a missing
         // password is a startup error, not a sink that fails every insert forever.
         if let Some(ch) = &self.clickhouse
@@ -3218,7 +3228,9 @@ impl Config {
         // Cache TTL tiers: every enabled tier must be a known tier (5m/1h/24h), the set must be
         // non-empty, and the default tier must be one of them — otherwise a no-ttl marker would
         // default straight into a rejected tier. Fail fast at startup with a clear message.
-        if self.cache.enabled {
+        // The cache TTL policy is also consumed by prefix-chain capture, which parses with
+        // the same policies whether or not the cache layer is on.
+        if self.cache.enabled || self.prefix_chain.enabled {
             for ttl in &self.cache.enabled_ttls {
                 if crate::prompt_cache::TtlTier::parse(ttl).is_none() {
                     return Err(Error::Internal {

--- a/dwctl/src/db/handlers/api_keys.rs
+++ b/dwctl/src/db/handlers/api_keys.rs
@@ -2614,6 +2614,7 @@ mod tests {
             openapi: Default::default(),
             cache: Default::default(),
             clickhouse: None,
+            prefix_chain: crate::prefix_chain::PrefixChainConfig::default(),
             continuation: Default::default(),
             keystore: None,
         };

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1450,7 +1450,7 @@ fn security_header_pairs(cfg: &crate::config::SecurityHeadersConfig) -> anyhow::
 /// Returns an error if CORS configuration is invalid, a configured security
 /// response header has an invalid value, or metrics initialization fails.
 #[instrument(skip_all)]
-#[allow(clippy::too_many_arguments)] // one optional collaborator per feature; a builder would be more code than the signature
+#[allow(clippy::too_many_arguments)]
 pub async fn build_router(
     state: &mut AppState,
     onwards_router: Router,

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -162,6 +162,7 @@ mod metrics;
 mod notifications;
 mod openapi;
 mod payment_providers;
+pub mod prefix_chain;
 pub mod pricing;
 mod probes;
 pub mod prompt_cache;
@@ -1449,6 +1450,7 @@ fn security_header_pairs(cfg: &crate::config::SecurityHeadersConfig) -> anyhow::
 /// Returns an error if CORS configuration is invalid, a configured security
 /// response header has an invalid value, or metrics initialization fails.
 #[instrument(skip_all)]
+#[allow(clippy::too_many_arguments)] // one optional collaborator per feature; a builder would be more code than the signature
 pub async fn build_router(
     state: &mut AppState,
     onwards_router: Router,
@@ -1457,6 +1459,7 @@ pub async fn build_router(
     metrics_recorder: Option<GenAiMetrics>,
     strict_mode: bool,
     inference_middleware_state: Option<crate::inference::middleware::InferenceMiddlewareState>,
+    prefix_chain: Option<Arc<crate::prefix_chain::PrefixChainRecorder>>,
 ) -> anyhow::Result<Router> {
     let config = state.current_config();
 
@@ -1501,7 +1504,8 @@ pub async fn build_router(
             // parse (the same value request logging stores), via `TokenMetrics::from`.
             // The outlet sits outer to translation, so it captures the foreign
             // response body; `AiResponse` covers each protocol's own shape.
-            let analytics_handler = request_logging::AnalyticsHandler::new(sender, uuid::Uuid::new_v4(), config.as_ref().clone());
+            let analytics_handler = request_logging::AnalyticsHandler::new(sender, uuid::Uuid::new_v4(), config.as_ref().clone())
+                .with_prefix_chain(prefix_chain);
             multi_handler = multi_handler.with(analytics_handler);
         }
 
@@ -2510,6 +2514,8 @@ pub struct BackgroundServices {
     strict_mode: bool,
     /// Sender for analytics records (if analytics is enabled)
     analytics_sender: Option<request_logging::batcher::AnalyticsSender>,
+    /// Prefix-chain recorder (workload profiling), when `prefix_chain.enabled`.
+    prefix_chain: Option<Arc<crate::prefix_chain::PrefixChainRecorder>>,
     /// Sender for completed-response records consumed by the in-process
     /// `RequestsWriter` (replaces the underway response jobs). Always set
     /// once `setup_background_services` runs; `None` only in test harnesses
@@ -3452,6 +3458,46 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         None
     };
 
+    // Prefix-chain capture: a ClickHouse sink task plus the recorder the analytics
+    // handler calls. Config validation already guaranteed the clickhouse section, the
+    // tokenizer URL and the key are present when this is enabled.
+    let prefix_chain = if config.prefix_chain.enabled {
+        let ch_config = config
+            .clickhouse
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("prefix_chain.enabled requires a clickhouse section"))?;
+        let client = crate::clickhouse::ClickHouseClient::from_config(ch_config)?;
+        let (sink_handle, sink) =
+            crate::clickhouse::ClickHouseSink::<crate::prefix_chain::PromptChainRow>::new(client, config.prefix_chain.sink_options())?;
+        let sink_shutdown = shutdown_token.clone();
+        background_tasks.spawn("prefix-chain-sink", async move {
+            sink.run(sink_shutdown).await;
+            Ok(())
+        });
+        let key = config.prefix_chain.key_bytes().map_err(|e| anyhow::anyhow!("prefix_chain: {e}"))?;
+        let recorder = crate::prefix_chain::PrefixChainRecorder::new(
+            key,
+            config.prefix_chain.key_version,
+            crate::prefix_chain::ModelFilter::from_config(&config.prefix_chain.models),
+            crate::prompt_cache::TierPolicy::from_config(&config.cache.enabled_ttls, &config.cache.default_ttl),
+            crate::prompt_cache::TelemetryPolicy::from_config(
+                config.cache.telemetry_blocks.strip_from_prompt,
+                &config.cache.telemetry_blocks.prefixes,
+            ),
+            crate::prompt_cache::TokenizerClient::new(config.cache.tokenizer_url.clone()),
+            crate::prompt_cache::PrincipalResolver::new(pool.clone()),
+            sink_handle,
+        );
+        info!(
+            models = ?config.prefix_chain.models,
+            table = %config.prefix_chain.table,
+            "Prefix-chain capture enabled"
+        );
+        Some(Arc::new(recorder))
+    } else {
+        None
+    };
+
     // Start the responses writer. Replaces the underway create-response /
     // complete-response jobs. Outlet's FusilladeOutletHandler holds the
     // sender; this task drains the channel and flushes to fusillade.
@@ -3511,6 +3557,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         onwards_sender,
         strict_mode: config.onwards.strict_mode,
         analytics_sender,
+        prefix_chain,
         requests_writer_sender,
         background_tasks,
         task_names,
@@ -3881,6 +3928,7 @@ impl Application {
             metrics_recorder,
             bg_services.onwards_targets.strict_mode,
             Some(inference_middleware_state),
+            bg_services.prefix_chain.clone(),
         )
         .await?;
 

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -3487,6 +3487,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
             crate::prompt_cache::TokenizerClient::new(config.cache.tokenizer_url.clone()),
             crate::prompt_cache::PrincipalResolver::new(pool.clone()),
             sink_handle,
+            config.prefix_chain.max_in_flight,
         );
         info!(
             models = ?config.prefix_chain.models,

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -1474,12 +1474,15 @@ pub async fn build_router(
     let request_logging_enabled = state.outlet_db.is_some() && config.enable_request_logging;
     let analytics_enabled = config.enable_analytics;
 
-    let outlet_layer = if request_logging_enabled || analytics_enabled {
+    let outlet_layer = if request_logging_enabled || analytics_enabled || prefix_chain.is_some() {
         // Store the metrics recorder in state (created earlier in Application::new)
         state.metrics_recorder = metrics_recorder;
 
         // Build handler chain based on config
         let mut multi_handler = MultiHandler::new();
+        // One instance id for every handler that writes `(instance_id, correlation_id)`, so
+        // their rows join.
+        let instance_id = uuid::Uuid::new_v4();
 
         // Add PostgresHandler for request logging if enabled
         if request_logging_enabled {
@@ -1504,9 +1507,16 @@ pub async fn build_router(
             // parse (the same value request logging stores), via `TokenMetrics::from`.
             // The outlet sits outer to translation, so it captures the foreign
             // response body; `AiResponse` covers each protocol's own shape.
-            let analytics_handler = request_logging::AnalyticsHandler::new(sender, uuid::Uuid::new_v4(), config.as_ref().clone())
-                .with_prefix_chain(prefix_chain);
+            let analytics_handler = request_logging::AnalyticsHandler::new(sender, instance_id, config.as_ref().clone());
             multi_handler = multi_handler.with(analytics_handler);
+        }
+
+        if let Some(recorder) = prefix_chain {
+            multi_handler = multi_handler.with(crate::prefix_chain::PrefixChainHandler::new(
+                recorder,
+                instance_id,
+                config.as_ref().clone(),
+            ));
         }
 
         // Add FusilladeOutletHandler so completed responses get written to
@@ -3468,7 +3478,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
             .ok_or_else(|| anyhow::anyhow!("prefix_chain.enabled requires a clickhouse section"))?;
         let client = crate::clickhouse::ClickHouseClient::from_config(ch_config)?;
         let (sink_handle, sink) =
-            crate::clickhouse::ClickHouseSink::<crate::prefix_chain::PromptChainRow>::new(client, config.prefix_chain.sink_options())?;
+            crate::clickhouse::ClickHouseSink::<crate::prefix_chain::PromptChainRow>::new(client, crate::prefix_chain::sink_options())?;
         let sink_shutdown = shutdown_token.clone();
         background_tasks.spawn("prefix-chain-sink", async move {
             sink.run(sink_shutdown).await;
@@ -3477,7 +3487,6 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         let key = config.prefix_chain.key_bytes().map_err(|e| anyhow::anyhow!("prefix_chain: {e}"))?;
         let recorder = crate::prefix_chain::PrefixChainRecorder::new(
             key,
-            config.prefix_chain.key_version,
             crate::prefix_chain::ModelFilter::from_config(&config.prefix_chain.models),
             crate::prompt_cache::TierPolicy::from_config(&config.cache.enabled_ttls, &config.cache.default_ttl),
             crate::prompt_cache::TelemetryPolicy::from_config(
@@ -3487,13 +3496,8 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
             crate::prompt_cache::TokenizerClient::new(config.cache.tokenizer_url.clone()),
             crate::prompt_cache::PrincipalResolver::new(pool.clone()),
             sink_handle,
-            config.prefix_chain.max_in_flight,
         );
-        info!(
-            models = ?config.prefix_chain.models,
-            table = %config.prefix_chain.table,
-            "Prefix-chain capture enabled"
-        );
+        info!(models = ?config.prefix_chain.models, "Prefix-chain capture enabled");
         Some(Arc::new(recorder))
     } else {
         None

--- a/dwctl/src/metrics/errors.rs
+++ b/dwctl/src/metrics/errors.rs
@@ -27,6 +27,7 @@ pub mod component {
     pub const ANALYTICS: &str = "analytics";
     pub const ANALYTICS_BATCHER: &str = "analytics_batcher";
     pub const CLICKHOUSE_SINK: &str = "clickhouse_sink";
+    pub const PREFIX_CHAIN: &str = "prefix_chain";
     pub const RESPONSES_WRITER: &str = "responses_writer";
     pub const BATCH_POPULATE: &str = "batch_populate";
     pub const PAYMENTS: &str = "payments";

--- a/dwctl/src/prefix_chain/mod.rs
+++ b/dwctl/src/prefix_chain/mod.rs
@@ -1,27 +1,18 @@
-//! Prefix-chain capture: content-free records of prompt STRUCTURE, per chat-completions
-//! request, written to ClickHouse for workload profiling.
+//! Prefix-chain capture: a content-free record of each chat-completions prompt's
+//! structure, written to ClickHouse.
 //!
-//! Zero-data-retention customers give us no bodies, and the analytics row alone cannot
-//! say which requests share a prefix (a system prompt, a tool set) or how a conversation
-//! grows turn by turn. This module records, per request, a chain of keyed hashes: one per
-//! content block of the prompt in parse order (tool definitions, system, each message,
-//! each tool call), each an HMAC-SHA256 over the cumulative content up to that block,
-//! truncated to 16 bytes. Equal prefixes give equal chain prefixes, so sessions and
-//! shared templates fall out of the data with no content stored; without the key a
-//! leaked table is structure only. Alongside the chain: each block's role and its
-//! token count on its own (tokenizer-svc), so template overhead and per-block sizes are
-//! recoverable, which is what a replay corpus needs.
+//! Per served request: one entry per content block of the prompt in parse order (tool
+//! definitions, system, messages, tool calls), each an HMAC-SHA256 over the cumulative
+//! content up to that block, truncated to 16 bytes and hex-encoded; the block roles; and
+//! each block's own token count from tokenizer-svc. Equal prefixes give equal chain
+//! prefixes, so shared prefixes and multi-turn continuations are recoverable without
+//! storing content, and without the key the table is structure only.
 //!
-//! The block split and the cumulative hashes are the prompt-cache layer's own parser
-//! ([`crate::prompt_cache::parse_chat_completions`]) under the same policies the billing
-//! classifier uses, so a chain entry is exactly `HMAC(prefix_hash)` of what that layer
-//! would index. Nothing here touches the classify path or billing: capture runs in the
-//! outlet analytics handler, after the response, off the request path, and any failure
-//! yields no record and a counter.
-//!
-//! Best effort end to end: the ClickHouse sink drops on a full queue or a twice-failed
-//! insert (see [`crate::clickhouse`]). Design and decisions: notes campaign
-//! `zdr-workload-profiling`, 2026-09-02.
+//! The block split and the cumulative hashes come from the prompt-cache parser
+//! ([`crate::prompt_cache::parse_chat_completions`]) under the same policies the cache
+//! classifier uses. Capture runs in the outlet analytics handler after the response, off
+//! the request path; the classify path is not involved. Any failure yields no record and
+//! a counter. Delivery is best effort (see [`crate::clickhouse`]).
 
 use std::collections::HashSet;
 use std::fmt;
@@ -619,9 +610,9 @@ mod tests {
     #[test]
     fn model_filter_semantics() {
         assert!(ModelFilter::from_config(&None).allows("anything"));
-        let only = ModelFilter::from_config(&Some(vec!["runware-zai/glm-5.2".into()]));
-        assert!(only.allows("runware-zai/glm-5.2"));
-        assert!(!only.allows("Runware-zai/glm-5.2"), "exact, case-sensitive");
+        let only = ModelFilter::from_config(&Some(vec!["vendor/model-a".into()]));
+        assert!(only.allows("vendor/model-a"));
+        assert!(!only.allows("Vendor/model-a"), "exact, case-sensitive");
         assert!(!only.allows("other"));
     }
 

--- a/dwctl/src/prefix_chain/mod.rs
+++ b/dwctl/src/prefix_chain/mod.rs
@@ -30,7 +30,7 @@ use sha2::Sha256;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
-use crate::clickhouse::{ClickhouseConfig, SinkHandle, SinkOptions, is_identifier};
+use crate::clickhouse::{ClickhouseConfig, SinkHandle, SinkOptions};
 use crate::metrics::errors::component::PREFIX_CHAIN;
 use crate::prompt_cache::{
     ParseError, PrincipalResolver, TelemetryPolicy, TierPolicy, TokenizerClient, TokenizerError, parse_chat_completions,
@@ -41,77 +41,29 @@ pub const RECORD_VERSION: u8 = 1;
 /// Bytes of the HMAC kept per chain entry (hex-encoded to 32 characters in the row).
 const HASH_BYTES: usize = 16;
 
-fn default_key_version() -> u8 {
-    1
-}
-fn default_table() -> String {
-    "prompt_chains".to_string()
-}
-fn default_flush_interval() -> Duration {
-    Duration::from_secs(5)
-}
-fn default_max_batch_rows() -> usize {
-    5_000
-}
-fn default_queue_capacity() -> usize {
-    20_000
-}
-fn default_retry_delay() -> Duration {
-    Duration::from_millis(500)
-}
-fn default_max_in_flight() -> usize {
-    256
-}
+/// Table the rows land in; its shape is fixed by the warehouse migration.
+const TABLE: &str = "prompt_chains";
+const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+const MAX_BATCH_ROWS: usize = 5_000;
+const QUEUE_CAPACITY: usize = 20_000;
+const RETRY_DELAY: Duration = Duration::from_millis(500);
+/// Cap on requests whose principal lookup and tokenization are in flight at once; beyond
+/// it a request is skipped (counted `backpressure`) rather than queued holding its prompt.
+const MAX_IN_FLIGHT: usize = 256;
 
 /// The `prefix_chain` config section.
-///
-/// The connection lives on the top-level `clickhouse` section; this holds what is
-/// specific to this writer. The semantics are chosen so that no configuration is a
-/// silent no-op — see [`PrefixChainConfig::validate`].
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct PrefixChainConfig {
-    /// Master switch. `false` is the only off state: no parse, no sink, no records.
+    /// `false` is the only off state.
     pub enabled: bool,
-    /// Which models to capture. `null` / absent: every model. A non-empty list: exactly
-    /// those dwctl aliases, matched exactly and case-sensitively against the alias the
-    /// request resolved to (the string that lands in `http_analytics.model`). An empty
-    /// list is a startup error. Accepts a YAML list or a comma-separated string (env).
+    /// `null`: every model. A non-empty list: exactly these dwctl aliases, matched exactly
+    /// and case-sensitively. An empty list is a startup error. Accepts a YAML list or a
+    /// comma-separated string (env).
     #[serde(deserialize_with = "deserialize_model_list")]
     pub models: Option<Vec<String>>,
     /// 32-byte key, hex-encoded (64 characters). `DWCTL_PREFIX_CHAIN__HMAC_KEY`.
     pub hmac_key: String,
-    /// Recorded on every row so chains under different keys are never joined.
-    pub key_version: u8,
-    /// Table within the `clickhouse` section's database.
-    pub table: String,
-    #[serde(with = "humantime_serde")]
-    pub flush_interval: Duration,
-    pub max_batch_rows: usize,
-    pub queue_capacity: usize,
-    #[serde(with = "humantime_serde")]
-    pub retry_delay: Duration,
-    /// Cap on requests whose principal lookup and tokenization are in flight at once.
-    /// Beyond it, new requests are skipped (counted `backpressure`) rather than queued,
-    /// so a slow tokenizer-svc bounds memory instead of growing a backlog of prompts.
-    pub max_in_flight: usize,
-}
-
-impl Default for PrefixChainConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            models: None,
-            hmac_key: String::new(),
-            key_version: default_key_version(),
-            table: default_table(),
-            flush_interval: default_flush_interval(),
-            max_batch_rows: default_max_batch_rows(),
-            queue_capacity: default_queue_capacity(),
-            retry_delay: default_retry_delay(),
-            max_in_flight: default_max_in_flight(),
-        }
-    }
 }
 
 impl fmt::Debug for PrefixChainConfig {
@@ -120,13 +72,6 @@ impl fmt::Debug for PrefixChainConfig {
             .field("enabled", &self.enabled)
             .field("models", &self.models)
             .field("hmac_key", &if self.hmac_key.is_empty() { "<unset>" } else { "<redacted>" })
-            .field("key_version", &self.key_version)
-            .field("table", &self.table)
-            .field("flush_interval", &self.flush_interval)
-            .field("max_batch_rows", &self.max_batch_rows)
-            .field("queue_capacity", &self.queue_capacity)
-            .field("retry_delay", &self.retry_delay)
-            .field("max_in_flight", &self.max_in_flight)
             .finish()
     }
 }
@@ -149,52 +94,53 @@ fn deserialize_model_list<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<
 }
 
 impl PrefixChainConfig {
-    /// The rules that keep this from being a silent no-op:
-    /// - `enabled: false` ignores everything else.
-    /// - `enabled: true` requires the `clickhouse` section, a tokenizer-svc URL, a
-    ///   well-formed key, a non-empty `models` list if one is given, and sane sink sizes.
+    /// `enabled: false` ignores everything else. `enabled: true` requires the `clickhouse`
+    /// section, a tokenizer-svc URL, a 32-byte key, and a non-empty `models` list if one
+    /// is given.
     pub fn validate(&self, clickhouse: Option<&ClickhouseConfig>, tokenizer_url: &str) -> Result<(), String> {
         if !self.enabled {
             return Ok(());
         }
         if clickhouse.is_none() {
-            return Err("prefix_chain.enabled is true but there is no clickhouse section; add one (endpoint_url, user, password) or set prefix_chain.enabled: false".to_string());
+            return Err("prefix_chain.enabled is true but there is no clickhouse section".to_string());
         }
         if tokenizer_url.trim().is_empty() {
-            return Err("prefix_chain.enabled is true but cache.tokenizer_url is empty; per-block token counts need tokenizer-svc (set DWCTL_CACHE__TOKENIZER_URL)".to_string());
+            return Err("prefix_chain.enabled is true but cache.tokenizer_url is empty".to_string());
         }
         self.key_bytes()?;
         if let Some(models) = &self.models
             && models.is_empty()
         {
-            return Err("prefix_chain.models is an empty list: an armed sink that records nothing is indistinguishable from a broken one. Omit models to capture every model, or set prefix_chain.enabled: false".to_string());
+            return Err(
+                "prefix_chain.models is an empty list; omit it to capture every model, or set prefix_chain.enabled: false".to_string(),
+            );
         }
-        if !is_identifier(&self.table) {
-            return Err(format!("prefix_chain.table {:?} is not a plain identifier", self.table));
-        }
-        if self.max_in_flight == 0 {
-            return Err("prefix_chain.max_in_flight must be > 0".to_string());
-        }
-        self.sink_options().validate().map_err(|e| format!("prefix_chain: {e}"))
+        Ok(())
     }
 
-    /// Decode the hex key. 32 bytes exactly: a shorter key is a typo, a longer one is
-    /// probably the wrong secret.
     pub fn key_bytes(&self) -> Result<[u8; 32], String> {
-        let raw = hex::decode(self.hmac_key.trim())
-            .map_err(|_| "prefix_chain.hmac_key is not hex (expected 64 hex characters, DWCTL_PREFIX_CHAIN__HMAC_KEY)".to_string())?;
+        let raw =
+            hex::decode(self.hmac_key.trim()).map_err(|_| "prefix_chain.hmac_key is not hex (expected 64 hex characters)".to_string())?;
         <[u8; 32]>::try_from(raw).map_err(|v| format!("prefix_chain.hmac_key decodes to {} bytes, expected 32", v.len()))
     }
+}
 
-    pub fn sink_options(&self) -> SinkOptions {
-        SinkOptions {
-            table: self.table.clone(),
-            flush_interval: self.flush_interval,
-            max_batch_rows: self.max_batch_rows,
-            queue_capacity: self.queue_capacity,
-            retry_delay: self.retry_delay,
-        }
+/// Sink settings for the chain table.
+pub fn sink_options() -> SinkOptions {
+    SinkOptions {
+        table: TABLE.to_string(),
+        flush_interval: FLUSH_INTERVAL,
+        max_batch_rows: MAX_BATCH_ROWS,
+        queue_capacity: QUEUE_CAPACITY,
+        retry_delay: RETRY_DELAY,
     }
+}
+
+/// Which key produced a chain: the first byte of SHA-256 over the key. Rows stamped with
+/// different ids never join, and nobody has to remember to bump a version on rotation.
+pub fn key_id(key: &[u8; 32]) -> u8 {
+    use sha2::Digest as _;
+    sha2::Sha256::digest(key)[0]
 }
 
 /// Which models the recorder captures. Built from `prefix_chain.models`.
@@ -236,6 +182,7 @@ pub struct PromptChainRow {
     /// Empty when the model is unmapped on tokenizer-svc or the call failed.
     pub block_tokens: Vec<u32>,
     pub tokenizer_version: String,
+    /// See [`key_id`]; stored in the `key_version` column.
     pub key_version: u8,
     pub v: u8,
 }
@@ -309,20 +256,18 @@ impl ChainHasher {
 
 pub struct PrefixChainRecorder {
     hasher: ChainHasher,
-    key_version: u8,
+    key_id: u8,
     filter: ModelFilter,
     tokenizer: TokenizerClient,
     principal: PrincipalResolver,
     sink: SinkHandle<PromptChainRow>,
-    /// Bounds the spawned tail (principal lookup, tokenization, send). See
-    /// `PrefixChainConfig::max_in_flight`.
     in_flight: Arc<Semaphore>,
 }
 
 impl fmt::Debug for PrefixChainRecorder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PrefixChainRecorder")
-            .field("key_version", &self.key_version)
+            .field("key_id", &self.key_id)
             .field("filter", &self.filter)
             .finish_non_exhaustive()
     }
@@ -349,26 +294,23 @@ fn skipped(reason: &'static str) {
 }
 
 impl PrefixChainRecorder {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         key: [u8; 32],
-        key_version: u8,
         filter: ModelFilter,
         tier_policy: TierPolicy,
         telemetry: TelemetryPolicy,
         tokenizer: TokenizerClient,
         principal: PrincipalResolver,
         sink: SinkHandle<PromptChainRow>,
-        max_in_flight: usize,
     ) -> Self {
         Self {
+            key_id: key_id(&key),
             hasher: ChainHasher::new(key, tier_policy, telemetry),
-            key_version,
             filter,
             tokenizer,
             principal,
             sink,
-            in_flight: Arc::new(Semaphore::new(max_in_flight.max(1))),
+            in_flight: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
         }
     }
 
@@ -485,11 +427,61 @@ impl PrefixChainRecorder {
             block_roles: chain.roles,
             block_tokens,
             tokenizer_version,
-            key_version: self.key_version,
+            key_version: self.key_id,
             v: RECORD_VERSION,
         };
         let outcome = if self.sink.send(row) { "recorded" } else { "dropped" };
         counter!("dwctl_prefix_chain_records_total", "outcome" => outcome).increment(1);
+    }
+}
+
+/// The outlet handler: sees every captured request and response, and hands served
+/// chat-completions requests to the recorder.
+pub struct PrefixChainHandler {
+    recorder: Arc<PrefixChainRecorder>,
+    /// The analytics instance id, so rows join `http_analytics` on
+    /// `(instance_id, correlation_id)`.
+    instance_id: Uuid,
+    config: crate::config::Config,
+}
+
+impl PrefixChainHandler {
+    pub fn new(recorder: Arc<PrefixChainRecorder>, instance_id: Uuid, config: crate::config::Config) -> Self {
+        Self {
+            recorder,
+            instance_id,
+            config,
+        }
+    }
+}
+
+impl outlet::RequestHandler for PrefixChainHandler {
+    async fn handle_request(&self, _data: outlet::RequestData) {}
+
+    async fn handle_response(&self, request_data: outlet::RequestData, response_data: outlet::ResponseData) {
+        // Only served requests: a rejected one (bad key, unknown model, rate limit) never
+        // becomes a principal lookup, a tokenizer call or a row.
+        if !response_data.status.is_success() {
+            return;
+        }
+        let api_key = match crate::request_logging::serializers::Auth::from_request(&request_data, &self.config) {
+            crate::request_logging::serializers::Auth::ApiKey { bearer_token } => Some(bearer_token),
+            crate::request_logging::serializers::Auth::None => None,
+        };
+        let model = request_data
+            .body
+            .as_ref()
+            .and_then(|b| serde_json::from_slice::<serde_json::Value>(b).ok())
+            .and_then(|v| v.get("model").and_then(|m| m.as_str()).map(String::from));
+        self.recorder.observe(Observation {
+            instance_id: self.instance_id,
+            correlation_id: request_data.correlation_id as i64,
+            timestamp: DateTime::<Utc>::from(request_data.timestamp),
+            model,
+            api_key,
+            path: request_data.uri.path().to_string(),
+            body: request_data.body.clone(),
+        });
     }
 }
 
@@ -517,14 +509,12 @@ mod tests {
         let (tier, telemetry) = policies();
         let rec = PrefixChainRecorder::new(
             key,
-            1,
             filter,
             tier,
             telemetry,
             TokenizerClient::new("http://127.0.0.1:9"),
             PrincipalResolver::new(pool),
             SinkHandle::for_test(tx, "prompt_chains"),
-            4,
         );
         (Arc::new(rec), rx)
     }
@@ -622,7 +612,6 @@ mod tests {
             database: "clay".into(),
             user: "dwctl".into(),
             password: "pw".into(),
-            request_timeout: Duration::from_secs(30),
         }
     }
 
@@ -632,6 +621,12 @@ mod tests {
             hmac_key: "ab".repeat(32),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn key_id_is_derived_from_the_key() {
+        assert_eq!(key_id(&key(1)), key_id(&key(1)));
+        assert_ne!(key_id(&key(1)), key_id(&key(2)));
     }
 
     #[test]

--- a/dwctl/src/prefix_chain/mod.rs
+++ b/dwctl/src/prefix_chain/mod.rs
@@ -136,11 +136,13 @@ pub fn sink_options() -> SinkOptions {
     }
 }
 
-/// Which key produced a chain: the first byte of SHA-256 over the key. Rows stamped with
-/// different ids never join, and nobody has to remember to bump a version on rotation.
-pub fn key_id(key: &[u8; 32]) -> u8 {
+/// Which key produced a chain: the first four bytes of SHA-256 over the key, big-endian.
+/// Rows stamped with different ids never join, and nobody has to remember to bump a
+/// version on rotation.
+pub fn key_id(key: &[u8; 32]) -> u32 {
     use sha2::Digest as _;
-    sha2::Sha256::digest(key)[0]
+    let digest = sha2::Sha256::digest(key);
+    u32::from_be_bytes([digest[0], digest[1], digest[2], digest[3]])
 }
 
 /// Which models the recorder captures. Built from `prefix_chain.models`.
@@ -183,7 +185,7 @@ pub struct PromptChainRow {
     pub block_tokens: Vec<u32>,
     pub tokenizer_version: String,
     /// See [`key_id`]; stored in the `key_version` column.
-    pub key_version: u8,
+    pub key_version: u32,
     pub v: u8,
 }
 
@@ -256,7 +258,7 @@ impl ChainHasher {
 
 pub struct PrefixChainRecorder {
     hasher: ChainHasher,
-    key_id: u8,
+    key_id: u32,
     filter: ModelFilter,
     tokenizer: TokenizerClient,
     principal: PrincipalResolver,
@@ -462,6 +464,12 @@ impl outlet::RequestHandler for PrefixChainHandler {
         // Only served requests: a rejected one (bad key, unknown model, rate limit) never
         // becomes a principal lookup, a tokenizer call or a row.
         if !response_data.status.is_success() {
+            return;
+        }
+        // The path check comes before the body parse: every other route is skipped for
+        // the cost of a string compare, not a JSON parse of its request body.
+        if !request_data.uri.path().ends_with("/chat/completions") {
+            skipped("not_chat");
             return;
         }
         let api_key = match crate::request_logging::serializers::Auth::from_request(&request_data, &self.config) {
@@ -728,7 +736,7 @@ mod tests {
         rec.observe(observation("/chat/completions", Some("m"), None, Some(b.clone())));
         rec.observe(observation("/chat/completions", Some("m"), Some("sk"), None));
         rec.observe(observation("/chat/completions", Some("m"), Some("sk"), Some(b"nope".to_vec())));
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        assert!(rx.try_recv().is_err(), "nothing recorded");
+        let nothing = tokio::time::timeout(Duration::from_millis(50), rx.recv()).await;
+        assert!(nothing.is_err(), "nothing recorded");
     }
 }

--- a/dwctl/src/prefix_chain/mod.rs
+++ b/dwctl/src/prefix_chain/mod.rs
@@ -1,0 +1,686 @@
+//! Prefix-chain capture: content-free records of prompt STRUCTURE, per chat-completions
+//! request, written to ClickHouse for workload profiling.
+//!
+//! Zero-data-retention customers give us no bodies, and the analytics row alone cannot
+//! say which requests share a prefix (a system prompt, a tool set) or how a conversation
+//! grows turn by turn. This module records, per request, a chain of keyed hashes: one per
+//! content block of the prompt in parse order (tool definitions, system, each message,
+//! each tool call), each an HMAC-SHA256 over the cumulative content up to that block,
+//! truncated to 16 bytes. Equal prefixes give equal chain prefixes, so sessions and
+//! shared templates fall out of the data with no content stored; without the key a
+//! leaked table is structure only. Alongside the chain: each block's role and its
+//! token count on its own (tokenizer-svc), so template overhead and per-block sizes are
+//! recoverable, which is what a replay corpus needs.
+//!
+//! The block split and the cumulative hashes are the prompt-cache layer's own parser
+//! ([`crate::prompt_cache::parse_chat_completions`]) under the same policies the billing
+//! classifier uses, so a chain entry is exactly `HMAC(prefix_hash)` of what that layer
+//! would index. Nothing here touches the classify path or billing: capture runs in the
+//! outlet analytics handler, after the response, off the request path, and any failure
+//! yields no record and a counter.
+//!
+//! Best effort end to end: the ClickHouse sink drops on a full queue or a twice-failed
+//! insert (see [`crate::clickhouse`]). Design and decisions: notes campaign
+//! `zdr-workload-profiling`, 2026-09-02.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, KeyInit, Mac};
+use metrics::counter;
+use serde::{Deserialize, Deserializer, Serialize};
+use sha2::Sha256;
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use crate::clickhouse::{ClickhouseConfig, SinkHandle, SinkOptions, is_identifier};
+use crate::prompt_cache::{
+    ParseError, PrincipalResolver, TelemetryPolicy, TierPolicy, TokenizerClient, TokenizerError, parse_chat_completions,
+};
+
+/// Schema version of [`PromptChainRow`]. Bump when the row shape changes.
+pub const RECORD_VERSION: u8 = 1;
+/// Bytes of the HMAC kept per chain entry (hex-encoded to 32 characters in the row).
+const HASH_BYTES: usize = 16;
+
+fn default_key_version() -> u8 {
+    1
+}
+fn default_table() -> String {
+    "prompt_chains".to_string()
+}
+fn default_flush_interval() -> Duration {
+    Duration::from_secs(5)
+}
+fn default_max_batch_rows() -> usize {
+    5_000
+}
+fn default_queue_capacity() -> usize {
+    20_000
+}
+fn default_retry_delay() -> Duration {
+    Duration::from_millis(500)
+}
+
+/// The `prefix_chain` config section.
+///
+/// The connection lives on the top-level `clickhouse` section; this holds what is
+/// specific to this writer. The semantics are chosen so that no configuration is a
+/// silent no-op — see [`PrefixChainConfig::validate`].
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PrefixChainConfig {
+    /// Master switch. `false` is the only off state: no parse, no sink, no records.
+    pub enabled: bool,
+    /// Which models to capture. `null` / absent: every model. A non-empty list: exactly
+    /// those dwctl aliases, matched exactly and case-sensitively against the alias the
+    /// request resolved to (the string that lands in `http_analytics.model`). An empty
+    /// list is a startup error. Accepts a YAML list or a comma-separated string (env).
+    #[serde(deserialize_with = "deserialize_model_list")]
+    pub models: Option<Vec<String>>,
+    /// 32-byte key, hex-encoded (64 characters). `DWCTL_PREFIX_CHAIN__HMAC_KEY`.
+    pub hmac_key: String,
+    /// Recorded on every row so chains under different keys are never joined.
+    pub key_version: u8,
+    /// Table within the `clickhouse` section's database.
+    pub table: String,
+    #[serde(with = "humantime_serde")]
+    pub flush_interval: Duration,
+    pub max_batch_rows: usize,
+    pub queue_capacity: usize,
+    #[serde(with = "humantime_serde")]
+    pub retry_delay: Duration,
+}
+
+impl Default for PrefixChainConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            models: None,
+            hmac_key: String::new(),
+            key_version: default_key_version(),
+            table: default_table(),
+            flush_interval: default_flush_interval(),
+            max_batch_rows: default_max_batch_rows(),
+            queue_capacity: default_queue_capacity(),
+            retry_delay: default_retry_delay(),
+        }
+    }
+}
+
+impl fmt::Debug for PrefixChainConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrefixChainConfig")
+            .field("enabled", &self.enabled)
+            .field("models", &self.models)
+            .field("hmac_key", &if self.hmac_key.is_empty() { "<unset>" } else { "<redacted>" })
+            .field("key_version", &self.key_version)
+            .field("table", &self.table)
+            .field("flush_interval", &self.flush_interval)
+            .field("max_batch_rows", &self.max_batch_rows)
+            .field("queue_capacity", &self.queue_capacity)
+            .field("retry_delay", &self.retry_delay)
+            .finish()
+    }
+}
+
+/// `models` accepts a sequence (YAML) or a comma-separated string (env override).
+/// Absent stays `None`. An empty string becomes an empty list, which validation rejects
+/// with the same message as an empty YAML list.
+fn deserialize_model_list<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<String>>, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Raw {
+        Seq(Vec<String>),
+        Str(String),
+    }
+    Ok(match Option::<Raw>::deserialize(d)? {
+        None => None,
+        Some(Raw::Seq(v)) => Some(v),
+        Some(Raw::Str(s)) => Some(s.split(',').map(|m| m.trim().to_string()).filter(|m| !m.is_empty()).collect()),
+    })
+}
+
+impl PrefixChainConfig {
+    /// The rules that keep this from being a silent no-op:
+    /// - `enabled: false` ignores everything else.
+    /// - `enabled: true` requires the `clickhouse` section, a tokenizer-svc URL, a
+    ///   well-formed key, a non-empty `models` list if one is given, and sane sink sizes.
+    pub fn validate(&self, clickhouse: Option<&ClickhouseConfig>, tokenizer_url: &str) -> Result<(), String> {
+        if !self.enabled {
+            return Ok(());
+        }
+        if clickhouse.is_none() {
+            return Err("prefix_chain.enabled is true but there is no clickhouse section; add one (endpoint_url, user, password) or set prefix_chain.enabled: false".to_string());
+        }
+        if tokenizer_url.trim().is_empty() {
+            return Err("prefix_chain.enabled is true but cache.tokenizer_url is empty; per-block token counts need tokenizer-svc (set DWCTL_CACHE__TOKENIZER_URL)".to_string());
+        }
+        self.key_bytes()?;
+        if let Some(models) = &self.models
+            && models.is_empty()
+        {
+            return Err("prefix_chain.models is an empty list: an armed sink that records nothing is indistinguishable from a broken one. Omit models to capture every model, or set prefix_chain.enabled: false".to_string());
+        }
+        if !is_identifier(&self.table) {
+            return Err(format!("prefix_chain.table {:?} is not a plain identifier", self.table));
+        }
+        self.sink_options().validate().map_err(|e| format!("prefix_chain: {e}"))
+    }
+
+    /// Decode the hex key. 32 bytes exactly: a shorter key is a typo, a longer one is
+    /// probably the wrong secret.
+    pub fn key_bytes(&self) -> Result<[u8; 32], String> {
+        let raw = hex::decode(self.hmac_key.trim())
+            .map_err(|_| "prefix_chain.hmac_key is not hex (expected 64 hex characters, DWCTL_PREFIX_CHAIN__HMAC_KEY)".to_string())?;
+        <[u8; 32]>::try_from(raw).map_err(|v| format!("prefix_chain.hmac_key decodes to {} bytes, expected 32", v.len()))
+    }
+
+    pub fn sink_options(&self) -> SinkOptions {
+        SinkOptions {
+            table: self.table.clone(),
+            flush_interval: self.flush_interval,
+            max_batch_rows: self.max_batch_rows,
+            queue_capacity: self.queue_capacity,
+            retry_delay: self.retry_delay,
+        }
+    }
+}
+
+/// Which models the recorder captures. Built from `prefix_chain.models`.
+#[derive(Debug, Clone)]
+pub enum ModelFilter {
+    All,
+    Only(HashSet<String>),
+}
+
+impl ModelFilter {
+    pub fn from_config(models: &Option<Vec<String>>) -> Self {
+        match models {
+            None => Self::All,
+            Some(list) => Self::Only(list.iter().cloned().collect()),
+        }
+    }
+
+    pub fn allows(&self, model: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::Only(set) => set.contains(model),
+        }
+    }
+}
+
+/// One row of `clay.prompt_chains`. Field names are the column names; the sink inserts
+/// it as `JSONEachRow`. `ts` serializes as RFC3339 (`...Z`), which the sink's
+/// `date_time_input_format=best_effort` setting parses.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PromptChainRow {
+    pub ts: DateTime<Utc>,
+    pub instance_id: Uuid,
+    pub correlation_id: i64,
+    pub principal_id: Uuid,
+    pub model: String,
+    /// Hex, 32 characters each, one per block boundary in parse order.
+    pub chain: Vec<String>,
+    pub block_roles: Vec<String>,
+    /// Empty when the model is unmapped on tokenizer-svc or the call failed.
+    pub block_tokens: Vec<u32>,
+    pub tokenizer_version: String,
+    pub key_version: u8,
+    pub v: u8,
+}
+
+/// The content-free view of one prompt, before tokenization: hashes and roles per
+/// block, plus the block texts that go to tokenizer-svc and nowhere else.
+pub struct Chain {
+    pub hashes: Vec<String>,
+    pub roles: Vec<String>,
+    texts: Vec<String>,
+}
+
+impl Chain {
+    pub fn len(&self) -> usize {
+        self.hashes.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.hashes.is_empty()
+    }
+}
+
+/// What the analytics handler hands the recorder for one completed request.
+pub struct Observation {
+    pub instance_id: Uuid,
+    pub correlation_id: i64,
+    pub timestamp: DateTime<Utc>,
+    /// The alias the request named, as `http_analytics.model` records it.
+    pub model: Option<String>,
+    /// The bearer token, resolved to the billing principal off the request path.
+    pub api_key: Option<String>,
+    pub path: String,
+    pub body: Option<Bytes>,
+}
+
+/// The pure part: parse with the cache layer's parser, key each cumulative hash.
+pub struct ChainHasher {
+    key: [u8; 32],
+    tier_policy: TierPolicy,
+    telemetry: TelemetryPolicy,
+}
+
+impl ChainHasher {
+    pub fn new(key: [u8; 32], tier_policy: TierPolicy, telemetry: TelemetryPolicy) -> Self {
+        Self {
+            key,
+            tier_policy,
+            telemetry,
+        }
+    }
+
+    /// No I/O, no side effects. The block texts in the result go to tokenizer-svc and
+    /// nowhere else.
+    pub fn chain_for(&self, body: &[u8]) -> Result<Chain, ParseError> {
+        let parsed = parse_chat_completions(body, &self.tier_policy, &self.telemetry)?;
+        let hashes = parsed
+            .cumulative_hashes
+            .iter()
+            .map(|h| hex::encode(&self.mac(h)[..HASH_BYTES]))
+            .collect();
+        let roles = parsed.blocks.iter().map(|b| b.role.clone()).collect();
+        let texts = parsed.blocks.into_iter().map(|b| b.text).collect();
+        Ok(Chain { hashes, roles, texts })
+    }
+
+    fn mac(&self, data: &[u8]) -> [u8; 32] {
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.key).expect("a 32-byte key is always a valid HMAC key");
+        mac.update(data);
+        mac.finalize().into_bytes().into()
+    }
+}
+
+pub struct PrefixChainRecorder {
+    hasher: ChainHasher,
+    key_version: u8,
+    filter: ModelFilter,
+    tokenizer: TokenizerClient,
+    principal: PrincipalResolver,
+    sink: SinkHandle<PromptChainRow>,
+}
+
+impl fmt::Debug for PrefixChainRecorder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrefixChainRecorder")
+            .field("key_version", &self.key_version)
+            .field("filter", &self.filter)
+            .finish_non_exhaustive()
+    }
+}
+
+fn skipped(reason: &'static str) {
+    counter!("dwctl_prefix_chain_skipped_total", "reason" => reason).increment(1);
+}
+
+impl PrefixChainRecorder {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        key: [u8; 32],
+        key_version: u8,
+        filter: ModelFilter,
+        tier_policy: TierPolicy,
+        telemetry: TelemetryPolicy,
+        tokenizer: TokenizerClient,
+        principal: PrincipalResolver,
+        sink: SinkHandle<PromptChainRow>,
+    ) -> Self {
+        Self {
+            hasher: ChainHasher::new(key, tier_policy, telemetry),
+            key_version,
+            filter,
+            tokenizer,
+            principal,
+            sink,
+        }
+    }
+
+    /// Record one request. The synchronous part (path and model filter, parse, HMAC)
+    /// is microseconds and runs inline; principal resolution, tokenization and the
+    /// sink send are spawned so a slow tokenizer-svc never backs up the analytics
+    /// handler. Every early exit increments `dwctl_prefix_chain_skipped_total`.
+    pub fn observe(self: &Arc<Self>, obs: Observation) {
+        if !obs.path.ends_with("/chat/completions") {
+            skipped("not_chat");
+            return;
+        }
+        let Some(model) = obs.model else {
+            skipped("no_model");
+            return;
+        };
+        if !self.filter.allows(&model) {
+            skipped("model_filtered");
+            return;
+        }
+        let Some(body) = obs.body else {
+            skipped("no_body");
+            return;
+        };
+        let Some(api_key) = obs.api_key else {
+            skipped("no_api_key");
+            return;
+        };
+        let chain = match self.chain_for(&body) {
+            Ok(c) if !c.is_empty() => c,
+            Ok(_) => {
+                skipped("empty_prompt");
+                return;
+            }
+            Err(e) => {
+                // A body the cache parser rejects (malformed markers, not JSON). Nothing
+                // payload-shaped is logged: the error names the rule, not the content.
+                debug!(correlation_id = obs.correlation_id, error = %e, "prefix chain: prompt not parseable; skipped");
+                skipped("parse_error");
+                return;
+            }
+        };
+        let this = Arc::clone(self);
+        tokio::spawn(async move {
+            this.finish(model, api_key, chain, obs.instance_id, obs.correlation_id, obs.timestamp)
+                .await;
+        });
+    }
+
+    /// See [`ChainHasher::chain_for`].
+    pub fn chain_for(&self, body: &[u8]) -> Result<Chain, ParseError> {
+        self.hasher.chain_for(body)
+    }
+
+    async fn finish(&self, model: String, api_key: String, chain: Chain, instance_id: Uuid, correlation_id: i64, ts: DateTime<Utc>) {
+        let principal_id = match self.principal.resolve(&api_key).await {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                skipped("unknown_principal");
+                return;
+            }
+            Err(e) => {
+                warn!(correlation_id, error = %e, "prefix chain: principal lookup failed; skipped");
+                skipped("principal_error");
+                return;
+            }
+        };
+
+        let (block_tokens, tokenizer_version) = match self.tokenizer.tokenize(&model, &chain.texts).await {
+            Ok(r) if r.segment_counts.len() == chain.len() => {
+                counter!("dwctl_prefix_chain_tokenize_total", "outcome" => "ok").increment(1);
+                (r.segment_counts, r.tokenizer_version)
+            }
+            Ok(r) => {
+                warn!(
+                    correlation_id,
+                    got = r.segment_counts.len(),
+                    want = chain.len(),
+                    "prefix chain: tokenizer returned the wrong number of counts; recorded without counts"
+                );
+                counter!("dwctl_prefix_chain_tokenize_total", "outcome" => "mismatch").increment(1);
+                (Vec::new(), String::new())
+            }
+            Err(TokenizerError::Unmapped(_)) => {
+                counter!("dwctl_prefix_chain_tokenize_total", "outcome" => "unmapped").increment(1);
+                (Vec::new(), String::new())
+            }
+            Err(e) => {
+                debug!(correlation_id, error = %e, "prefix chain: tokenizer call failed; recorded without counts");
+                counter!("dwctl_prefix_chain_tokenize_total", "outcome" => "error").increment(1);
+                (Vec::new(), String::new())
+            }
+        };
+
+        let row = PromptChainRow {
+            ts,
+            instance_id,
+            correlation_id,
+            principal_id,
+            model,
+            chain: chain.hashes,
+            block_roles: chain.roles,
+            block_tokens,
+            tokenizer_version,
+            key_version: self.key_version,
+            v: RECORD_VERSION,
+        };
+        let outcome = if self.sink.send(row) { "recorded" } else { "dropped" };
+        counter!("dwctl_prefix_chain_records_total", "outcome" => outcome).increment(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clickhouse::ClickhouseConfig;
+    use tokio::sync::mpsc;
+
+    fn key(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    fn policies() -> (TierPolicy, TelemetryPolicy) {
+        (
+            TierPolicy::from_config(&["5m".into(), "1h".into(), "24h".into()], "5m"),
+            TelemetryPolicy::from_config(false, &[]),
+        )
+    }
+
+    /// A recorder whose async tail can never succeed (unreachable tokenizer, resolver on
+    /// the given pool) — enough for the pure `chain_for` and the inline filters.
+    fn recorder_with(pool: sqlx::PgPool, key: [u8; 32], filter: ModelFilter) -> (Arc<PrefixChainRecorder>, mpsc::Receiver<PromptChainRow>) {
+        let (tx, rx) = mpsc::channel(8);
+        let (tier, telemetry) = policies();
+        let rec = PrefixChainRecorder::new(
+            key,
+            1,
+            filter,
+            tier,
+            telemetry,
+            TokenizerClient::new("http://127.0.0.1:9"),
+            PrincipalResolver::new(pool),
+            SinkHandle::for_test(tx, "prompt_chains"),
+        );
+        (Arc::new(rec), rx)
+    }
+
+    /// The pure part on its own: no pool, no sink.
+    fn hasher(key: [u8; 32]) -> ChainHasher {
+        let (tier, telemetry) = policies();
+        ChainHasher::new(key, tier, telemetry)
+    }
+
+    fn body(messages: &[(&str, &str)], tools: usize) -> Vec<u8> {
+        let msgs: Vec<serde_json::Value> = messages.iter().map(|(r, c)| serde_json::json!({"role": r, "content": c})).collect();
+        let tools: Vec<serde_json::Value> = (0..tools)
+            .map(|i| serde_json::json!({"type": "function", "function": {"name": format!("t{i}"), "parameters": {"type": "object"}}}))
+            .collect();
+        let mut v = serde_json::json!({"model": "m", "messages": msgs});
+        if !tools.is_empty() {
+            v["tools"] = serde_json::Value::Array(tools);
+        }
+        serde_json::to_vec(&v).unwrap()
+    }
+
+    #[test]
+    fn chain_is_one_entry_per_block_in_parse_order() {
+        let rec = hasher(key(1));
+        let c = rec
+            .chain_for(&body(&[("system", "s"), ("user", "u"), ("assistant", "a")], 2))
+            .unwrap();
+        assert_eq!(c.roles, vec!["tool_definition", "tool_definition", "system", "user", "assistant"]);
+        assert_eq!(c.hashes.len(), 5);
+        assert!(c.hashes.iter().all(|h| h.len() == 32 && h.chars().all(|ch| ch.is_ascii_hexdigit())));
+        assert_eq!(c.hashes.iter().collect::<HashSet<_>>().len(), 5, "cumulative hashes are distinct");
+    }
+
+    /// The property everything downstream rests on: extending a conversation keeps the
+    /// earlier chain as a prefix, and a different earlier turn changes every later entry.
+    #[test]
+    fn extending_a_conversation_extends_the_chain() {
+        let rec = hasher(key(1));
+        let one = rec.chain_for(&body(&[("system", "s"), ("user", "u1")], 0)).unwrap();
+        let two = rec
+            .chain_for(&body(&[("system", "s"), ("user", "u1"), ("assistant", "a1"), ("user", "u2")], 0))
+            .unwrap();
+        assert_eq!(&two.hashes[..2], &one.hashes[..]);
+        let other = rec
+            .chain_for(&body(
+                &[("system", "s"), ("user", "DIFFERENT"), ("assistant", "a1"), ("user", "u2")],
+                0,
+            ))
+            .unwrap();
+        assert_eq!(other.hashes[0], two.hashes[0], "shared system prompt");
+        assert!(
+            other.hashes[1..].iter().zip(&two.hashes[1..]).all(|(a, b)| a != b),
+            "everything after the divergence differs"
+        );
+    }
+
+    #[test]
+    fn same_body_same_key_is_deterministic_and_a_different_key_is_unrelated() {
+        let a = hasher(key(1));
+        let b = hasher(key(1));
+        let c = hasher(key(2));
+        let payload = body(&[("user", "hello")], 0);
+        assert_eq!(a.chain_for(&payload).unwrap().hashes, b.chain_for(&payload).unwrap().hashes);
+        assert_ne!(a.chain_for(&payload).unwrap().hashes, c.chain_for(&payload).unwrap().hashes);
+    }
+
+    #[test]
+    fn chain_never_contains_content() {
+        let rec = hasher(key(1));
+        let c = rec.chain_for(&body(&[("user", "the secret phrase")], 0)).unwrap();
+        let serialized = serde_json::to_string(&c.hashes).unwrap() + &serde_json::to_string(&c.roles).unwrap();
+        assert!(!serialized.contains("secret"));
+    }
+
+    #[test]
+    fn unparseable_bodies_are_errors_not_panics() {
+        let rec = hasher(key(1));
+        assert!(rec.chain_for(b"not json").is_err());
+        assert!(rec.chain_for(&body(&[], 0)).unwrap().is_empty(), "no blocks, empty chain");
+    }
+
+    #[test]
+    fn model_filter_semantics() {
+        assert!(ModelFilter::from_config(&None).allows("anything"));
+        let only = ModelFilter::from_config(&Some(vec!["runware-zai/glm-5.2".into()]));
+        assert!(only.allows("runware-zai/glm-5.2"));
+        assert!(!only.allows("Runware-zai/glm-5.2"), "exact, case-sensitive");
+        assert!(!only.allows("other"));
+    }
+
+    fn ch() -> ClickhouseConfig {
+        ClickhouseConfig {
+            endpoint_url: "https://x.clickhouse.cloud:8443".into(),
+            database: "clay".into(),
+            user: "dwctl".into(),
+            password: "pw".into(),
+            request_timeout: Duration::from_secs(30),
+        }
+    }
+
+    fn enabled() -> PrefixChainConfig {
+        PrefixChainConfig {
+            enabled: true,
+            hmac_key: "ab".repeat(32),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn disabled_config_ignores_everything_else() {
+        let mut c = PrefixChainConfig::default();
+        c.hmac_key = "garbage".into();
+        c.models = Some(vec![]);
+        assert!(c.validate(None, "").is_ok());
+    }
+
+    #[test]
+    fn enabled_config_requires_the_connection_the_tokenizer_and_a_real_key() {
+        assert!(enabled().validate(Some(&ch()), "http://tokenizer-svc:8088").is_ok());
+        assert!(
+            enabled()
+                .validate(None, "http://tokenizer-svc:8088")
+                .unwrap_err()
+                .contains("clickhouse section")
+        );
+        assert!(enabled().validate(Some(&ch()), "").unwrap_err().contains("tokenizer_url"));
+        let mut c = enabled();
+        c.hmac_key = "abc".into();
+        assert!(c.validate(Some(&ch()), "http://t").unwrap_err().contains("hmac_key"));
+        let mut c = enabled();
+        c.hmac_key = "00".repeat(16);
+        assert!(c.validate(Some(&ch()), "http://t").unwrap_err().contains("expected 32"));
+    }
+
+    #[test]
+    fn empty_model_list_is_rejected_but_null_and_lists_are_fine() {
+        let mut c = enabled();
+        c.models = Some(vec![]);
+        assert!(c.validate(Some(&ch()), "http://t").unwrap_err().contains("empty list"));
+        c.models = None;
+        assert!(c.validate(Some(&ch()), "http://t").is_ok());
+        c.models = Some(vec!["a".into()]);
+        assert!(c.validate(Some(&ch()), "http://t").is_ok());
+    }
+
+    #[test]
+    fn models_deserializes_from_a_list_or_a_comma_string() {
+        let from_yaml: PrefixChainConfig = serde_json::from_str(r#"{"models": ["a", "b"]}"#).unwrap();
+        assert_eq!(from_yaml.models, Some(vec!["a".into(), "b".into()]));
+        let from_env: PrefixChainConfig = serde_json::from_str(r#"{"models": "a, b ,c"}"#).unwrap();
+        assert_eq!(from_env.models, Some(vec!["a".into(), "b".into(), "c".into()]));
+        let empty: PrefixChainConfig = serde_json::from_str(r#"{"models": ""}"#).unwrap();
+        assert_eq!(
+            empty.models,
+            Some(vec![]),
+            "an empty string is the empty list, which validation rejects"
+        );
+        let absent: PrefixChainConfig = serde_json::from_str(r#"{"enabled": false}"#).unwrap();
+        assert_eq!(absent.models, None);
+        let null: PrefixChainConfig = serde_json::from_str(r#"{"models": null}"#).unwrap();
+        assert_eq!(null.models, None);
+    }
+
+    #[test]
+    fn debug_output_redacts_the_key() {
+        let s = format!("{:?}", enabled());
+        assert!(s.contains("<redacted>"));
+        assert!(!s.contains("abab"), "{s}");
+    }
+
+    fn observation(path: &str, model: Option<&str>, api_key: Option<&str>, body: Option<Vec<u8>>) -> Observation {
+        Observation {
+            instance_id: Uuid::nil(),
+            correlation_id: 7,
+            timestamp: Utc::now(),
+            model: model.map(String::from),
+            api_key: api_key.map(String::from),
+            path: path.to_string(),
+            body: body.map(Bytes::from),
+        }
+    }
+
+    /// The inline part of `observe` filters without spawning: nothing reaches the sink
+    /// for non-chat paths, filtered models, or missing pieces.
+    #[sqlx::test]
+    async fn observe_filters_before_spawning(pool: sqlx::PgPool) {
+        let (rec, mut rx) = recorder_with(pool, key(1), ModelFilter::from_config(&Some(vec!["m".into()])));
+        let b = body(&[("user", "hi")], 0);
+        rec.observe(observation("/embeddings", Some("m"), Some("sk"), Some(b.clone())));
+        rec.observe(observation("/chat/completions", Some("other"), Some("sk"), Some(b.clone())));
+        rec.observe(observation("/chat/completions", None, Some("sk"), Some(b.clone())));
+        rec.observe(observation("/chat/completions", Some("m"), None, Some(b.clone())));
+        rec.observe(observation("/chat/completions", Some("m"), Some("sk"), None));
+        rec.observe(observation("/chat/completions", Some("m"), Some("sk"), Some(b"nope".to_vec())));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(rx.try_recv().is_err(), "nothing recorded");
+    }
+}

--- a/dwctl/src/prefix_chain/mod.rs
+++ b/dwctl/src/prefix_chain/mod.rs
@@ -28,6 +28,8 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
+use tokio::sync::Semaphore;
+
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use hmac::{Hmac, KeyInit, Mac};
@@ -38,6 +40,7 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::clickhouse::{ClickhouseConfig, SinkHandle, SinkOptions, is_identifier};
+use crate::metrics::errors::component::PREFIX_CHAIN;
 use crate::prompt_cache::{
     ParseError, PrincipalResolver, TelemetryPolicy, TierPolicy, TokenizerClient, TokenizerError, parse_chat_completions,
 };
@@ -64,6 +67,9 @@ fn default_queue_capacity() -> usize {
 }
 fn default_retry_delay() -> Duration {
     Duration::from_millis(500)
+}
+fn default_max_in_flight() -> usize {
+    256
 }
 
 /// The `prefix_chain` config section.
@@ -94,6 +100,10 @@ pub struct PrefixChainConfig {
     pub queue_capacity: usize,
     #[serde(with = "humantime_serde")]
     pub retry_delay: Duration,
+    /// Cap on requests whose principal lookup and tokenization are in flight at once.
+    /// Beyond it, new requests are skipped (counted `backpressure`) rather than queued,
+    /// so a slow tokenizer-svc bounds memory instead of growing a backlog of prompts.
+    pub max_in_flight: usize,
 }
 
 impl Default for PrefixChainConfig {
@@ -108,6 +118,7 @@ impl Default for PrefixChainConfig {
             max_batch_rows: default_max_batch_rows(),
             queue_capacity: default_queue_capacity(),
             retry_delay: default_retry_delay(),
+            max_in_flight: default_max_in_flight(),
         }
     }
 }
@@ -124,6 +135,7 @@ impl fmt::Debug for PrefixChainConfig {
             .field("max_batch_rows", &self.max_batch_rows)
             .field("queue_capacity", &self.queue_capacity)
             .field("retry_delay", &self.retry_delay)
+            .field("max_in_flight", &self.max_in_flight)
             .finish()
     }
 }
@@ -168,6 +180,9 @@ impl PrefixChainConfig {
         }
         if !is_identifier(&self.table) {
             return Err(format!("prefix_chain.table {:?} is not a plain identifier", self.table));
+        }
+        if self.max_in_flight == 0 {
+            return Err("prefix_chain.max_in_flight must be > 0".to_string());
         }
         self.sink_options().validate().map_err(|e| format!("prefix_chain: {e}"))
     }
@@ -308,6 +323,9 @@ pub struct PrefixChainRecorder {
     tokenizer: TokenizerClient,
     principal: PrincipalResolver,
     sink: SinkHandle<PromptChainRow>,
+    /// Bounds the spawned tail (principal lookup, tokenization, send). See
+    /// `PrefixChainConfig::max_in_flight`.
+    in_flight: Arc<Semaphore>,
 }
 
 impl fmt::Debug for PrefixChainRecorder {
@@ -316,6 +334,22 @@ impl fmt::Debug for PrefixChainRecorder {
             .field("key_version", &self.key_version)
             .field("filter", &self.filter)
             .finish_non_exhaustive()
+    }
+}
+
+/// A fixed, content-free name for a parse failure. `ParseError`'s Display can echo the
+/// client's own value (an invalid TTL string, an unsupported content type), so logs and
+/// labels use this instead.
+fn parse_error_kind(e: &ParseError) -> &'static str {
+    match e {
+        ParseError::Json(_) => "json",
+        ParseError::TooManyBreakpoints => "too_many_breakpoints",
+        ParseError::InvalidTtl(_) => "invalid_ttl",
+        ParseError::UnsupportedType(_) => "unsupported_type",
+        ParseError::DisabledTier(_) => "disabled_tier",
+        ParseError::MalformedCacheControl => "malformed_cache_control",
+        ParseError::AutomaticTtlConflict => "automatic_ttl_conflict",
+        ParseError::NoAutomaticSlot => "automatic_no_slot",
     }
 }
 
@@ -334,6 +368,7 @@ impl PrefixChainRecorder {
         tokenizer: TokenizerClient,
         principal: PrincipalResolver,
         sink: SinkHandle<PromptChainRow>,
+        max_in_flight: usize,
     ) -> Self {
         Self {
             hasher: ChainHasher::new(key, tier_policy, telemetry),
@@ -342,6 +377,7 @@ impl PrefixChainRecorder {
             tokenizer,
             principal,
             sink,
+            in_flight: Arc::new(Semaphore::new(max_in_flight.max(1))),
         }
     }
 
@@ -377,15 +413,27 @@ impl PrefixChainRecorder {
                 return;
             }
             Err(e) => {
-                // A body the cache parser rejects (malformed markers, not JSON). Nothing
-                // payload-shaped is logged: the error names the rule, not the content.
-                debug!(correlation_id = obs.correlation_id, error = %e, "prefix chain: prompt not parseable; skipped");
+                // A body the cache parser rejects (malformed markers, not JSON). Only the
+                // rule that fired is logged: some ParseError variants carry the offending
+                // client value in their Display text, which must never reach a log.
+                let kind = parse_error_kind(&e);
+                debug!(
+                    correlation_id = obs.correlation_id,
+                    kind, "prefix chain: prompt not parseable; skipped"
+                );
                 skipped("parse_error");
                 return;
             }
         };
+        // Bound the spawned tail: the task holds the block texts and the key while it waits
+        // on Postgres and tokenizer-svc, so under a slow dependency we drop, not queue.
+        let Ok(permit) = Arc::clone(&self.in_flight).try_acquire_owned() else {
+            skipped("backpressure");
+            return;
+        };
         let this = Arc::clone(self);
         tokio::spawn(async move {
+            let _permit = permit;
             this.finish(model, api_key, chain, obs.instance_id, obs.correlation_id, obs.timestamp)
                 .await;
         });
@@ -404,7 +452,7 @@ impl PrefixChainRecorder {
                 return;
             }
             Err(e) => {
-                warn!(correlation_id, error = %e, "prefix chain: principal lookup failed; skipped");
+                crate::background_error!(PREFIX_CHAIN, "principal_lookup", Error, correlation_id, error = %e, "prefix chain: principal lookup failed; skipped");
                 skipped("principal_error");
                 return;
             }
@@ -430,7 +478,7 @@ impl PrefixChainRecorder {
                 (Vec::new(), String::new())
             }
             Err(e) => {
-                debug!(correlation_id, error = %e, "prefix chain: tokenizer call failed; recorded without counts");
+                crate::background_error!(PREFIX_CHAIN, "tokenize", Warning, correlation_id, error = %e, "prefix chain: tokenizer call failed; recorded without counts");
                 counter!("dwctl_prefix_chain_tokenize_total", "outcome" => "error").increment(1);
                 (Vec::new(), String::new())
             }
@@ -485,6 +533,7 @@ mod tests {
             TokenizerClient::new("http://127.0.0.1:9"),
             PrincipalResolver::new(pool),
             SinkHandle::for_test(tx, "prompt_chains"),
+            4,
         );
         (Arc::new(rec), rx)
     }
@@ -647,6 +696,19 @@ mod tests {
         assert_eq!(absent.models, None);
         let null: PrefixChainConfig = serde_json::from_str(r#"{"models": null}"#).unwrap();
         assert_eq!(null.models, None);
+    }
+
+    #[test]
+    fn parse_errors_log_a_fixed_kind_not_the_client_value() {
+        let (tier, telemetry) = policies();
+        let err = parse_chat_completions(
+            br#"{"model":"m","tools":[{"type":"function","function":{"name":"t"},"cache_control":{"type":"SECRET-VALUE"}}],"messages":[{"role":"user","content":"x"}]}"#,
+            &tier,
+            &telemetry,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("SECRET-VALUE"), "Display echoes the client value: {err}");
+        assert!(!parse_error_kind(&err).contains("SECRET"));
     }
 
     #[test]

--- a/dwctl/src/request_logging/analytics_handler.rs
+++ b/dwctl/src/request_logging/analytics_handler.rs
@@ -51,7 +51,6 @@ use crate::request_logging::models::AiResponse;
 use crate::request_logging::serializers::{Auth, UsageMetrics, parse_ai_response};
 use crate::request_logging::utils::{extract_header_as_string, extract_header_as_uuid};
 use outlet::{RequestData, RequestHandler, ResponseData};
-use std::sync::Arc;
 use tracing::{Instrument, info_span};
 use uuid::Uuid;
 
@@ -114,9 +113,6 @@ pub struct AnalyticsHandler {
     sender: AnalyticsSender,
     instance_id: Uuid,
     config: Config,
-    /// Workload-profiling capture, when enabled. Sees the same request and response this
-    /// handler does and records prompt structure (never content); see `prefix_chain`.
-    prefix_chain: Option<Arc<crate::prefix_chain::PrefixChainRecorder>>,
 }
 
 impl AnalyticsHandler {
@@ -132,14 +128,7 @@ impl AnalyticsHandler {
             sender,
             instance_id,
             config,
-            prefix_chain: None,
         }
-    }
-
-    /// Attach the prefix-chain recorder. `None` leaves capture off.
-    pub fn with_prefix_chain(mut self, recorder: Option<Arc<crate::prefix_chain::PrefixChainRecorder>>) -> Self {
-        self.prefix_chain = recorder;
-        self
     }
 }
 
@@ -234,24 +223,6 @@ impl RequestHandler for AnalyticsHandler {
                 Auth::ApiKey { bearer_token } => Some(bearer_token.clone()),
                 Auth::None => None,
             };
-
-            // Workload profiling: the prompt's structure, keyed and content-free. The
-            // inline part is a parse and a few HMACs; everything slow is spawned inside.
-            // Only served requests: a rejected one (bad key, unknown model, rate limit)
-            // never becomes a principal lookup, a tokenizer call or a row.
-            if let Some(recorder) = &self.prefix_chain
-                && (200..300).contains(&metrics.status_code)
-            {
-                recorder.observe(crate::prefix_chain::Observation {
-                    instance_id: self.instance_id,
-                    correlation_id: metrics.correlation_id,
-                    timestamp: metrics.timestamp,
-                    model: metrics.request_model.clone(),
-                    api_key: bearer_token.clone(),
-                    path: request_data.uri.path().to_string(),
-                    body: request_data.body.clone(),
-                });
-            }
 
             // Build the raw record (no DB enrichment)
             // Note: request_origin is computed in the batcher after api_key_purpose is resolved

--- a/dwctl/src/request_logging/analytics_handler.rs
+++ b/dwctl/src/request_logging/analytics_handler.rs
@@ -51,6 +51,7 @@ use crate::request_logging::models::AiResponse;
 use crate::request_logging::serializers::{Auth, UsageMetrics, parse_ai_response};
 use crate::request_logging::utils::{extract_header_as_string, extract_header_as_uuid};
 use outlet::{RequestData, RequestHandler, ResponseData};
+use std::sync::Arc;
 use tracing::{Instrument, info_span};
 use uuid::Uuid;
 
@@ -113,6 +114,9 @@ pub struct AnalyticsHandler {
     sender: AnalyticsSender,
     instance_id: Uuid,
     config: Config,
+    /// Workload-profiling capture, when enabled. Sees the same request and response this
+    /// handler does and records prompt structure (never content); see `prefix_chain`.
+    prefix_chain: Option<Arc<crate::prefix_chain::PrefixChainRecorder>>,
 }
 
 impl AnalyticsHandler {
@@ -128,7 +132,14 @@ impl AnalyticsHandler {
             sender,
             instance_id,
             config,
+            prefix_chain: None,
         }
+    }
+
+    /// Attach the prefix-chain recorder. `None` leaves capture off.
+    pub fn with_prefix_chain(mut self, recorder: Option<Arc<crate::prefix_chain::PrefixChainRecorder>>) -> Self {
+        self.prefix_chain = recorder;
+        self
     }
 }
 
@@ -223,6 +234,20 @@ impl RequestHandler for AnalyticsHandler {
                 Auth::ApiKey { bearer_token } => Some(bearer_token.clone()),
                 Auth::None => None,
             };
+
+            // Workload profiling: the prompt's structure, keyed and content-free. The
+            // inline part is a parse and a few HMACs; everything slow is spawned inside.
+            if let Some(recorder) = &self.prefix_chain {
+                recorder.observe(crate::prefix_chain::Observation {
+                    instance_id: self.instance_id,
+                    correlation_id: metrics.correlation_id,
+                    timestamp: metrics.timestamp,
+                    model: metrics.request_model.clone(),
+                    api_key: bearer_token.clone(),
+                    path: request_data.uri.path().to_string(),
+                    body: request_data.body.clone(),
+                });
+            }
 
             // Build the raw record (no DB enrichment)
             // Note: request_origin is computed in the batcher after api_key_purpose is resolved

--- a/dwctl/src/request_logging/analytics_handler.rs
+++ b/dwctl/src/request_logging/analytics_handler.rs
@@ -237,7 +237,11 @@ impl RequestHandler for AnalyticsHandler {
 
             // Workload profiling: the prompt's structure, keyed and content-free. The
             // inline part is a parse and a few HMACs; everything slow is spawned inside.
-            if let Some(recorder) = &self.prefix_chain {
+            // Only served requests: a rejected one (bad key, unknown model, rate limit)
+            // never becomes a principal lookup, a tokenizer call or a row.
+            if let Some(recorder) = &self.prefix_chain
+                && (200..300).contains(&metrics.status_code)
+            {
                 recorder.observe(crate::prefix_chain::Observation {
                     instance_id: self.instance_id,
                     correlation_id: metrics.correlation_id,

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -1415,7 +1415,7 @@ async fn test_request_logging_disabled(pool: PgPool) {
             as std::sync::Arc<dyn crate::image_normalizer::ImageNormalizer>)
         .build();
     let onwards_router = axum::Router::new(); // Empty onwards router for testing
-    let router = super::build_router(&mut app_state, onwards_router, None, None, None, false, None)
+    let router = super::build_router(&mut app_state, onwards_router, None, None, None, false, None, None)
         .await
         .expect("Failed to build router");
 
@@ -2079,7 +2079,7 @@ async fn test_build_router_with_metrics_disabled(pool: PgPool) {
         .build();
 
     let onwards_router = axum::Router::new();
-    let router = super::build_router(&mut app_state, onwards_router, None, None, None, false, None)
+    let router = super::build_router(&mut app_state, onwards_router, None, None, None, false, None, None)
         .await
         .expect("Failed to build router");
     let server = axum_test::TestServer::new(router).expect("Failed to create test server");
@@ -2141,7 +2141,7 @@ async fn test_build_router_with_metrics_enabled(pool: PgPool) {
         .build();
 
     let onwards_router = axum::Router::new();
-    let router = super::build_router(&mut app_state, onwards_router, None, None, None, false, None)
+    let router = super::build_router(&mut app_state, onwards_router, None, None, None, false, None, None)
         .await
         .expect("Failed to build router");
     let server = axum_test::TestServer::new(router).expect("Failed to create test server");

--- a/dwctl/src/test/utils.rs
+++ b/dwctl/src/test/utils.rs
@@ -211,6 +211,7 @@ pub fn create_test_config() -> crate::config::Config {
 
     crate::config::Config {
         clickhouse: None,
+        prefix_chain: crate::prefix_chain::PrefixChainConfig::default(),
         database_url: None,
         database_replica_url: None,
         database: crate::config::DatabaseConfig::External {


### PR DESCRIPTION
Builds on #1553 and #1554.

**What it records.** Per served (2xx) chat-completions request: a chain of keyed hashes of the prompt's content blocks in parse order (tool definitions, system, each message, each tool call), each an HMAC-SHA256 over the cumulative content up to that block, truncated to 16 bytes, hex; the block roles; and each block's own token count from tokenizer-svc. One row per request in `prompt_chains`, joinable to `http_analytics` on `(instance_id, correlation_id)`. No content is stored.

**Where it runs.** Its own outlet handler, after the response, off the request path, sharing the analytics handler's instance id so rows join. It reuses the prompt-cache parser and tokenizer client under the same policies the cache classifier uses; the classify path is untouched. The inline part is a parse and a few HMACs; principal resolution, tokenization and the sink send are spawned per request under a fixed in-flight cap. Every early exit is a counter (`dwctl_prefix_chain_skipped_total{reason}`); dependency failures go through `background_error!`.

**Config** (`prefix_chain` section; requires the `clickhouse` section and `cache.tokenizer_url`):
- `enabled`: `false` is the only off state.
- `models`: `null` captures every model; a non-empty list captures exactly those aliases; an empty list is a startup error. A comma-separated string works for the env override.
- `hmac_key`: 32 bytes, hex. The id stamped on rows is derived from the key.

Sink cadence, queue size, in-flight cap and table name are constants.

**Tests.** Chain determinism and the prefix property; key separation and key id derivation; no content in the chain; parse errors are errors not panics and are logged by fixed kind only; model filter semantics; config validation for every rule above; the inline filters in `observe` never spawn for non-chat paths, filtered models or missing pieces. Clippy and the payload-logging guard clean.

https://claude.ai/code/session_015Rtq2g2DyKJkqHgbi8qK6f
