### PR TITLE
feat(preview): dispatch load-test label changes

### DIFF
--- a/.github/workflows/preview-close.yml
+++ b/.github/workflows/preview-close.yml
@@ -3,7 +3,7 @@ name: Preview
 on:
   pull_request:
     branches: [main]
-    types: [closed]
+    types: [closed, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -16,6 +16,7 @@ jobs:
   close:
     name: Close preview
     if: >-
+      github.event.action == 'closed' &&
       startsWith(github.head_ref, 'preview/') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
@@ -29,6 +30,31 @@ jobs:
               owner: '${{ secrets.DEPLOY_TARGET_OWNER }}',
               repo: '${{ secrets.DEPLOY_TARGET_REPO }}',
               event_type: 'preview-closed',
+              client_payload: {
+                repository: context.repo.owner + '/' + context.repo.repo,
+                pull_request: context.payload.pull_request.number,
+                branch: context.payload.pull_request.head.ref,
+                sha: context.payload.pull_request.head.sha
+              }
+            })
+  load-test-changed:
+    name: Publish load-test change
+    if: >-
+      (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+      github.event.label.name == 'load-test' &&
+      startsWith(github.event.pull_request.head.ref, 'preview/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish preview load-test change
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ secrets.PREVIEW_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: '${{ secrets.DEPLOY_TARGET_OWNER }}',
+              repo: '${{ secrets.DEPLOY_TARGET_REPO }}',
+              event_type: 'preview-load-test-changed',
               client_payload: {
                 repository: context.repo.owner + '/' + context.repo.repo,
                 pull_request: context.payload.pull_request.number,

--- a/scripts/tests/preview_workflow_test.rb
+++ b/scripts/tests/preview_workflow_test.rb
@@ -36,7 +36,7 @@ class PreviewWorkflowTest < Minitest::Test
   def test_closing_a_preview_pr_publishes_only_its_source_identity
     workflow = File.read(File.join(ROOT, ".github", "workflows", "preview-close.yml"))
 
-    assert_includes workflow, "types: [closed]"
+    assert_includes workflow, "types: [closed, labeled, unlabeled]"
     assert_includes workflow, "startsWith(github.head_ref, 'preview/')"
     assert_includes workflow, "github.event.pull_request.head.repo.full_name == github.repository"
     assert_includes workflow, "preview-closed"
@@ -44,6 +44,33 @@ class PreviewWorkflowTest < Minitest::Test
     refute_includes workflow, "artifact_kind"
     refute_includes workflow, "pull_request_target"
     refute_includes workflow, "doubleword.ai"
+  end
+
+  def test_load_test_label_changes_dispatch_only_the_authoritative_preview_identity
+    workflow = File.read(File.join(ROOT, ".github", "workflows", "preview-close.yml"))
+    label_dispatch = workflow[/^  load-test-changed:\n.*?(?=^  \S|\z)/m]
+
+    assert_includes workflow, "types: [closed, labeled, unlabeled]"
+    refute_nil label_dispatch
+    assert_includes label_dispatch, "github.event.action == 'labeled' || github.event.action == 'unlabeled'"
+    assert_includes label_dispatch, "github.event.label.name == 'load-test'"
+    assert_includes label_dispatch, "startsWith(github.event.pull_request.head.ref, 'preview/')"
+    assert_includes label_dispatch,
+                    "github.event.pull_request.head.repo.full_name == github.repository"
+    assert_includes label_dispatch, "github-token: ${{ secrets.PREVIEW_DISPATCH_TOKEN }}"
+    assert_includes label_dispatch, "owner: '${{ secrets.DEPLOY_TARGET_OWNER }}'"
+    assert_includes label_dispatch, "repo: '${{ secrets.DEPLOY_TARGET_REPO }}'"
+    assert_includes label_dispatch, "event_type: 'preview-load-test-changed'"
+
+    client_payload = label_dispatch[/client_payload: \{\n.*?^              \}/m]
+    refute_nil client_payload
+    assert_includes client_payload, "repository: context.repo.owner + '/' + context.repo.repo"
+    assert_includes client_payload, "pull_request: context.payload.pull_request.number"
+    assert_includes client_payload, "branch: context.payload.pull_request.head.ref"
+    assert_includes client_payload, "sha: context.payload.pull_request.head.sha"
+    refute_includes client_payload, "labels:"
+    refute_includes client_payload, "enabled:"
+    refute_includes workflow, "pull_request_target"
   end
 
   def test_preview_workflows_pin_reusable_actions

--- a/scripts/tests/preview_workflow_test.rb
+++ b/scripts/tests/preview_workflow_test.rb
@@ -71,8 +71,12 @@ class PreviewWorkflowTest < Minitest::Test
     assert_includes client_payload, "pull_request: context.payload.pull_request.number"
     assert_includes client_payload, "branch: context.payload.pull_request.head.ref"
     assert_includes client_payload, "sha: context.payload.pull_request.head.sha"
+    payload_property_lines = client_payload.lines.filter do |line|
+      line.match?(/^                \S/)
+    end
+    assert_equal 4, payload_property_lines.length
     assert_equal %w[repository pull_request branch sha],
-                 client_payload.scan(/^                ([a-z_]+):/).flatten
+                 payload_property_lines.map { |line| line[/^                ([a-z_]+):/, 1] }.compact
     refute_includes workflow, "pull_request_target"
   end
 

--- a/scripts/tests/preview_workflow_test.rb
+++ b/scripts/tests/preview_workflow_test.rb
@@ -35,12 +35,15 @@ class PreviewWorkflowTest < Minitest::Test
 
   def test_closing_a_preview_pr_publishes_only_its_source_identity
     workflow = File.read(File.join(ROOT, ".github", "workflows", "preview-close.yml"))
+    close_job = workflow[/^  close:\n.*?(?=^  \S|\z)/m]
 
     assert_includes workflow, "types: [closed, labeled, unlabeled]"
-    assert_includes workflow, "startsWith(github.head_ref, 'preview/')"
-    assert_includes workflow, "github.event.pull_request.head.repo.full_name == github.repository"
-    assert_includes workflow, "preview-closed"
-    assert_includes workflow, "context.payload.pull_request.head.sha"
+    refute_nil close_job
+    assert_includes close_job, "github.event.action == 'closed'"
+    assert_includes close_job, "startsWith(github.head_ref, 'preview/')"
+    assert_includes close_job, "github.event.pull_request.head.repo.full_name == github.repository"
+    assert_includes close_job, "preview-closed"
+    assert_includes close_job, "context.payload.pull_request.head.sha"
     refute_includes workflow, "artifact_kind"
     refute_includes workflow, "pull_request_target"
     refute_includes workflow, "doubleword.ai"
@@ -48,28 +51,28 @@ class PreviewWorkflowTest < Minitest::Test
 
   def test_load_test_label_changes_dispatch_only_the_authoritative_preview_identity
     workflow = File.read(File.join(ROOT, ".github", "workflows", "preview-close.yml"))
-    label_dispatch = workflow[/^  load-test-changed:\n.*?(?=^  \S|\z)/m]
+    load_test_changed_job = workflow[/^  load-test-changed:\n.*?(?=^  \S|\z)/m]
 
     assert_includes workflow, "types: [closed, labeled, unlabeled]"
-    refute_nil label_dispatch
-    assert_includes label_dispatch, "github.event.action == 'labeled' || github.event.action == 'unlabeled'"
-    assert_includes label_dispatch, "github.event.label.name == 'load-test'"
-    assert_includes label_dispatch, "startsWith(github.event.pull_request.head.ref, 'preview/')"
-    assert_includes label_dispatch,
+    refute_nil load_test_changed_job
+    assert_includes load_test_changed_job, "github.event.action == 'labeled' || github.event.action == 'unlabeled'"
+    assert_includes load_test_changed_job, "github.event.label.name == 'load-test'"
+    assert_includes load_test_changed_job, "startsWith(github.event.pull_request.head.ref, 'preview/')"
+    assert_includes load_test_changed_job,
                     "github.event.pull_request.head.repo.full_name == github.repository"
-    assert_includes label_dispatch, "github-token: ${{ secrets.PREVIEW_DISPATCH_TOKEN }}"
-    assert_includes label_dispatch, "owner: '${{ secrets.DEPLOY_TARGET_OWNER }}'"
-    assert_includes label_dispatch, "repo: '${{ secrets.DEPLOY_TARGET_REPO }}'"
-    assert_includes label_dispatch, "event_type: 'preview-load-test-changed'"
+    assert_includes load_test_changed_job, "github-token: ${{ secrets.PREVIEW_DISPATCH_TOKEN }}"
+    assert_includes load_test_changed_job, "owner: '${{ secrets.DEPLOY_TARGET_OWNER }}'"
+    assert_includes load_test_changed_job, "repo: '${{ secrets.DEPLOY_TARGET_REPO }}'"
+    assert_includes load_test_changed_job, "event_type: 'preview-load-test-changed'"
 
-    client_payload = label_dispatch[/client_payload: \{\n.*?^              \}/m]
+    client_payload = load_test_changed_job[/client_payload: \{\n(?<fields>.*?)^              \}/m, :fields]
     refute_nil client_payload
     assert_includes client_payload, "repository: context.repo.owner + '/' + context.repo.repo"
     assert_includes client_payload, "pull_request: context.payload.pull_request.number"
     assert_includes client_payload, "branch: context.payload.pull_request.head.ref"
     assert_includes client_payload, "sha: context.payload.pull_request.head.sha"
-    refute_includes client_payload, "labels:"
-    refute_includes client_payload, "enabled:"
+    assert_equal %w[repository pull_request branch sha],
+                 client_payload.scan(/^                ([a-z_]+):/).flatten
     refute_includes workflow, "pull_request_target"
   end
 

--- a/scripts/tests/preview_workflow_test.rb
+++ b/scripts/tests/preview_workflow_test.rb
@@ -65,18 +65,17 @@ class PreviewWorkflowTest < Minitest::Test
     assert_includes load_test_changed_job, "repo: '${{ secrets.DEPLOY_TARGET_REPO }}'"
     assert_includes load_test_changed_job, "event_type: 'preview-load-test-changed'"
 
-    client_payload = load_test_changed_job[/client_payload: \{\n(?<fields>.*?)^              \}/m, :fields]
+    client_payload = load_test_changed_job[/client_payload: \{\n(?<fields>(?:^                .*\n)*)^              \}\n            \}\)/m, :fields]
     refute_nil client_payload
-    assert_includes client_payload, "repository: context.repo.owner + '/' + context.repo.repo"
-    assert_includes client_payload, "pull_request: context.payload.pull_request.number"
-    assert_includes client_payload, "branch: context.payload.pull_request.head.ref"
-    assert_includes client_payload, "sha: context.payload.pull_request.head.sha"
-    payload_property_lines = client_payload.lines.filter do |line|
-      line.match?(/^                \S/)
-    end
-    assert_equal 4, payload_property_lines.length
-    assert_equal %w[repository pull_request branch sha],
-                 payload_property_lines.map { |line| line[/^                ([a-z_]+):/, 1] }.compact
+    expected_client_payload = <<~PAYLOAD
+      repository: context.repo.owner + '/' + context.repo.repo,
+      pull_request: context.payload.pull_request.number,
+      branch: context.payload.pull_request.head.ref,
+      sha: context.payload.pull_request.head.sha
+    PAYLOAD
+    normalized_client_payload = client_payload.lines.map(&:strip).reject(&:empty?).join("\n")
+
+    assert_equal expected_client_payload.strip, normalized_client_payload
     refute_includes workflow, "pull_request_target"
   end
 


### PR DESCRIPTION
## What changed

- extend the existing preview-close workflow to receive `labeled` and `unlabeled` PR events while keeping the close path explicitly restricted to `closed`;
- dispatch `preview-load-test-changed` only for the exact `load-test` label on canonical same-repository `preview/*` PR heads;
- send only repository, pull-request number, branch, and SHA identity to the internal receiver.

The receiver does not trust an enabled boolean or label payload: it re-fetches the live PR and derives current desired state before proposing any internal change.

## Verification

- `ruby scripts/tests/preview_workflow_test.rb` — 6 runs, 132 assertions;
- workflow YAML parse and branch diff checks;
- exact trigger, guard, secret, event-type, four-key payload, action pinning, and `pull_request_target` absence contracts;
- independent whole-branch review found no Critical, Important, or Minor issues.

## Dependency and merge order

Internal receiver and benchmark implementation: https://github.com/doublewordai/internal/pull/1804

Merge and deploy the internal PR first. Until that receiver exists, this event has no supported consumer. Neither workflow writes Kubernetes state directly.
