### PR TITLE
feat(dwctl): real token-by-token streaming for flex requests via a Redis chunk relay

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,6 +158,16 @@ jobs:
             sleep 1
           done
 
+      - name: Start Redis
+        # The flex live-relay tests (chunk_relay, outbound_request) need a
+        # real Redis; they default to redis://localhost:6379.
+        run: |
+          docker run -d --name redis -p 6379:6379 redis:7
+          for _ in $(seq 1 30); do
+            docker exec redis redis-cli ping && break
+            sleep 1
+          done
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/config.yaml
+++ b/config.yaml
@@ -367,6 +367,21 @@ keystore:
  wrap_keys:
    dev-1: "local-dev-wrap-key-not-a-secret"
 
+# Flex live-streaming (prototype, default off): relays real per-token deltas
+# over Redis Streams instead of poll-and-replay. Absent/enabled:false leaves
+# today's flex streaming unchanged.
+#
+# Local dev: run `just redis-start`, then uncomment the block below.
+# flex_live_streaming:
+#   enabled: false
+#   chunk_relay:
+#     redis_url: "redis://localhost:6379"
+#     stream_ttl_secs: 600
+#     maxlen: 2000
+#     publish_channel_capacity: 1024
+#     reader_poll_interval_ms: 75
+#   poll_fallback_interval_ms: 5000
+
 # Batches API configuration
 batches:
   # Enable batches API endpoints (/files, /batches)

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -108,10 +108,12 @@ hickory-resolver = { version = "0.26", default-features = false, features = [
   "tokio",
 ] }
 aes-gcm = "0.10.3"
-# Redis-backed keystore for zero-data-retention flex request keys.
+# Redis-backed keystore for zero-data-retention flex request keys, and the
+# flex live-streaming chunk relay (Redis Streams).
 deadpool-redis = "0.18"
 redis = { version = "0.27", default-features = false, features = [
   "tokio-rustls-comp",
+  "streams",
 ] }
 paste = "1.0"
 serde_with = "3.14.1"

--- a/dwctl/src/auth/middleware.rs
+++ b/dwctl/src/auth/middleware.rs
@@ -519,6 +519,7 @@ mod tests {
             response_store: state.response_store,
             image_normalizer: state.image_normalizer.clone(),
             keystore: state.keystore.clone(),
+            chunk_relay: state.chunk_relay.clone(),
         };
 
         let request = axum::http::Request::builder()
@@ -633,6 +634,7 @@ mod tests {
             response_store: state.response_store,
             image_normalizer: state.image_normalizer.clone(),
             keystore: state.keystore.clone(),
+            chunk_relay: state.chunk_relay.clone(),
         };
 
         let header_external_user_id = header_user.external_user_id.as_ref().unwrap_or(&header_user.username);
@@ -749,6 +751,7 @@ mod tests {
             response_store: state.response_store,
             image_normalizer: state.image_normalizer.clone(),
             keystore: state.keystore.clone(),
+            chunk_relay: state.chunk_relay.clone(),
         };
 
         // Request with JWT cookie - should be ignored since native auth is disabled
@@ -933,6 +936,7 @@ mod tests {
             response_store: state.response_store,
             image_normalizer: state.image_normalizer.clone(),
             keystore: state.keystore.clone(),
+            chunk_relay: state.chunk_relay.clone(),
         };
 
         let external_user_id = user.external_user_id.as_ref().unwrap_or(&user.username);
@@ -1049,6 +1053,7 @@ mod tests {
             response_store: state.response_store,
             image_normalizer: state.image_normalizer.clone(),
             keystore: state.keystore.clone(),
+            chunk_relay: state.chunk_relay.clone(),
         };
 
         let request = axum::http::Request::builder()

--- a/dwctl/src/chunk_relay.rs
+++ b/dwctl/src/chunk_relay.rs
@@ -232,10 +232,10 @@ async fn publisher_loop(pool: Pool, mut rx: mpsc::Receiver<PublishMsg>, ttl_secs
         // Refresh the TTL periodically rather than on every message — halves
         // command volume, and the stream only needs to outlive its last write
         // by roughly stream_ttl_secs, not by an exact amount.
-        if msg.seq % EXPIRE_REFRESH_EVERY == 0 || msg.done {
-            if let Err(e) = cmd("EXPIRE").arg(&key).arg(ttl_secs).query_async::<i64>(&mut conn).await {
-                tracing::debug!(request_id = %msg.request_id, error = %e, "chunk relay EXPIRE failed");
-            }
+        if (msg.seq % EXPIRE_REFRESH_EVERY == 0 || msg.done)
+            && let Err(e) = cmd("EXPIRE").arg(&key).arg(ttl_secs).query_async::<i64>(&mut conn).await
+        {
+            tracing::debug!(request_id = %msg.request_id, error = %e, "chunk relay EXPIRE failed");
         }
     }
 }

--- a/dwctl/src/chunk_relay.rs
+++ b/dwctl/src/chunk_relay.rs
@@ -45,8 +45,8 @@ pub struct ChunkRelayConfig {
     /// higher QPS, so a shared instance risks a streaming burst affecting
     /// ZDR keystore latency.
     pub redis_url: String,
-    /// Refreshed on every publish, so a stream expires this long after its
-    /// last message, not from creation.
+    /// Refreshed periodically while a stream is active, so it expires
+    /// roughly this long after its last message, not from creation.
     #[serde(default = "default_stream_ttl_secs")]
     pub stream_ttl_secs: u64,
     #[serde(default = "default_maxlen")]
@@ -81,6 +81,9 @@ fn default_publish_channel_capacity() -> usize {
 fn default_reader_poll_interval_ms() -> u64 {
     75
 }
+
+/// How often (in messages) to refresh a stream's TTL.
+const EXPIRE_REFRESH_EVERY: u64 = 20;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ChunkRelayError {
@@ -226,8 +229,13 @@ async fn publisher_loop(pool: Pool, mut rx: mpsc::Receiver<PublishMsg>, ttl_secs
             continue;
         }
 
-        if let Err(e) = cmd("EXPIRE").arg(&key).arg(ttl_secs).query_async::<i64>(&mut conn).await {
-            tracing::debug!(request_id = %msg.request_id, error = %e, "chunk relay EXPIRE failed");
+        // Refresh the TTL periodically rather than on every message — halves
+        // command volume, and the stream only needs to outlive its last write
+        // by roughly stream_ttl_secs, not by an exact amount.
+        if msg.seq % EXPIRE_REFRESH_EVERY == 0 || msg.done {
+            if let Err(e) = cmd("EXPIRE").arg(&key).arg(ttl_secs).query_async::<i64>(&mut conn).await {
+                tracing::debug!(request_id = %msg.request_id, error = %e, "chunk relay EXPIRE failed");
+            }
         }
     }
 }
@@ -453,6 +461,9 @@ mod tests {
         let mut cfg = test_config();
         cfg.maxlen = 5;
         cfg.stream_ttl_secs = 120;
+        // This test's burst-publishes far faster than real (paced) traffic
+        // would, so the reader needs a tighter tick to keep up with it.
+        cfg.reader_poll_interval_ms = 1;
         let relay = ChunkRelay::from_config(&cfg).expect("relay should build against local redis");
         let request_id = Uuid::new_v4();
         let key = stream_key(request_id);
@@ -465,6 +476,9 @@ mod tests {
         let mut stream = relay.subscribe(request_id);
         for i in 0..PUBLISHED - 1 {
             relay.publish_nonblocking(request_id, i, "x");
+            // Let the publisher/reader tasks interleave, like real (paced)
+            // traffic would, instead of racing ahead of the reader.
+            tokio::task::yield_now().await;
         }
         relay.publish_done_nonblocking(request_id, PUBLISHED - 1);
         collect_until_done(&mut stream, Duration::from_secs(10)).await;

--- a/dwctl/src/chunk_relay.rs
+++ b/dwctl/src/chunk_relay.rs
@@ -2,17 +2,15 @@
 //!
 //! Relays the per-token SSE events the daemon already sees
 //! (`crate::inference::outbound_request::Sink::absorb`) to the client-holding
-//! pod. Best-effort: the persisted body stays authoritative, this is just a
-//! live tail on top of it.
+//! pod. Best-effort — the persisted body stays authoritative.
 //!
 //! Streams over pub/sub: `request_id` exists before the daemon claims the
-//! row, so a subscriber can start listening before anything is published —
-//! pub/sub would silently lose those early messages, a stream lets a late
-//! subscriber replay from the start.
+//! row, so a subscriber can listen before anything is published — pub/sub
+//! would silently lose those early messages, a stream lets it replay them.
 //!
 //! Publish (`Sink::absorb`) is synchronous and can't `.await`, so it's a
 //! `try_send` into a channel drained by one background task. Subscribe uses
-//! one shared reader task doing a single `XREAD` per tick across all
+//! one shared reader doing a single `XREAD` per tick across all
 //! subscribers, instead of one blocking connection per client.
 
 use std::collections::HashMap;

--- a/dwctl/src/chunk_relay.rs
+++ b/dwctl/src/chunk_relay.rs
@@ -1,0 +1,511 @@
+//! Cross-pod relay for live flex-streaming chunks, over Redis Streams.
+//!
+//! Relays the per-token SSE events the daemon already sees
+//! (`crate::inference::outbound_request::Sink::absorb`) to the client-holding
+//! pod. Best-effort: the persisted body stays authoritative, this is just a
+//! live tail on top of it.
+//!
+//! Streams over pub/sub: `request_id` exists before the daemon claims the
+//! row, so a subscriber can start listening before anything is published —
+//! pub/sub would silently lose those early messages, a stream lets a late
+//! subscriber replay from the start.
+//!
+//! Publish (`Sink::absorb`) is synchronous and can't `.await`, so it's a
+//! `try_send` into a channel drained by one background task. Subscribe uses
+//! one shared reader task doing a single `XREAD` per tick across all
+//! subscribers, instead of one blocking connection per client.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use deadpool_redis::redis::streams::StreamReadReply;
+use deadpool_redis::redis::{Value, cmd};
+use deadpool_redis::{Config as RedisConfig, Pool, Runtime};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use uuid::Uuid;
+
+/// One relayed chunk, in delivery order.
+#[derive(Debug, Clone)]
+pub struct ChunkMsg {
+    pub seq: u64,
+    pub data: String,
+    pub done: bool,
+}
+
+pub type ChunkStream = ReceiverStream<ChunkMsg>;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ChunkRelayConfig {
+    /// Independent of `keystore.redis_url` — chunk-relay traffic is much
+    /// higher QPS, so a shared instance risks a streaming burst affecting
+    /// ZDR keystore latency.
+    pub redis_url: String,
+    /// Refreshed on every publish, so a stream expires this long after its
+    /// last message, not from creation.
+    #[serde(default = "default_stream_ttl_secs")]
+    pub stream_ttl_secs: u64,
+    #[serde(default = "default_maxlen")]
+    pub maxlen: usize,
+    #[serde(default = "default_publish_channel_capacity")]
+    pub publish_channel_capacity: usize,
+    #[serde(default = "default_reader_poll_interval_ms")]
+    pub reader_poll_interval_ms: u64,
+}
+
+impl Default for ChunkRelayConfig {
+    fn default() -> Self {
+        Self {
+            redis_url: String::new(),
+            stream_ttl_secs: default_stream_ttl_secs(),
+            maxlen: default_maxlen(),
+            publish_channel_capacity: default_publish_channel_capacity(),
+            reader_poll_interval_ms: default_reader_poll_interval_ms(),
+        }
+    }
+}
+
+fn default_stream_ttl_secs() -> u64 {
+    600
+}
+fn default_maxlen() -> usize {
+    2000
+}
+fn default_publish_channel_capacity() -> usize {
+    1024
+}
+fn default_reader_poll_interval_ms() -> u64 {
+    75
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChunkRelayError {
+    #[error("chunk relay unreachable: {0}")]
+    Unreachable(String),
+
+    #[error("chunk relay configuration error: {0}")]
+    Config(String),
+}
+
+impl ChunkRelayError {
+    pub fn is_unreachable(&self) -> bool {
+        matches!(self, Self::Unreachable(_))
+    }
+}
+
+struct PublishMsg {
+    request_id: Uuid,
+    seq: u64,
+    data: String,
+    done: bool,
+}
+
+struct ReaderEntry {
+    tx: mpsc::Sender<ChunkMsg>,
+    last_id: String,
+}
+
+fn stream_key(request_id: Uuid) -> String {
+    format!("flex:chunks:{request_id}")
+}
+
+fn parse_stream_key(key: &str) -> Option<Uuid> {
+    key.strip_prefix("flex:chunks:").and_then(|s| Uuid::parse_str(s).ok())
+}
+
+/// Cheap to clone — publish/subscribe go through the shared background
+/// tasks spawned once in [`ChunkRelay::from_config`].
+#[derive(Clone)]
+pub struct ChunkRelay {
+    publish_tx: mpsc::Sender<PublishMsg>,
+    registry: Arc<DashMap<Uuid, ReaderEntry>>,
+}
+
+impl ChunkRelay {
+    /// Spawns the publisher and reader tasks. Construct once at startup and
+    /// clone the handle; do not call per request.
+    pub fn from_config(cfg: &ChunkRelayConfig) -> Result<Self, ChunkRelayError> {
+        let pool = RedisConfig::from_url(cfg.redis_url.clone())
+            .create_pool(Some(Runtime::Tokio1))
+            .map_err(|e| ChunkRelayError::Config(format!("failed to create redis pool: {e}")))?;
+
+        let (publish_tx, publish_rx) = mpsc::channel(cfg.publish_channel_capacity);
+        let registry: Arc<DashMap<Uuid, ReaderEntry>> = Arc::new(DashMap::new());
+
+        tokio::spawn(publisher_loop(pool.clone(), publish_rx, cfg.stream_ttl_secs, cfg.maxlen));
+        tokio::spawn(reader_loop(
+            pool,
+            registry.clone(),
+            Duration::from_millis(cfg.reader_poll_interval_ms),
+        ));
+
+        Ok(Self { publish_tx, registry })
+    }
+
+    /// Non-blocking — called from `Sink::absorb`, which can't `.await`. A
+    /// full channel or unreachable Redis just drops the message.
+    pub fn publish_nonblocking(&self, request_id: Uuid, seq: u64, data: &str) {
+        let msg = PublishMsg {
+            request_id,
+            seq,
+            data: data.to_string(),
+            done: false,
+        };
+        if let Err(e) = self.publish_tx.try_send(msg) {
+            tracing::debug!(%request_id, seq, error = %e, "chunk relay publish dropped");
+        }
+    }
+
+    /// Call on every daemon-side exit path (success, timeout, parse error),
+    /// not just success, so a subscriber always gets a clean stop signal.
+    pub fn publish_done_nonblocking(&self, request_id: Uuid, seq: u64) {
+        let msg = PublishMsg {
+            request_id,
+            seq,
+            data: String::new(),
+            done: true,
+        };
+        if let Err(e) = self.publish_tx.try_send(msg) {
+            tracing::debug!(%request_id, seq, error = %e, "chunk relay done-sentinel dropped");
+        }
+    }
+
+    /// Reads from the start of the stream, so a late subscriber still sees
+    /// earlier chunks.
+    pub fn subscribe(&self, request_id: Uuid) -> ChunkStream {
+        let (tx, rx) = mpsc::channel(64);
+        self.registry.insert(
+            request_id,
+            ReaderEntry {
+                tx,
+                last_id: "0".to_string(),
+            },
+        );
+        ReceiverStream::new(rx)
+    }
+
+    /// Dropping the stream also works (the reader notices a closed channel
+    /// and removes the entry); this just skips one extra poll cycle.
+    pub fn unsubscribe(&self, request_id: &Uuid) {
+        self.registry.remove(request_id);
+    }
+}
+
+async fn publisher_loop(pool: Pool, mut rx: mpsc::Receiver<PublishMsg>, ttl_secs: u64, maxlen: usize) {
+    while let Some(msg) = rx.recv().await {
+        let mut conn = match pool.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(request_id = %msg.request_id, error = %e, "chunk relay: redis unreachable, dropping publish");
+                continue;
+            }
+        };
+
+        let key = stream_key(msg.request_id);
+        let result = cmd("XADD")
+            .arg(&key)
+            .arg("MAXLEN")
+            .arg("~")
+            .arg(maxlen)
+            .arg("*")
+            .arg("seq")
+            .arg(msg.seq)
+            .arg("data")
+            .arg(&msg.data)
+            .arg("done")
+            .arg(if msg.done { "1" } else { "0" })
+            .query_async::<String>(&mut conn)
+            .await;
+
+        if let Err(e) = result {
+            tracing::debug!(request_id = %msg.request_id, error = %e, "chunk relay XADD failed");
+            continue;
+        }
+
+        if let Err(e) = cmd("EXPIRE").arg(&key).arg(ttl_secs).query_async::<i64>(&mut conn).await {
+            tracing::debug!(request_id = %msg.request_id, error = %e, "chunk relay EXPIRE failed");
+        }
+    }
+}
+
+/// One `XREAD` per tick across every subscribed stream, fanned out to each
+/// subscriber's channel — the fix for the connection-per-reader scaling
+/// limit a naive per-subscriber `XREAD BLOCK` would hit.
+async fn reader_loop(pool: Pool, registry: Arc<DashMap<Uuid, ReaderEntry>>, poll_interval: Duration) {
+    loop {
+        tokio::time::sleep(poll_interval).await;
+
+        let ids: Vec<Uuid> = registry.iter().map(|entry| *entry.key()).collect();
+        if ids.is_empty() {
+            continue;
+        }
+
+        let mut conn = match pool.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(error = %e, "chunk relay: redis unreachable, reader retrying next tick");
+                continue;
+            }
+        };
+
+        let mut command = cmd("XREAD");
+        command.arg("COUNT").arg(500).arg("STREAMS");
+        for id in &ids {
+            command.arg(stream_key(*id));
+        }
+        for id in &ids {
+            let last_id = registry.get(id).map(|e| e.last_id.clone()).unwrap_or_else(|| "0".to_string());
+            command.arg(last_id);
+        }
+
+        let reply = match command.query_async::<Option<StreamReadReply>>(&mut conn).await {
+            Ok(Some(reply)) => reply,
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::debug!(error = %e, "chunk relay XREAD failed");
+                continue;
+            }
+        };
+
+        for stream in reply.keys {
+            let Some(request_id) = parse_stream_key(&stream.key) else {
+                continue;
+            };
+
+            for entry_id in stream.ids {
+                let fields = field_map(&entry_id.map);
+                let seq: u64 = fields.get("seq").and_then(|s| s.parse().ok()).unwrap_or(0);
+                let data = fields.get("data").cloned().unwrap_or_default();
+                let done = fields.get("done").map(String::as_str) == Some("1");
+
+                let delivered = registry
+                    .get(&request_id)
+                    .map(|subscriber| subscriber.tx.try_send(ChunkMsg { seq, data, done }).is_ok())
+                    .unwrap_or(false);
+
+                if !delivered {
+                    registry.remove(&request_id);
+                    continue;
+                }
+
+                if let Some(mut subscriber) = registry.get_mut(&request_id) {
+                    subscriber.last_id = entry_id.id.clone();
+                }
+                if done {
+                    registry.remove(&request_id);
+                }
+            }
+        }
+    }
+}
+
+fn field_map(fields: &HashMap<String, Value>) -> HashMap<String, String> {
+    fields
+        .iter()
+        .filter_map(|(k, v)| value_to_string(v).map(|v| (k.clone(), v)))
+        .collect()
+}
+
+fn value_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::BulkString(bytes) => String::from_utf8(bytes.clone()).ok(),
+        Value::SimpleString(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_key_roundtrips_through_parse() {
+        let id = Uuid::new_v4();
+        assert_eq!(parse_stream_key(&stream_key(id)), Some(id));
+    }
+
+    #[test]
+    fn parse_stream_key_rejects_wrong_prefix() {
+        assert_eq!(parse_stream_key("not:a:relay:key"), None);
+    }
+
+    #[test]
+    fn is_unreachable_distinguishes_error_kinds() {
+        assert!(ChunkRelayError::Unreachable("x".into()).is_unreachable());
+        assert!(!ChunkRelayError::Config("x".into()).is_unreachable());
+    }
+
+    // Needs a real Redis; override TEST_REDIS_URL if `just redis-start`'s
+    // default doesn't apply.
+    fn test_config() -> ChunkRelayConfig {
+        ChunkRelayConfig {
+            redis_url: std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string()),
+            stream_ttl_secs: 60,
+            maxlen: 2000,
+            publish_channel_capacity: 1024,
+            reader_poll_interval_ms: 20,
+        }
+    }
+
+    async fn collect_until_done(stream: &mut ChunkStream, timeout: Duration) -> Vec<ChunkMsg> {
+        use futures::StreamExt;
+        let mut out = Vec::new();
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                panic!("no done sentinel within {timeout:?}; collected so far: {out:?}");
+            }
+            match tokio::time::timeout(remaining, stream.next()).await {
+                Ok(Some(msg)) => {
+                    let done = msg.done;
+                    out.push(msg);
+                    if done {
+                        return out;
+                    }
+                }
+                Ok(None) => panic!("stream ended without a done sentinel; collected so far: {out:?}"),
+                Err(_) => panic!("timed out waiting for the next chunk; collected so far: {out:?}"),
+            }
+        }
+    }
+
+    async fn raw_conn(cfg: &ChunkRelayConfig) -> deadpool_redis::Connection {
+        let pool = RedisConfig::from_url(cfg.redis_url.clone())
+            .create_pool(Some(Runtime::Tokio1))
+            .expect("redis pool for test setup");
+        pool.get().await.expect("redis connection for test setup")
+    }
+
+    async fn wait_for_xlen_at_least(conn: &mut deadpool_redis::Connection, key: &str, min_len: i64, timeout: Duration) -> i64 {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let len: i64 = cmd("XLEN").arg(key).query_async(conn).await.unwrap_or(0);
+            if len >= min_len {
+                return len;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!("XLEN({key}) did not reach {min_len} within {timeout:?} (last seen {len})");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    // EXPIRE is a separate round trip after XADD, so this is polled
+    // independently rather than assumed from XLEN.
+    async fn wait_for_ttl_positive(conn: &mut deadpool_redis::Connection, key: &str, timeout: Duration) -> i64 {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let ttl: i64 = cmd("TTL").arg(key).query_async(conn).await.unwrap_or(-1);
+            if ttl > 0 {
+                return ttl;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!("TTL({key}) did not become positive within {timeout:?} (last seen {ttl})");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_then_subscribe_delivers_in_order() {
+        let relay = ChunkRelay::from_config(&test_config()).expect("relay should build against local redis");
+        let request_id = Uuid::new_v4();
+        let mut stream = relay.subscribe(request_id);
+
+        relay.publish_nonblocking(request_id, 0, "hello");
+        relay.publish_nonblocking(request_id, 1, "world");
+        relay.publish_done_nonblocking(request_id, 2);
+
+        let received = collect_until_done(&mut stream, Duration::from_secs(5)).await;
+
+        let data: Vec<&str> = received.iter().map(|m| m.data.as_str()).collect();
+        assert_eq!(data, vec!["hello", "world", ""]);
+        assert!(!received[0].done);
+        assert!(!received[1].done);
+        assert!(received[2].done);
+    }
+
+    #[tokio::test]
+    async fn late_subscriber_still_sees_earlier_chunks() {
+        let cfg = test_config();
+        let relay = ChunkRelay::from_config(&cfg).expect("relay should build against local redis");
+        let request_id = Uuid::new_v4();
+
+        relay.publish_nonblocking(request_id, 0, "early");
+        let mut conn = raw_conn(&cfg).await;
+        wait_for_xlen_at_least(&mut conn, &stream_key(request_id), 1, Duration::from_secs(5)).await;
+
+        let mut stream = relay.subscribe(request_id);
+        relay.publish_done_nonblocking(request_id, 1);
+
+        let received = collect_until_done(&mut stream, Duration::from_secs(5)).await;
+        assert_eq!(received[0].data, "early");
+        assert!(received.last().unwrap().done);
+    }
+
+    #[tokio::test]
+    async fn maxlen_trims_and_expire_is_applied() {
+        let mut cfg = test_config();
+        cfg.maxlen = 5;
+        cfg.stream_ttl_secs = 120;
+        let relay = ChunkRelay::from_config(&cfg).expect("relay should build against local redis");
+        let request_id = Uuid::new_v4();
+        let key = stream_key(request_id);
+
+        // Approximate (~) trimming only evicts a whole internal node
+        // (~100 entries) at a time, so this needs enough volume to cross
+        // that boundary.
+        const PUBLISHED: u64 = 300;
+
+        let mut stream = relay.subscribe(request_id);
+        for i in 0..PUBLISHED - 1 {
+            relay.publish_nonblocking(request_id, i, "x");
+        }
+        relay.publish_done_nonblocking(request_id, PUBLISHED - 1);
+        collect_until_done(&mut stream, Duration::from_secs(10)).await;
+
+        let mut conn = raw_conn(&cfg).await;
+        let len: i64 = cmd("XLEN").arg(&key).query_async(&mut conn).await.expect("XLEN query");
+        assert!(
+            len < PUBLISHED as i64 - 50,
+            "expected MAXLEN ~ {} to have evicted at least one node's worth of the {PUBLISHED} published entries, got {len}",
+            cfg.maxlen
+        );
+
+        let ttl = wait_for_ttl_positive(&mut conn, &key, Duration::from_secs(5)).await;
+        assert!(
+            ttl <= cfg.stream_ttl_secs as i64,
+            "expected TTL <= {}s, got {ttl}",
+            cfg.stream_ttl_secs
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_nonblocking_never_blocks_even_when_redis_is_unreachable() {
+        // TEST-NET-1 (RFC 5737): non-routable, so the publisher stalls
+        // without ever landing a message.
+        let cfg = ChunkRelayConfig {
+            redis_url: "redis://192.0.2.1:6379".to_string(),
+            publish_channel_capacity: 1,
+            ..test_config()
+        };
+        let relay = ChunkRelay::from_config(&cfg).expect("pool construction doesn't itself connect");
+        let request_id = Uuid::new_v4();
+
+        let started = tokio::time::Instant::now();
+        for i in 0..50u64 {
+            relay.publish_nonblocking(request_id, i, "x");
+        }
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "50 publishes against an unreachable redis and a channel capacity of 1 took {elapsed:?} — publish_nonblocking must never block"
+        );
+    }
+}

--- a/dwctl/src/chunk_relay.rs
+++ b/dwctl/src/chunk_relay.rs
@@ -9,9 +9,12 @@
 //! would silently lose those early messages, a stream lets it replay them.
 //!
 //! Publish (`Sink::absorb`) is synchronous and can't `.await`, so it's a
-//! `try_send` into a channel drained by one background task. Subscribe uses
-//! one shared reader doing a single `XREAD` per tick across all
-//! subscribers, instead of one blocking connection per client.
+//! `try_send` into a channel drained by a shard of background publisher
+//! tasks. Subscribe fans out across a fixed number of reader shards, each
+//! doing a single `XREAD` per tick over its own slice of subscribers
+//! (`request_id % reader_workers`). Batched per shard instead of one
+//! blocking connection per client, but not diluted across every subscriber
+//! in the process the way a single shared reader would be under load.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -19,7 +22,7 @@ use std::time::Duration;
 
 use dashmap::DashMap;
 use deadpool_redis::redis::streams::StreamReadReply;
-use deadpool_redis::redis::{Value, cmd};
+use deadpool_redis::redis::{Value, cmd, pipe};
 use deadpool_redis::{Config as RedisConfig, Pool, Runtime};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -53,6 +56,23 @@ pub struct ChunkRelayConfig {
     pub publish_channel_capacity: usize,
     #[serde(default = "default_reader_poll_interval_ms")]
     pub reader_poll_interval_ms: u64,
+    /// Number of independent publisher shards, each with its own channel,
+    /// Redis connection, and background task. A single sequential publisher
+    /// (one `XADD` round trip at a time) has a hard throughput ceiling no
+    /// buffer size can fix. Once aggregate chunk volume exceeds it, the
+    /// channel backs up and overflows regardless of capacity. Sharding by
+    /// `request_id` lets that many `XADD`s be in flight concurrently.
+    #[serde(default = "default_publish_workers")]
+    pub publish_workers: usize,
+    /// Number of independent reader shards, each doing its own `XREAD` over
+    /// a fixed slice of subscribers (`request_id % reader_workers`), on its
+    /// own Redis connection. A single reader sweeping every subscriber
+    /// dilutes as subscriber count grows, so a request's chunks take longer
+    /// to reach it than the poll-fallback path, which doesn't dilute with
+    /// subscriber count and wins the terminal race instead. Sharding keeps
+    /// each reader's slice a fixed size regardless of total load.
+    #[serde(default = "default_reader_workers")]
+    pub reader_workers: usize,
 }
 
 impl Default for ChunkRelayConfig {
@@ -63,6 +83,8 @@ impl Default for ChunkRelayConfig {
             maxlen: default_maxlen(),
             publish_channel_capacity: default_publish_channel_capacity(),
             reader_poll_interval_ms: default_reader_poll_interval_ms(),
+            publish_workers: default_publish_workers(),
+            reader_workers: default_reader_workers(),
         }
     }
 }
@@ -78,6 +100,12 @@ fn default_publish_channel_capacity() -> usize {
 }
 fn default_reader_poll_interval_ms() -> u64 {
     75
+}
+fn default_publish_workers() -> usize {
+    8
+}
+fn default_reader_workers() -> usize {
+    8
 }
 
 /// How often (in messages) to refresh a stream's TTL.
@@ -122,29 +150,53 @@ fn parse_stream_key(key: &str) -> Option<Uuid> {
 /// tasks spawned once in [`ChunkRelay::from_config`].
 #[derive(Clone)]
 pub struct ChunkRelay {
-    publish_tx: mpsc::Sender<PublishMsg>,
+    /// One independent channel + background publisher per shard, see
+    /// `ChunkRelayConfig::publish_workers`. A request's chunks always hash
+    /// to the same shard, so per-request ordering into Redis is preserved.
+    publish_txs: Arc<[mpsc::Sender<PublishMsg>]>,
     registry: Arc<DashMap<Uuid, ReaderEntry>>,
 }
 
 impl ChunkRelay {
-    /// Spawns the publisher and reader tasks. Construct once at startup and
-    /// clone the handle; do not call per request.
+    /// Spawns the publisher shards and the reader task. Construct once at
+    /// startup and clone the handle; do not call per request.
     pub fn from_config(cfg: &ChunkRelayConfig) -> Result<Self, ChunkRelayError> {
         let pool = RedisConfig::from_url(cfg.redis_url.clone())
             .create_pool(Some(Runtime::Tokio1))
             .map_err(|e| ChunkRelayError::Config(format!("failed to create redis pool: {e}")))?;
 
-        let (publish_tx, publish_rx) = mpsc::channel(cfg.publish_channel_capacity);
+        let workers = cfg.publish_workers.max(1);
+        let publish_txs: Vec<mpsc::Sender<PublishMsg>> = (0..workers)
+            .map(|_| {
+                let (tx, rx) = mpsc::channel(cfg.publish_channel_capacity);
+                tokio::spawn(publisher_loop(pool.clone(), rx, cfg.stream_ttl_secs, cfg.maxlen));
+                tx
+            })
+            .collect();
         let registry: Arc<DashMap<Uuid, ReaderEntry>> = Arc::new(DashMap::new());
 
-        tokio::spawn(publisher_loop(pool.clone(), publish_rx, cfg.stream_ttl_secs, cfg.maxlen));
-        tokio::spawn(reader_loop(
-            pool,
-            registry.clone(),
-            Duration::from_millis(cfg.reader_poll_interval_ms),
-        ));
+        let reader_workers = cfg.reader_workers.max(1);
+        for shard in 0..reader_workers {
+            tokio::spawn(reader_loop(
+                pool.clone(),
+                registry.clone(),
+                Duration::from_millis(cfg.reader_poll_interval_ms),
+                shard,
+                reader_workers,
+            ));
+        }
 
-        Ok(Self { publish_tx, registry })
+        Ok(Self {
+            publish_txs: publish_txs.into(),
+            registry,
+        })
+    }
+
+    /// Every chunk for a given request goes through the same shard, so
+    /// ordering into that request's stream is preserved.
+    fn shard_for(&self, request_id: Uuid) -> &mpsc::Sender<PublishMsg> {
+        let idx = (request_id.as_u128() % self.publish_txs.len() as u128) as usize;
+        &self.publish_txs[idx]
     }
 
     /// Non-blocking — called from `Sink::absorb`, which can't `.await`. A
@@ -156,7 +208,7 @@ impl ChunkRelay {
             data: data.to_string(),
             done: false,
         };
-        if let Err(e) = self.publish_tx.try_send(msg) {
+        if let Err(e) = self.shard_for(request_id).try_send(msg) {
             tracing::debug!(%request_id, seq, error = %e, "chunk relay publish dropped");
         }
     }
@@ -170,15 +222,22 @@ impl ChunkRelay {
             data: String::new(),
             done: true,
         };
-        if let Err(e) = self.publish_tx.try_send(msg) {
+        if let Err(e) = self.shard_for(request_id).try_send(msg) {
             tracing::debug!(%request_id, seq, error = %e, "chunk relay done-sentinel dropped");
         }
     }
 
     /// Reads from the start of the stream, so a late subscriber still sees
     /// earlier chunks.
+    ///
+    /// Capacity must absorb one reader-loop tick's worth of a burst. A
+    /// bursty upstream can hand the daemon hundreds of chunks between ticks,
+    /// and the reader forwards a subscriber's whole backlog in one pass. Too
+    /// small silently drops the subscriber (`try_send` fails once, the
+    /// reader removes the registry entry) and hands the request to the poll
+    /// fallback with no error surfaced. This was 64 and hit in practice.
     pub fn subscribe(&self, request_id: Uuid) -> ChunkStream {
-        let (tx, rx) = mpsc::channel(64);
+        let (tx, rx) = mpsc::channel(4096);
         self.registry.insert(
             request_id,
             ReaderEntry {
@@ -196,44 +255,76 @@ impl ChunkRelay {
     }
 }
 
+/// Max messages pipelined into one Redis round trip. A burst of many
+/// requests finishing at once can queue tens of thousands of messages
+/// behind a single shard, so this bounds each pipeline call instead of
+/// letting it grow without limit.
+const MAX_PUBLISH_BATCH: usize = 256;
+
+/// Drains whatever's already queued (up to `MAX_PUBLISH_BATCH`) into one
+/// pipelined Redis call instead of one round trip per message, and holds
+/// its connection for the task's lifetime instead of re-acquiring it every
+/// message. One round trip per message was the actual bottleneck this was
+/// built to fix. Under a burst of concurrent requests finishing close
+/// together, a shard's queue built up tens of thousands of messages, and
+/// awaiting each round trip serially measured a 20-30s gap between a
+/// request's last chunk being queued and it landing in Redis. That made
+/// the live-relay-vs-poll-fallback race hopeless no matter how the reader
+/// or the race itself was tuned. Pipelining turns it into O(1) round trips
+/// per batch instead of O(n).
 async fn publisher_loop(pool: Pool, mut rx: mpsc::Receiver<PublishMsg>, ttl_secs: u64, maxlen: usize) {
-    while let Some(msg) = rx.recv().await {
-        let mut conn = match pool.get().await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::debug!(request_id = %msg.request_id, error = %e, "chunk relay: redis unreachable, dropping publish");
-                continue;
+    let mut conn = None;
+
+    loop {
+        let Some(first) = rx.recv().await else { return };
+        let mut batch = vec![first];
+        while batch.len() < MAX_PUBLISH_BATCH {
+            match rx.try_recv() {
+                Ok(msg) => batch.push(msg),
+                Err(_) => break,
             }
-        };
-
-        let key = stream_key(msg.request_id);
-        let result = cmd("XADD")
-            .arg(&key)
-            .arg("MAXLEN")
-            .arg("~")
-            .arg(maxlen)
-            .arg("*")
-            .arg("seq")
-            .arg(msg.seq)
-            .arg("data")
-            .arg(&msg.data)
-            .arg("done")
-            .arg(if msg.done { "1" } else { "0" })
-            .query_async::<String>(&mut conn)
-            .await;
-
-        if let Err(e) = result {
-            tracing::debug!(request_id = %msg.request_id, error = %e, "chunk relay XADD failed");
-            continue;
         }
 
-        // Refresh the TTL periodically rather than on every message — halves
-        // command volume, and the stream only needs to outlive its last write
-        // by roughly stream_ttl_secs, not by an exact amount.
-        if (msg.seq % EXPIRE_REFRESH_EVERY == 0 || msg.done)
-            && let Err(e) = cmd("EXPIRE").arg(&key).arg(ttl_secs).query_async::<i64>(&mut conn).await
-        {
-            tracing::debug!(request_id = %msg.request_id, error = %e, "chunk relay EXPIRE failed");
+        let c = match conn.as_mut() {
+            Some(c) => c,
+            None => match pool.get().await {
+                Ok(c) => conn.insert(c),
+                Err(e) => {
+                    tracing::debug!(error = %e, batch_len = batch.len(), "chunk relay: redis unreachable, dropping publish batch");
+                    continue;
+                }
+            },
+        };
+
+        let keys: Vec<String> = batch.iter().map(|m| stream_key(m.request_id)).collect();
+        let mut pipeline = pipe();
+        for (msg, key) in batch.iter().zip(&keys) {
+            pipeline
+                .cmd("XADD")
+                .arg(key)
+                .arg("MAXLEN")
+                .arg("~")
+                .arg(maxlen)
+                .arg("*")
+                .arg("seq")
+                .arg(msg.seq)
+                .arg("data")
+                .arg(&msg.data)
+                .arg("done")
+                .arg(if msg.done { "1" } else { "0" })
+                .ignore();
+            // Refresh the TTL periodically rather than on every message.
+            // Halves command volume, and the stream only needs to outlive
+            // its last write by roughly stream_ttl_secs, not exactly.
+            if msg.seq % EXPIRE_REFRESH_EVERY == 0 || msg.done {
+                pipeline.cmd("EXPIRE").arg(key).arg(ttl_secs).ignore();
+            }
+        }
+
+        if let Err(e) = pipeline.query_async::<()>(c).await {
+            tracing::debug!(error = %e, batch_len = batch.len(), "chunk relay: pipelined publish batch failed");
+            conn = None; // connection may be bad; get a fresh one next batch
+            continue;
         }
     }
 }
@@ -241,11 +332,15 @@ async fn publisher_loop(pool: Pool, mut rx: mpsc::Receiver<PublishMsg>, ttl_secs
 /// One `XREAD` per tick across every subscribed stream, fanned out to each
 /// subscriber's channel — the fix for the connection-per-reader scaling
 /// limit a naive per-subscriber `XREAD BLOCK` would hit.
-async fn reader_loop(pool: Pool, registry: Arc<DashMap<Uuid, ReaderEntry>>, poll_interval: Duration) {
+async fn reader_loop(pool: Pool, registry: Arc<DashMap<Uuid, ReaderEntry>>, poll_interval: Duration, shard: usize, n_shards: usize) {
     loop {
         tokio::time::sleep(poll_interval).await;
 
-        let ids: Vec<Uuid> = registry.iter().map(|entry| *entry.key()).collect();
+        let ids: Vec<Uuid> = registry
+            .iter()
+            .map(|entry| *entry.key())
+            .filter(|id| (id.as_u128() % n_shards as u128) as usize == shard)
+            .collect();
         if ids.is_empty() {
             continue;
         }
@@ -354,6 +449,8 @@ mod tests {
             maxlen: 2000,
             publish_channel_capacity: 1024,
             reader_poll_interval_ms: 20,
+            publish_workers: 2,
+            reader_workers: 2,
         }
     }
 

--- a/dwctl/src/chunk_relay.rs
+++ b/dwctl/src/chunk_relay.rs
@@ -333,6 +333,13 @@ async fn publisher_loop(pool: Pool, mut rx: mpsc::Receiver<PublishMsg>, ttl_secs
 /// subscriber's channel — the fix for the connection-per-reader scaling
 /// limit a naive per-subscriber `XREAD BLOCK` would hit.
 async fn reader_loop(pool: Pool, registry: Arc<DashMap<Uuid, ReaderEntry>>, poll_interval: Duration, shard: usize, n_shards: usize) {
+    // Held across ticks instead of `pool.get()` per tick, same reasoning as
+    // `publisher_loop`: re-acquiring every tick adds avoidable overhead, and
+    // under real load (many subscribers, larger `XREAD` replies) ticks can
+    // start overlapping enough that the pool grows well past its intended
+    // per-shard size instead of reusing one connection.
+    let mut conn = None;
+
     loop {
         tokio::time::sleep(poll_interval).await;
 
@@ -345,12 +352,15 @@ async fn reader_loop(pool: Pool, registry: Arc<DashMap<Uuid, ReaderEntry>>, poll
             continue;
         }
 
-        let mut conn = match pool.get().await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::debug!(error = %e, "chunk relay: redis unreachable, reader retrying next tick");
-                continue;
-            }
+        let c = match conn.as_mut() {
+            Some(c) => c,
+            None => match pool.get().await {
+                Ok(c) => conn.insert(c),
+                Err(e) => {
+                    tracing::debug!(error = %e, "chunk relay: redis unreachable, reader retrying next tick");
+                    continue;
+                }
+            },
         };
 
         let mut command = cmd("XREAD");
@@ -363,11 +373,12 @@ async fn reader_loop(pool: Pool, registry: Arc<DashMap<Uuid, ReaderEntry>>, poll
             command.arg(last_id);
         }
 
-        let reply = match command.query_async::<Option<StreamReadReply>>(&mut conn).await {
+        let reply = match command.query_async::<Option<StreamReadReply>>(c).await {
             Ok(Some(reply)) => reply,
             Ok(None) => continue,
             Err(e) => {
                 tracing::debug!(error = %e, "chunk relay XREAD failed");
+                conn = None; // connection may be bad; get a fresh one next tick
                 continue;
             }
         };

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -204,6 +204,10 @@ pub struct Config {
     /// (the default) leaves ZDR disabled.
     #[serde(default)]
     pub keystore: Option<crate::keystore::KeystoreConfig>,
+    /// Flex live-streaming (prototype, default off). See
+    /// [`FlexLiveStreamingConfig`].
+    #[serde(default)]
+    pub flex_live_streaming: FlexLiveStreamingConfig,
     /// OpenAPI spec exposure controls. Defaults disable the Admin spec
     /// (which describes internal management endpoints) and enable the
     /// AI spec (which mirrors the publicly-documented OpenAI surface).
@@ -2694,6 +2698,33 @@ impl Default for OnwardsSyncConfig {
     }
 }
 
+/// Relays real per-token SSE deltas over Redis Streams (`crate::chunk_relay`)
+/// instead of the poll-and-replay flex stream. Off by default.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct FlexLiveStreamingConfig {
+    /// Has no effect unless `chunk_relay` is also set.
+    pub enabled: bool,
+    pub chunk_relay: Option<crate::chunk_relay::ChunkRelayConfig>,
+    /// Correctness fallback once live streaming is enabled (default: 5000ms).
+    #[serde(default = "default_flex_live_streaming_poll_fallback_ms")]
+    pub poll_fallback_interval_ms: u64,
+}
+
+impl Default for FlexLiveStreamingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            chunk_relay: None,
+            poll_fallback_interval_ms: default_flex_live_streaming_poll_fallback_ms(),
+        }
+    }
+}
+
+fn default_flex_live_streaming_poll_fallback_ms() -> u64 {
+    5000
+}
+
 /// Usage-aggregate refresh daemon configuration.
 ///
 /// The daemon incrementally folds new `http_analytics` rows into the
@@ -3039,6 +3070,7 @@ impl Default for Config {
             connections: ConnectionsConfig::default(),
             image_normalizer: crate::image_normalizer::ImageNormalizerConfig::default(),
             keystore: None,
+            flex_live_streaming: FlexLiveStreamingConfig::default(),
             openapi: OpenApiConfig::default(),
             cache: CacheConfig::default(),
             clickhouse: None,

--- a/dwctl/src/db/handlers/api_keys.rs
+++ b/dwctl/src/db/handlers/api_keys.rs
@@ -2620,6 +2620,7 @@ mod tests {
             prefix_chain: crate::prefix_chain::PrefixChainConfig::default(),
             continuation: Default::default(),
             keystore: None,
+            flex_live_streaming: Default::default(),
         };
         crate::seed_database(&config.model_sources, &pool).await.unwrap();
 

--- a/dwctl/src/inference/middleware.rs
+++ b/dwctl/src/inference/middleware.rs
@@ -35,7 +35,7 @@ use sqlx_pool_router::PoolProvider;
 
 use super::image_normalizer_middleware::{normalize_error_response, normalize_value_to_tokens};
 use super::store::{self as response_store, ONWARDS_RESPONSE_ID_HEADER, OnwardsDaemonId};
-use super::streaming::{ReplayFrame, flex_stream_response};
+use super::streaming::{LiveRelayConfig, ReplayFrame, flex_stream_response};
 use crate::db::{errors::DbError, handlers::api_keys::ApiKeys, models::api_keys::ApiKeyPurpose};
 use crate::image_normalizer::ImageNormalizer;
 
@@ -73,6 +73,10 @@ pub struct InferenceMiddlewareState<P: PoolProvider + Clone = sqlx_pool_router::
     pub flex_completion_window: String,
     /// Encrypted key custody for ZDR flex bodies. `None` disables ZDR.
     pub keystore: Option<crate::keystore::Keystore>,
+    /// `None` disables live streaming. See `crate::chunk_relay`.
+    pub chunk_relay: Option<crate::chunk_relay::ChunkRelay>,
+    /// Correctness fallback interval once live streaming is active.
+    pub flex_poll_fallback_interval_ms: u64,
     /// Per-key ZDR policy map (api key secret to the owning account's
     /// `zero_data_retention` flag), kept fresh by [`crate::sync::zdr_keys`].
     /// Read by [`super::zdr::is_zdr_request`] on the submit path. Defaults to
@@ -1052,12 +1056,19 @@ async fn handle_chat_completion_flex_streaming<P: PoolProvider + Clone + Send + 
     request_id: uuid::Uuid,
     include_usage: bool,
 ) -> Response {
+    // Chat-completions only for now; Responses stays on poll-and-replay.
+    let live_relay = state.chunk_relay.clone().map(|relay| LiveRelayConfig {
+        relay,
+        poll_fallback_interval: std::time::Duration::from_millis(state.flex_poll_fallback_interval_ms),
+    });
+
     flex_stream_response(
         state.request_manager.clone(),
         flex_input,
         request_id,
         true,
         state.keystore.clone(),
+        live_relay,
         move |result| match result {
             Ok(detail) => {
                 let (status, body) = response_store::detail_to_chat_completion_object(detail);
@@ -1100,6 +1111,7 @@ async fn handle_responses_flex_streaming<P: PoolProvider + Clone + Send + Sync +
         request_id,
         false,
         state.keystore.clone(),
+        None, // live relay not wired to Responses yet
         move |result| match result {
             Ok(detail) => {
                 let response = response_store::detail_to_response_object(detail);

--- a/dwctl/src/inference/middleware.rs
+++ b/dwctl/src/inference/middleware.rs
@@ -502,11 +502,9 @@ pub async fn inference_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
             // the completed object instead, so it's chat-only.
             let flex_stream_include_usage =
                 flex_stream && is_chat_completions_api && request_value["stream_options"]["include_usage"].as_bool().unwrap_or(false);
-            // Captured before the `stream`/`stream_options` strip below, and
-            // before ZDR encryption replaces the plaintext body: this is what
-            // seeds the live relay's per-chunk reframing into `response.*`
-            // events (see `LiveRelayConfig::responses_reframe`), since the
-            // daemon-bound body is not guaranteed to still be plaintext JSON.
+            // Captured before the strip below and before ZDR encryption, since
+            // the daemon-bound body isn't guaranteed to stay plaintext JSON.
+            // Seeds the live relay's per-chunk reframe (`LiveRelayConfig::responses_reframe`).
             let responses_request_for_live_relay = if flex_stream && is_responses_api {
                 serde_json::from_value::<ResponsesRequest>(request_value.clone()).ok()
             } else {
@@ -1117,9 +1115,8 @@ async fn handle_responses_flex_streaming<P: PoolProvider + Clone + Send + Sync +
     request_id: uuid::Uuid,
     responses_request_for_live_relay: Option<ResponsesRequest>,
 ) -> Response {
-    // No live relay at all when the request failed to re-parse (should not
-    // happen — it was already validated on the way in), rather than falling
-    // back to unreframed chat-completions-shaped passthrough.
+    // No live relay if the request failed to re-parse (shouldn't happen —
+    // it was already validated) rather than falling back to raw passthrough.
     let live_relay = match (state.chunk_relay.clone(), responses_request_for_live_relay) {
         (Some(relay), Some(req)) => Some(LiveRelayConfig {
             relay,

--- a/dwctl/src/inference/middleware.rs
+++ b/dwctl/src/inference/middleware.rs
@@ -36,6 +36,7 @@ use sqlx_pool_router::PoolProvider;
 use super::image_normalizer_middleware::{normalize_error_response, normalize_value_to_tokens};
 use super::store::{self as response_store, ONWARDS_RESPONSE_ID_HEADER, OnwardsDaemonId};
 use super::streaming::{LiveRelayConfig, ReplayFrame, flex_stream_response};
+use super::translation::responses::types::ResponsesRequest;
 use crate::db::{errors::DbError, handlers::api_keys::ApiKeys, models::api_keys::ApiKeyPurpose};
 use crate::image_normalizer::ImageNormalizer;
 
@@ -501,6 +502,16 @@ pub async fn inference_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
             // the completed object instead, so it's chat-only.
             let flex_stream_include_usage =
                 flex_stream && is_chat_completions_api && request_value["stream_options"]["include_usage"].as_bool().unwrap_or(false);
+            // Captured before the `stream`/`stream_options` strip below, and
+            // before ZDR encryption replaces the plaintext body: this is what
+            // seeds the live relay's per-chunk reframing into `response.*`
+            // events (see `LiveRelayConfig::responses_reframe`), since the
+            // daemon-bound body is not guaranteed to still be plaintext JSON.
+            let responses_request_for_live_relay = if flex_stream && is_responses_api {
+                serde_json::from_value::<ResponsesRequest>(request_value.clone()).ok()
+            } else {
+                None
+            };
             if flex_stream && let Some(obj) = request_value.as_object_mut() {
                 obj.remove("stream");
                 obj.remove("stream_options");
@@ -596,7 +607,7 @@ pub async fn inference_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
                 (true, true) => handle_chat_completion_flex_streaming(&state, flex_input, request_id, flex_stream_include_usage).await,
                 (true, false) => handle_chat_completion_flex(&state, flex_input, request_id).await,
                 // Responses (embeddings flex was downgraded to realtime above).
-                (false, true) => handle_responses_flex_streaming(&state, flex_input, request_id).await,
+                (false, true) => handle_responses_flex_streaming(&state, flex_input, request_id, responses_request_for_live_relay).await,
                 (false, false) => handle_flex(&state, flex_input, &resp_id, model, background).await,
             }
         }
@@ -1056,10 +1067,10 @@ async fn handle_chat_completion_flex_streaming<P: PoolProvider + Clone + Send + 
     request_id: uuid::Uuid,
     include_usage: bool,
 ) -> Response {
-    // Chat-completions only for now; Responses stays on poll-and-replay.
     let live_relay = state.chunk_relay.clone().map(|relay| LiveRelayConfig {
         relay,
         poll_fallback_interval: std::time::Duration::from_millis(state.flex_poll_fallback_interval_ms),
+        responses_reframe: None,
     });
 
     flex_stream_response(
@@ -1104,14 +1115,27 @@ async fn handle_responses_flex_streaming<P: PoolProvider + Clone + Send + Sync +
     state: &InferenceMiddlewareState<P>,
     flex_input: fusillade::CreateFlexInput,
     request_id: uuid::Uuid,
+    responses_request_for_live_relay: Option<ResponsesRequest>,
 ) -> Response {
+    // No live relay at all when the request failed to re-parse (should not
+    // happen — it was already validated on the way in), rather than falling
+    // back to unreframed chat-completions-shaped passthrough.
+    let live_relay = match (state.chunk_relay.clone(), responses_request_for_live_relay) {
+        (Some(relay), Some(req)) => Some(LiveRelayConfig {
+            relay,
+            poll_fallback_interval: std::time::Duration::from_millis(state.flex_poll_fallback_interval_ms),
+            responses_reframe: Some((req, request_id.to_string())),
+        }),
+        _ => None,
+    };
+
     flex_stream_response(
         state.request_manager.clone(),
         flex_input,
         request_id,
         false,
         state.keystore.clone(),
-        None, // live relay not wired to Responses yet
+        live_relay,
         move |result| match result {
             Ok(detail) => {
                 let response = response_store::detail_to_response_object(detail);

--- a/dwctl/src/inference/outbound_request.rs
+++ b/dwctl/src/inference/outbound_request.rs
@@ -1,39 +1,26 @@
 //! Outbound request preparation, and the matching response-side reassembly.
 //!
-//! On the way to onwards this injects the streaming usage flags, so the upstream
-//! reports token usage we can bill from:
+//! On the way to onwards, injects streaming usage flags so the upstream
+//! reports token usage to bill from: `stream_options.include_usage = true`
+//! for `/chat/completions`/`/completions` streaming requests, and forces
+//! `stream: true` on batch traffic to a configured path.
 //!
-//! - for `/chat/completions` and legacy `/completions`, set
-//!   `stream_options.include_usage = true` on streaming requests (so the provider
-//!   emits a usage frame in the final SSE chunk), and force `stream: true` on
-//!   batch traffic to a configured path.
+//! On the way back, a forced request's response is read as SSE and
+//! reassembled into one non-streaming body. See [`should_force_stream`] for
+//! how the daemon's own traffic is recognised.
 //!
-//! On the way back, the response to a request this forced is read as SSE and
-//! reassembled into a single non-streaming body. Both halves of that
-//! transformation therefore live here, and the daemon that dispatches the request
-//! is not party to either: see [`should_force_stream`] for how its traffic is
-//! recognised.
-//!
-//! This was dwctl's `stream_usage_transform`, previously wired through onwards'
-//! `BodyTransformFn` hook. It deliberately does NOT scrub caller id fields: the
-//! inference middleware already strips those in the single parse-and-shape it does
-//! at the edge (`scrub_request_id_fields`, ported from onwards #240), so the body
-//! that reaches this layer is already scrubbed - a second scrub here would be a
-//! no-op duplicate.
+//! This was dwctl's `stream_usage_transform`, previously wired through
+//! onwards' `BodyTransformFn` hook. It does not scrub caller id fields — the
+//! inference middleware already does that in its single parse-and-shape at
+//! the edge, so a second scrub here would be a no-op duplicate.
 //!
 //! # Placement
 //!
-//! Innermost dwctl layer: inner to the cache layer (which must hash the original
-//! body) and running last before onwards.
-//!
-//! That position is load-bearing for the response half rather than incidental.
-//! Request logging is applied outer to this layer, so with the reassembly here it
-//! sees one complete body; with the reassembly anywhere outer to request logging
-//! it would see the event stream instead and retain every frame for the life of
-//! the request. A streaming response carries far more bytes on the wire than the
-//! body it assembles to, because each frame is a full JSON envelope around a few
-//! bytes of token delta, so that difference is a large multiplier on per-request
-//! memory rather than a small one.
+//! Innermost dwctl layer, running last before onwards, and inner to request
+//! logging — load-bearing for the response half: reassembling here means
+//! logging sees one complete body instead of the raw event stream, which
+//! can carry far more bytes on the wire than the body it assembles to
+//! (each frame is a full JSON envelope around a few bytes of delta).
 
 use std::time::Duration;
 
@@ -48,10 +35,8 @@ use tracing::{debug, warn};
 
 /// The three stream-shaped timeouts, mirroring the daemon's configuration.
 ///
-/// Three rather than two: the idle check between events is what catches a stream
-/// that opens and then stalls, and it has no equivalent in a single overall
-/// timeout. Without it such a stream is only caught by `body`, which is sized for
-/// a slow upstream and is far longer.
+/// Three, not two: the idle check between events catches a stream that opens
+/// and then stalls, which `body` — sized for a slow upstream — can't.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StreamTimeouts {
     /// Max time to the first event.
@@ -98,24 +83,18 @@ impl StreamTimeouts {
 
 /// Whether the daemon asked for this response to be streamed and reassembled.
 ///
-/// The daemon marks its own dispatches with this header. Nothing else at this
-/// layer can tell daemon traffic from a client's own request:
-/// `x-fusillade-request-id` is stamped by the edge on everything for
-/// correlation, `batch_id` is absent for batchless flex as well as for realtime,
-/// and the service tier never leaves the database. A client's request reaches
-/// the edge directly and never passes through the daemon's dispatch processor,
-/// which is what makes a mark set there the signal this needs.
-///
-/// Inferring it from the path instead collapses a streaming client's response
-/// into a single body, because the path is identical on both planes.
+/// The daemon marks its own dispatches with this header; nothing else here
+/// distinguishes daemon traffic from a client's own request, since a client
+/// never passes through the dispatch processor that sets it. Inferring this
+/// from the path instead would collapse a streaming client's response into
+/// a single body, because the path is identical on both planes.
 ///
 /// Trusting a header is safe only because the sso-stack ingress strips every
-/// `x-fusillade-*` header from external requests, which is the same perimeter
-/// the `x-fusillade-request-id` early return in `inference::middleware` already
-/// depends on - see the note on `strip_scheduling_priority`. A dwctl reachable
-/// without traversing that proxy would let a caller set this. The blast radius
-/// is narrow either way: a spoofed mark reassembles the caller's own response
-/// and buffers their own body, under the same budgets as any other request.
+/// `x-fusillade-*` header from external requests (the same perimeter
+/// `inference::middleware`'s own `x-fusillade-request-id` check depends on).
+/// A dwctl reachable without that proxy would let a caller set this, but the
+/// blast radius is narrow: a spoofed mark only reassembles and buffers the
+/// caller's own response.
 fn should_force_stream(parts: &axum::http::request::Parts) -> bool {
     parts.headers.get(STREAM_MARKER_HEADER).and_then(|v| v.to_str().ok()) == Some("1")
 }
@@ -123,12 +102,8 @@ fn should_force_stream(parts: &axum::http::request::Parts) -> bool {
 pub async fn outbound_request_middleware(State(cfg): State<OutboundConfig>, request: Request, next: Next) -> Response {
     let (mut parts, body) = request.into_parts();
 
-    // Two separate questions, and they must not share a condition. Whether the
-    // body can be edited depends on its shape; whether the response is
-    // reassembled depends only on the daemon's mark. Reassembly used to sit
-    // behind the shape guard, which held only because Responses reaches this
-    // layer already translated to the completions shape - masking the coupling
-    // rather than removing it.
+    // Must not share a condition: editing the body depends on its shape,
+    // reassembling the response depends only on the daemon's mark.
     let force_stream = should_force_stream(&parts);
     let relay_ctx = if force_stream {
         relay_context_for(&parts, &cfg).await
@@ -285,9 +260,8 @@ fn transform(bytes: &Bytes, force_stream: bool) -> Option<Vec<u8>> {
 
 /// Read an SSE response to completion and return the body it assembles to.
 ///
-/// Ported from fusillade's streaming client, which used to do this after the
-/// response had already passed request logging. The behaviours it preserves are
-/// load-bearing and are called out individually below.
+/// Ported from fusillade's streaming client (previously ran after request
+/// logging); the behaviours below preserve what that ordering depended on.
 async fn reassemble_stream(response: Response, timeouts: StreamTimeouts, relay_ctx: Option<RelayContext>) -> Response {
     use eventsource_stream::Eventsource;
 
@@ -301,23 +275,21 @@ async fn reassemble_stream(response: Response, timeouts: StreamTimeouts, relay_c
         .and_then(|v| v.split(';').next())
         .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("text/event-stream"));
 
-    // A streamable request can be rejected before streaming begins, and providers
-    // commonly answer that with an ordinary JSON error body. Feeding one to an SSE
-    // parser produces zero events and loses the diagnostic, so anything that is not
+    // A rejection before streaming begins is a plain JSON error body, and an
+    // SSE parser would yield zero events and lose it, so anything not
     // labelled as a stream passes through untouched.
     if !is_event_stream {
         return Response::from_parts(parts, body);
     }
 
-    // Only successful streams are reassembled into a completion object. An error
-    // status carrying an event stream keeps its raw data lines, because the
-    // reassembler models a completion and would mangle anything else.
+    // Only successful streams reassemble into a completion object; an error
+    // status keeps its raw data lines, since the reassembler models a
+    // completion and would mangle anything else.
     let reassemble = status.as_u16() < 400;
     let mut stream = body.into_data_stream().eventsource();
 
-    // Phase 1: the first event, under the time-to-first-token budget. Headers
-    // alone do not count as progress here: an upstream can return them and then
-    // queue, which is the case this budget exists to catch.
+    // Phase 1: the first event, under the time-to-first-token budget — an
+    // upstream returning only headers and then queuing is what this catches.
     let first_event = match tokio::time::timeout(timeouts.first_chunk, stream.next()).await {
         Err(_) => return timeout_response("first_chunk"),
         Ok(Some(Ok(event))) => Some(event),
@@ -354,9 +326,8 @@ async fn reassemble_stream(response: Response, timeouts: StreamTimeouts, relay_c
         Ok(Collected::Done(sink)) => sink,
     };
 
-    // Some providers answer 200 with an error envelope inside the stream. Surface
-    // it as a real HTTP error so downstream retry classification sees it, rather
-    // than as a successful but empty completion.
+    // Some providers answer 200 with an error envelope inside the stream —
+    // surface it as a real HTTP error so retry classification sees it.
     if let Some(data) = &sink.embedded_error
         && let Ok(envelope) = serde_json::from_str::<EmbeddedErrorEnvelope>(data)
     {
@@ -397,11 +368,10 @@ enum Collected {
 
 /// Folds SSE events into one body as they arrive.
 ///
-/// Incremental by design. A streaming response carries far more bytes on the wire
-/// than the body it assembles to, and some upstreams add content-free keepalive
-/// frames at a high rate for the life of the request, so buffering the frames and
-/// processing them at the end would make memory scale with stream length rather
-/// than with the result.
+/// Incremental by design: a streaming response carries far more bytes on the
+/// wire than the body it assembles to (some upstreams add high-rate
+/// keepalive frames), so buffering it all and processing at the end would
+/// scale memory with stream length instead of with the result.
 struct Sink {
     reassembler: openai_reassembler::Reassembler,
     /// Newline-joined raw event data, built only when not reassembling.
@@ -468,10 +438,9 @@ struct EmbeddedError {
 
 /// Gateway timeout naming which budget expired.
 ///
-/// A plain 504. The daemon already retries those, and retries all three of these
-/// budgets identically, so nothing downstream needs to tell them apart and no
-/// header or error type has to carry the distinction. Which one fired goes in the
-/// body, which is what the failure record keeps.
+/// A plain 504 — the daemon retries all three budgets identically, so
+/// nothing downstream needs to tell them apart. Which one fired goes in
+/// the body, which the failure record keeps.
 fn timeout_response(which: &str) -> Response {
     (StatusCode::GATEWAY_TIMEOUT, format!("upstream stream exceeded its {which} budget")).into_response()
 }
@@ -483,15 +452,11 @@ fn sse_parse_error(detail: &str) -> Response {
 
 /// Swap a reassembled body into the upstream response, keeping its headers.
 ///
-/// Only the headers the swap invalidates are touched. Everything else the
-/// upstream sent (rate limits, request ids, tracing headers) carries through,
-/// because this sits on the batch hot path and is the last thing to see them
-/// before request logging captures the response.
-///
-/// `Content-Length` and `Content-Encoding` go because the body is a different
-/// size and is no longer encoded as the upstream encoded it; leaving either
-/// would describe the old body. `Content-Type` becomes JSON because the response
-/// is no longer a stream.
+/// Only headers the swap invalidates are touched — everything else the
+/// upstream sent (rate limits, request ids, tracing headers) carries
+/// through. `Content-Length`/`Content-Encoding` go because the body is a
+/// different size and no longer encoded; `Content-Type` becomes JSON since
+/// the response is no longer a stream.
 fn json_body_response(mut parts: axum::http::response::Parts, status: StatusCode, body: String) -> Response {
     parts.status = status;
     parts.headers.remove(header::CONTENT_LENGTH);
@@ -664,9 +629,8 @@ mod tests {
         );
     }
 
-    /// A streamable request can be rejected before streaming begins, and the
-    /// answer is then an ordinary JSON body. Feeding that to an SSE parser would
-    /// yield zero events and lose the diagnostic.
+    /// A rejection before streaming begins is a plain JSON body, and an SSE
+    /// parser would yield zero events and lose the diagnostic.
     #[tokio::test]
     async fn non_sse_response_passes_through_untouched() {
         let mut resp = Response::new(Body::from(r#"{"error":"no such model"}"#));
@@ -720,12 +684,10 @@ mod tests {
         );
     }
 
-    /// Drive a real request through a real nest and report the content type the
-    /// caller receives. The upstream always streams; whether the caller sees a
-    /// stream or an assembled body is entirely this layer's decision.
-    ///
-    /// Hand-built `Parts` cannot answer this. They were what let a trigger that
-    /// matched every request through the edge pass as correct.
+    /// Drive a real request through a real nest and report the content type
+    /// the caller receives — whether it's a stream or an assembled body is
+    /// entirely this layer's decision. Hand-built `Parts` can't answer this;
+    /// they let a trigger that matched every request pass as correct.
     async fn content_type_through_the_edge(path: &str, headers: &[(&str, &str)]) -> String {
         use axum::{Router, routing::post};
 
@@ -760,10 +722,9 @@ mod tests {
         }
     }
 
-    /// The budgets have to come from the daemon's own configuration, and the
-    /// three are the same type in the same order, which is exactly the shape that
-    /// transposes silently. Every other test here supplies them directly, so
-    /// nothing else would notice two of them swapped.
+    /// The three budgets are the same type in the same order — exactly the
+    /// shape that transposes silently — and every other test here supplies
+    /// them directly, so nothing else would notice two swapped.
     #[test]
     fn the_budgets_are_read_from_the_daemons_own_configuration() {
         let mut daemon = crate::config::DaemonConfig::default();
@@ -795,10 +756,9 @@ mod tests {
         assert!(ct.starts_with("application/json"), "expected an assembled body, got {ct:?}");
     }
 
-    /// A streaming client must keep receiving a stream.
-    ///
-    /// The correlation header is present, because the edge stamps it on every
-    /// inbound request. That is exactly why it cannot be the signal: keying off
+    /// A streaming client must keep receiving a stream. The correlation
+    /// header is present here too (the edge stamps it on every inbound
+    /// request) — which is exactly why it can't be the signal: keying off
     /// it collapsed every streaming client's response into a single body.
     #[tokio::test]
     async fn client_traffic_still_streams() {

--- a/dwctl/src/inference/outbound_request.rs
+++ b/dwctl/src/inference/outbound_request.rs
@@ -66,6 +66,11 @@ pub struct StreamTimeouts {
 #[derive(Clone)]
 pub struct OutboundConfig {
     pub timeouts: StreamTimeouts,
+    /// `None` disables live relaying. See `crate::chunk_relay`.
+    pub relay: Option<crate::chunk_relay::ChunkRelay>,
+    /// Encrypts chunks for a ZDR-marked dispatch; `None` means no live
+    /// relay for those (never plaintext).
+    pub keystore: Option<crate::keystore::Keystore>,
 }
 
 /// `batch_metadata` key the daemon's dispatch sets to mark a request for
@@ -125,6 +130,11 @@ pub async fn outbound_request_middleware(State(cfg): State<OutboundConfig>, requ
     // layer already translated to the completions shape - masking the coupling
     // rather than removing it.
     let force_stream = should_force_stream(&parts);
+    let relay_ctx = if force_stream {
+        relay_context_for(&parts, &cfg).await
+    } else {
+        None
+    };
 
     let path = parts.uri.path();
     // `/chat/completions` also ends with `/completions`; both take the stream flags.
@@ -133,7 +143,7 @@ pub async fn outbound_request_middleware(State(cfg): State<OutboundConfig>, requ
         // dispatch still gets its response reassembled.
         let response = next.run(Request::from_parts(parts, body)).await;
         return if force_stream {
-            reassemble_stream(response, cfg.timeouts).await
+            reassemble_stream(response, cfg.timeouts, relay_ctx).await
         } else {
             response
         };
@@ -160,9 +170,86 @@ pub async fn outbound_request_middleware(State(cfg): State<OutboundConfig>, requ
     };
 
     if force_stream {
-        reassemble_stream(response, cfg.timeouts).await
+        reassemble_stream(response, cfg.timeouts, relay_ctx).await
     } else {
         response
+    }
+}
+
+/// Fetches the ZDR key up front (a network call `Sink::absorb` can't make);
+/// a missing keystore or failed fetch means no relay for this dispatch,
+/// never a plaintext one for ZDR content.
+async fn relay_context_for(parts: &axum::http::request::Parts, cfg: &OutboundConfig) -> Option<RelayContext> {
+    let relay = cfg.relay.clone()?;
+    let request_id = parts
+        .headers
+        .get("x-fusillade-request-id")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| uuid::Uuid::parse_str(s).ok())?;
+
+    let is_zdr = parts
+        .headers
+        .get(crate::inference::zdr::ZDR_MARKER_HEADER)
+        .and_then(|v| v.to_str().ok())
+        == Some("1");
+
+    let zdr_key = if is_zdr {
+        let keystore = cfg.keystore.as_ref()?;
+        let key_id = crate::inference::zdr::key_id(&request_id, crate::inference::zdr::KeyKind::Response);
+        match keystore.get(&key_id).await {
+            Ok(Some(key)) => Some(key),
+            Ok(None) => {
+                debug!(%request_id, "no ZDR response key for live relay; skipping relay for this dispatch");
+                return None;
+            }
+            Err(e) => {
+                debug!(%request_id, error = %e, "failed to fetch ZDR response key for live relay; skipping relay for this dispatch");
+                return None;
+            }
+        }
+    } else {
+        None
+    };
+
+    Some(RelayContext {
+        relay,
+        request_id,
+        zdr_key,
+        seq: 0,
+    })
+}
+
+/// Live-relay state for one dispatch attempt, owned by `Sink`. `Drop`
+/// publishes the terminal sentinel exactly once, covering every
+/// `reassemble_stream` exit path.
+struct RelayContext {
+    relay: crate::chunk_relay::ChunkRelay,
+    request_id: uuid::Uuid,
+    /// Fetched non-destructively; `None` for a non-ZDR dispatch.
+    zdr_key: Option<Vec<u8>>,
+    seq: u64,
+}
+
+impl RelayContext {
+    fn publish(&mut self, data: &str) {
+        let payload = match &self.zdr_key {
+            Some(key) => match crate::inference::zdr::encrypt_body(key, data) {
+                Ok(ciphertext) => ciphertext,
+                Err(e) => {
+                    debug!(request_id = %self.request_id, error = %e, "failed to encrypt chunk for live relay, dropping it");
+                    return;
+                }
+            },
+            None => data.to_string(),
+        };
+        self.relay.publish_nonblocking(self.request_id, self.seq, &payload);
+        self.seq += 1;
+    }
+}
+
+impl Drop for RelayContext {
+    fn drop(&mut self) {
+        self.relay.publish_done_nonblocking(self.request_id, self.seq);
     }
 }
 
@@ -201,7 +288,7 @@ fn transform(bytes: &Bytes, force_stream: bool) -> Option<Vec<u8>> {
 /// Ported from fusillade's streaming client, which used to do this after the
 /// response had already passed request logging. The behaviours it preserves are
 /// load-bearing and are called out individually below.
-async fn reassemble_stream(response: Response, timeouts: StreamTimeouts) -> Response {
+async fn reassemble_stream(response: Response, timeouts: StreamTimeouts, relay_ctx: Option<RelayContext>) -> Response {
     use eventsource_stream::Eventsource;
 
     let (parts, body) = response.into_parts();
@@ -240,8 +327,8 @@ async fn reassemble_stream(response: Response, timeouts: StreamTimeouts) -> Resp
 
     // Phase 2: the remainder, under the idle budget per event and the total
     // budget across all of them.
-    let outcome = tokio::time::timeout(timeouts.body, async {
-        let mut sink = Sink::new(reassemble);
+    let outcome = tokio::time::timeout(timeouts.body, async move {
+        let mut sink = Sink::new(reassemble, relay_ctx);
         if let Some(event) = first_event {
             sink.absorb(&event);
         }
@@ -253,7 +340,7 @@ async fn reassemble_stream(response: Response, timeouts: StreamTimeouts) -> Resp
                 Err(_) => return Collected::Stalled(sink.seen),
             }
         }
-        Collected::Done(sink)
+        Collected::Done(Box::new(sink))
     })
     .await;
 
@@ -301,7 +388,7 @@ async fn reassemble_stream(response: Response, timeouts: StreamTimeouts) -> Resp
 
 /// How the collection phase ended.
 enum Collected {
-    Done(Sink),
+    Done(Box<Sink>),
     /// Idle for longer than the per-event budget, carrying the events seen so far
     /// for the diagnostic.
     Stalled(usize),
@@ -324,16 +411,18 @@ struct Sink {
     /// Events seen, for the stall diagnostic.
     seen: usize,
     reassemble: bool,
+    relay_ctx: Option<RelayContext>,
 }
 
 impl Sink {
-    fn new(reassemble: bool) -> Self {
+    fn new(reassemble: bool, relay_ctx: Option<RelayContext>) -> Self {
         Self {
             reassembler: openai_reassembler::Reassembler::new(),
             raw: String::new(),
             embedded_error: None,
             seen: 0,
             reassemble,
+            relay_ctx,
         }
     }
 
@@ -348,6 +437,10 @@ impl Sink {
 
         if self.reassemble {
             self.reassembler.push(event);
+            // Additive only — never changes what's folded into the reassembler.
+            if let Some(ctx) = self.relay_ctx.as_mut() {
+                ctx.publish(&event.data);
+            }
         } else if !event.data.is_empty() && event.data != "[DONE]" {
             if !self.raw.is_empty() {
                 self.raw.push('\n');
@@ -496,7 +589,7 @@ mod tests {
         let frames = [chunk("Hello"), chunk(" world"), "[DONE]".to_string()];
         let refs: Vec<&str> = frames.iter().map(String::as_str).collect();
 
-        let out = reassemble_stream(sse_response(StatusCode::OK, &refs), timeouts(1000, 1000, 5000)).await;
+        let out = reassemble_stream(sse_response(StatusCode::OK, &refs), timeouts(1000, 1000, 5000), None).await;
 
         assert_eq!(out.status(), StatusCode::OK);
         assert_eq!(
@@ -521,8 +614,8 @@ mod tests {
         let clean = [chunk("Hello"), chunk(" world")];
         let clean_refs: Vec<&str> = clean.iter().map(String::as_str).collect();
 
-        let a = reassemble_stream(sse_response(StatusCode::OK, &noisy_refs), timeouts(1000, 1000, 5000)).await;
-        let b = reassemble_stream(sse_response(StatusCode::OK, &clean_refs), timeouts(1000, 1000, 5000)).await;
+        let a = reassemble_stream(sse_response(StatusCode::OK, &noisy_refs), timeouts(1000, 1000, 5000), None).await;
+        let b = reassemble_stream(sse_response(StatusCode::OK, &clean_refs), timeouts(1000, 1000, 5000), None).await;
 
         assert_eq!(body_string(a).await, body_string(b).await, "keepalives changed the assembled body");
     }
@@ -533,7 +626,7 @@ mod tests {
     async fn embedded_error_is_reclassified_to_a_real_status() {
         let frames = [r#"{"error":{"code":429,"message":"slow down"}}"#];
 
-        let out = reassemble_stream(sse_response(StatusCode::OK, &frames), timeouts(1000, 1000, 5000)).await;
+        let out = reassemble_stream(sse_response(StatusCode::OK, &frames), timeouts(1000, 1000, 5000), None).await;
 
         assert_eq!(out.status(), StatusCode::TOO_MANY_REQUESTS);
         assert!(body_string(out).await.contains("slow down"));
@@ -547,7 +640,7 @@ mod tests {
             r#"{"error":{"code":500,"message":"second"}}"#,
         ];
 
-        let out = reassemble_stream(sse_response(StatusCode::OK, &frames), timeouts(1000, 1000, 5000)).await;
+        let out = reassemble_stream(sse_response(StatusCode::OK, &frames), timeouts(1000, 1000, 5000), None).await;
 
         assert_eq!(out.status(), StatusCode::TOO_MANY_REQUESTS);
         let body = body_string(out).await;
@@ -561,7 +654,7 @@ mod tests {
     async fn error_status_keeps_raw_event_data() {
         let frames = [r#"{"detail":"bad request"}"#, "", "[DONE]"];
 
-        let out = reassemble_stream(sse_response(StatusCode::BAD_REQUEST, &frames), timeouts(1000, 1000, 5000)).await;
+        let out = reassemble_stream(sse_response(StatusCode::BAD_REQUEST, &frames), timeouts(1000, 1000, 5000), None).await;
 
         assert_eq!(out.status(), StatusCode::BAD_REQUEST);
         assert_eq!(
@@ -581,7 +674,7 @@ mod tests {
         resp.headers_mut()
             .insert(header::CONTENT_TYPE, header::HeaderValue::from_static("application/json"));
 
-        let out = reassemble_stream(resp, timeouts(1000, 1000, 5000)).await;
+        let out = reassemble_stream(resp, timeouts(1000, 1000, 5000), None).await;
 
         assert_eq!(out.status(), StatusCode::NOT_FOUND);
         assert_eq!(body_string(out).await, r#"{"error":"no such model"}"#);
@@ -592,7 +685,7 @@ mod tests {
     async fn no_first_event_reports_a_first_chunk_timeout() {
         let response = slow_sse_response(vec![(400, chunk("late"))]);
 
-        let out = reassemble_stream(response, timeouts(50, 5000, 5000)).await;
+        let out = reassemble_stream(response, timeouts(50, 5000, 5000), None).await;
 
         assert_eq!(out.status(), StatusCode::GATEWAY_TIMEOUT);
         assert!(body_string(out).await.contains("first_chunk"));
@@ -604,7 +697,7 @@ mod tests {
     async fn a_stalled_stream_reports_a_chunk_timeout() {
         let response = slow_sse_response(vec![(0, chunk("hi")), (400, chunk(" there"))]);
 
-        let out = reassemble_stream(response, timeouts(1000, 50, 5000)).await;
+        let out = reassemble_stream(response, timeouts(1000, 50, 5000), None).await;
 
         assert_eq!(out.status(), StatusCode::GATEWAY_TIMEOUT);
         assert!(
@@ -618,7 +711,7 @@ mod tests {
     async fn a_long_stream_reports_a_body_timeout() {
         let frames: Vec<(u64, String)> = (0..20).map(|_| (30, chunk("x"))).collect();
 
-        let out = reassemble_stream(slow_sse_response(frames), timeouts(1000, 1000, 120)).await;
+        let out = reassemble_stream(slow_sse_response(frames), timeouts(1000, 1000, 120), None).await;
 
         assert_eq!(out.status(), StatusCode::GATEWAY_TIMEOUT);
         assert!(
@@ -662,6 +755,8 @@ mod tests {
     fn config() -> OutboundConfig {
         OutboundConfig {
             timeouts: timeouts(1000, 1000, 5000),
+            relay: None,
+            keystore: None,
         }
     }
 
@@ -731,5 +826,122 @@ mod tests {
     async fn marked_responses_traffic_is_reassembled() {
         let ct = content_type_through_the_edge("/ai/v1/responses", &[(STREAM_MARKER_HEADER, "1")]).await;
         assert!(ct.starts_with("application/json"), "expected an assembled body, got {ct:?}");
+    }
+
+    // Needs a real Redis; override TEST_REDIS_URL if `just redis-start`'s
+    // default doesn't apply.
+    fn test_relay() -> crate::chunk_relay::ChunkRelay {
+        let cfg = crate::chunk_relay::ChunkRelayConfig {
+            redis_url: std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string()),
+            ..Default::default()
+        };
+        crate::chunk_relay::ChunkRelay::from_config(&cfg).expect("relay should build against local redis")
+    }
+
+    async fn collect_relayed_until_done(stream: &mut crate::chunk_relay::ChunkStream) -> Vec<crate::chunk_relay::ChunkMsg> {
+        use futures::StreamExt;
+        let mut out = Vec::new();
+        loop {
+            match tokio::time::timeout(Duration::from_secs(5), stream.next()).await {
+                Ok(Some(msg)) => {
+                    let done = msg.done;
+                    out.push(msg);
+                    if done {
+                        return out;
+                    }
+                }
+                Ok(None) => panic!("relay stream ended without a done sentinel; collected so far: {out:?}"),
+                Err(_) => panic!("timed out waiting for a relayed chunk; collected so far: {out:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn relaying_does_not_change_the_persisted_body() {
+        let frames = [chunk("Hello"), chunk(" world"), "[DONE]".to_string()];
+        let refs: Vec<&str> = frames.iter().map(String::as_str).collect();
+
+        let without_relay = reassemble_stream(sse_response(StatusCode::OK, &refs), timeouts(1000, 1000, 5000), None).await;
+        let without_relay_body = body_string(without_relay).await;
+
+        let relay_ctx = RelayContext {
+            relay: test_relay(),
+            request_id: uuid::Uuid::new_v4(),
+            zdr_key: None,
+            seq: 0,
+        };
+        let with_relay = reassemble_stream(sse_response(StatusCode::OK, &refs), timeouts(1000, 1000, 5000), Some(relay_ctx)).await;
+        let with_relay_body = body_string(with_relay).await;
+
+        assert_eq!(
+            without_relay_body, with_relay_body,
+            "relaying must never change the persisted/reassembled body"
+        );
+    }
+
+    #[tokio::test]
+    async fn relaying_delivers_one_message_per_frame_in_order_then_done() {
+        let frames = [chunk("Hello"), chunk(" world"), "[DONE]".to_string()];
+        let refs: Vec<&str> = frames.iter().map(String::as_str).collect();
+
+        let relay = test_relay();
+        let request_id = uuid::Uuid::new_v4();
+        let mut relayed = relay.subscribe(request_id);
+        let relay_ctx = RelayContext {
+            relay,
+            request_id,
+            zdr_key: None,
+            seq: 0,
+        };
+
+        reassemble_stream(sse_response(StatusCode::OK, &refs), timeouts(1000, 1000, 5000), Some(relay_ctx)).await;
+
+        let received = collect_relayed_until_done(&mut relayed).await;
+
+        assert_eq!(
+            received.len(),
+            refs.len() + 1,
+            "expected one relayed message per SSE frame plus a trailing done sentinel"
+        );
+        for (relayed_msg, frame) in received.iter().zip(refs.iter()) {
+            assert_eq!(&relayed_msg.data, frame);
+        }
+        assert!(received.last().unwrap().done);
+    }
+
+    /// ZDR chunks must arrive as ciphertext, decrypt correctly, and never
+    /// perturb the persisted body.
+    #[tokio::test]
+    async fn zdr_relay_encrypts_chunks_without_perturbing_the_persisted_body() {
+        let frames = [chunk("secret"), "[DONE]".to_string()];
+        let refs: Vec<&str> = frames.iter().map(String::as_str).collect();
+
+        let plain = reassemble_stream(sse_response(StatusCode::OK, &refs), timeouts(1000, 1000, 5000), None).await;
+        let plain_body = body_string(plain).await;
+
+        let relay = test_relay();
+        let request_id = uuid::Uuid::new_v4();
+        let mut relayed = relay.subscribe(request_id);
+        let key = crate::keystore::generate_key();
+        let relay_ctx = RelayContext {
+            relay,
+            request_id,
+            zdr_key: Some(key.to_vec()),
+            seq: 0,
+        };
+
+        let zdr_response = reassemble_stream(sse_response(StatusCode::OK, &refs), timeouts(1000, 1000, 5000), Some(relay_ctx)).await;
+        let zdr_body = body_string(zdr_response).await;
+        assert_eq!(
+            plain_body, zdr_body,
+            "ZDR chunk encryption must never change the persisted/reassembled body"
+        );
+
+        let received = collect_relayed_until_done(&mut relayed).await;
+        for (relayed_msg, frame) in received.iter().zip(refs.iter()) {
+            assert_ne!(&relayed_msg.data, frame, "ZDR chunks must never be relayed in plaintext");
+            let decrypted = crate::inference::zdr::decrypt_body(&key, &relayed_msg.data).expect("chunk should decrypt with the same key");
+            assert_eq!(decrypted, *frame);
+        }
     }
 }

--- a/dwctl/src/inference/store.rs
+++ b/dwctl/src/inference/store.rs
@@ -452,6 +452,15 @@ fn state_to_status(state: &str) -> &'static str {
     }
 }
 
+/// Extract the `response` field from the last event in a raw SSE event
+/// sequence (`event: X\ndata: {...}\n\n` blocks). The last event is always
+/// `response.completed`/`.failed`, which carries the full object.
+fn last_sse_event_response(sse_text: &str) -> Option<serde_json::Value> {
+    let last_block = sse_text.split("\n\n").filter(|b| !b.trim().is_empty()).last()?;
+    let data_line = last_block.lines().find_map(|line| line.strip_prefix("data: "))?;
+    serde_json::from_str::<serde_json::Value>(data_line).ok()?.get("response").cloned()
+}
+
 /// Convert a `RequestDetail` into an Open Responses API Response object.
 pub fn detail_to_response_object(detail: &fusillade::RequestDetail) -> serde_json::Value {
     let status = state_to_status(&detail.status);
@@ -504,22 +513,32 @@ pub fn detail_to_response_object(detail: &fusillade::RequestDetail) -> serde_jso
                 "code": response_status,
                 "message": message,
             });
-        } else if let Some(ref body) = detail.response_body
-            && let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body)
-        {
-            if let Some(output) = parsed.get("output") {
-                resp["output"] = output.clone();
-            }
-            if let Some(usage) = parsed.get("usage") {
-                resp["usage"] = usage.clone();
-            }
-            // ChatCompletion format (batch results)
-            if parsed.get("choices").is_some() {
-                resp["output"] = serde_json::json!([{
-                    "type": "message",
-                    "role": "assistant",
-                    "content": parsed
-                }]);
+        } else if let Some(ref body) = detail.response_body {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+                if let Some(output) = parsed.get("output") {
+                    resp["output"] = output.clone();
+                }
+                if let Some(usage) = parsed.get("usage") {
+                    resp["usage"] = usage.clone();
+                }
+                // ChatCompletion format (batch results)
+                if parsed.get("choices").is_some() {
+                    resp["output"] = serde_json::json!([{
+                        "type": "message",
+                        "role": "assistant",
+                        "content": parsed
+                    }]);
+                }
+            } else if let Some(final_response) = last_sse_event_response(body) {
+                // Responses-surface reassembly stores the raw SSE event
+                // sequence (translated upstream of persist), not a plain
+                // JSON body. The last event carries the full object.
+                if let Some(output) = final_response.get("output") {
+                    resp["output"] = output.clone();
+                }
+                if let Some(usage) = final_response.get("usage") {
+                    resp["usage"] = usage.clone();
+                }
             }
         }
         resp["completed_at"] = serde_json::json!(detail.completed_at.map(|t| t.timestamp()));

--- a/dwctl/src/inference/streaming.rs
+++ b/dwctl/src/inference/streaming.rs
@@ -32,12 +32,9 @@ pub struct LiveRelayConfig {
     /// Correctness fallback while the relay is primary — deliberately much
     /// slower than the 500ms used when live streaming is off.
     pub poll_fallback_interval: std::time::Duration,
-    /// `Some` on the Responses surface: the client's own request plus its
-    /// tracking id, used to reframe each relayed chunk into `response.*`
-    /// events. Relayed chunks are Chat Completions shaped (Responses reaches
-    /// `outbound_request` already translated to that shape — see its module
-    /// docs), so they need the same reframing `ResponsesStreamReframer` gives
-    /// the live warm path. `None` forwards chunks as-is (chat-completions).
+    /// `Some` on the Responses surface: seeds a per-chunk reframe into
+    /// `response.*` events, since relayed chunks are Chat Completions shaped
+    /// (see `outbound_request`'s module docs). `None` forwards chunks as-is.
     pub responses_reframe: Option<(ResponsesRequest, String)>,
 }
 
@@ -98,28 +95,19 @@ impl ReplayFrame {
 /// Respond-first SSE for the blocking flex streaming surfaces
 /// (chat-completions and responses).
 ///
-/// Flex is daemon-processed and can sit queued for a long time, so we return
-/// `200 text/event-stream` immediately and poll the daemon *inside* the
-/// stream. axum's [`KeepAlive`] injects `:` comments while we wait, keeping
-/// the client connection warm past idle timeouts (a poll-then-respond design
-/// would send no bytes — not even headers — until the daemon finished, and a
-/// client idle timeout could fire first).
+/// Flex can sit queued a long time, so this returns `200 text/event-stream`
+/// immediately and polls the daemon *inside* the stream. `KeepAlive` covers
+/// the wait with `:` comments — a poll-then-respond design would send no
+/// bytes until the daemon finished, risking a client idle timeout first.
+/// Enqueue failure is the exception: it happens before any byte is sent, so
+/// it still returns a clean JSON `500`.
 ///
-/// When the request reaches a terminal state, `render` turns the outcome —
-/// `Ok(detail)` on a terminal row, `Err(msg)` on timeout/poll failure — into
-/// the frames to emit: success chunks/events on 2xx, an in-stream error frame
-/// otherwise. Errors are delivered *down the stream*, not as an HTTP status,
-/// because the `200` was already committed.
-///
-/// Enqueue failure is the one exception: it happens before any byte is sent,
-/// so it still returns a clean JSON `500`.
-///
-/// `done_sentinel` appends a trailing `data: [DONE]` (the chat-completions
-/// terminator); the Responses surface ends on `response.completed`/`.failed`
-/// and passes `false`.
-///
-/// `live_relay`, when set, races a relay task against the poll task (see
-/// [`Terminal`]); `None` is exactly today's behavior.
+/// On a terminal result, `render` turns it into frames; errors go down the
+/// stream, not as an HTTP status, since the `200` is already committed.
+/// `done_sentinel` appends `data: [DONE]` for chat-completions; Responses
+/// ends on `response.completed`/`.failed` and passes `false`. `live_relay`,
+/// when set, races a relay task against the poll task (see [`Terminal`]);
+/// `None` is today's poll-only behavior.
 pub async fn flex_stream_response<P, F>(
     request_manager: Arc<fusillade_arsenal::PostgresRequestManager<P>>,
     flex_input: fusillade::CreateFlexInput,
@@ -176,12 +164,9 @@ where
         ));
     }
 
-    // Poll task: the HTTP response is already returning; this fills the stream
-    // once the daemon reaches a terminal state. Until then the channel is idle
-    // and axum's keep-alive holds the connection open.
-    //
-    // Races against `terminal.claimed_by_other()` so a relay-delivered
-    // response doesn't sit open until this task's own next poll tick.
+    // The HTTP response is already returning; this fills the stream once the
+    // daemon reaches a terminal state. Races `terminal.claimed_by_other()` so
+    // a relay-delivered response doesn't sit open until this task's next poll.
     tokio::spawn(async move {
         let timeout = std::time::Duration::from_secs(3600);
 
@@ -268,10 +253,8 @@ async fn run_live_relay(
                         return;
                     }
                     match reframe.as_mut() {
-                        // Nothing in the raw relayed stream says "response
-                        // complete" — that only exists once reframed, so
-                        // finalize() (response.completed/output_item.done etc.)
-                        // has to run here rather than arriving as a message.
+                        // Nothing in the raw stream says "response complete" —
+                        // only finalize() produces that, so it runs here.
                         Some((state, _, _)) => {
                             for event in state.finalize() {
                                 if send_streaming_event(&tx, &event).await.is_err() {

--- a/dwctl/src/inference/streaming.rs
+++ b/dwctl/src/inference/streaming.rs
@@ -7,15 +7,65 @@
 //! in `inference/middleware.rs`.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use axum::response::sse::{Event, KeepAlive, Sse};
+use futures::StreamExt;
 use serde_json::Value;
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
+
+use super::zdr;
 
 /// Buffer size for the flex replay channel: a finished request renders to a
 /// small, bounded set of frames, so a shallow buffer is enough.
 const FLEX_REPLAY_BUFFER: usize = 16;
+
+/// `None` means `flex_stream_response` behaves exactly as before: a single
+/// 500ms poll task, no relay subscriber.
+#[derive(Clone)]
+pub struct LiveRelayConfig {
+    pub relay: crate::chunk_relay::ChunkRelay,
+    /// Correctness fallback while the relay is primary — deliberately much
+    /// slower than the 500ms used when live streaming is off.
+    pub poll_fallback_interval: std::time::Duration,
+}
+
+/// Ensures only one of {poll task, relay task} sends the terminal frame(s).
+struct Terminal {
+    claimed: AtomicBool,
+    notify: Notify,
+}
+
+impl Terminal {
+    fn new() -> Self {
+        Self {
+            claimed: AtomicBool::new(false),
+            notify: Notify::new(),
+        }
+    }
+
+    /// `true` for exactly one caller, ever; wakes anyone parked in
+    /// `claimed_by_other` so they stand down immediately.
+    fn claim(&self) -> bool {
+        let already_claimed = self.claimed.swap(true, Ordering::SeqCst);
+        if !already_claimed {
+            self.notify.notify_waiters();
+        }
+        !already_claimed
+    }
+
+    /// The `Notified` future must be created before checking `claimed`:
+    /// `notify_waiters()` only wakes already-registered waiters, so
+    /// checking first can miss a concurrent `claim()`.
+    async fn claimed_by_other(&self) {
+        let notified = self.notify.notified();
+        if self.claimed.load(Ordering::SeqCst) {
+            return;
+        }
+        notified.await;
+    }
+}
 
 /// One SSE frame to replay once a flex request reaches a terminal state.
 pub struct ReplayFrame {
@@ -57,12 +107,16 @@ impl ReplayFrame {
 /// `done_sentinel` appends a trailing `data: [DONE]` (the chat-completions
 /// terminator); the Responses surface ends on `response.completed`/`.failed`
 /// and passes `false`.
+///
+/// `live_relay`, when set, races a relay task against the poll task (see
+/// [`Terminal`]); `None` is exactly today's behavior.
 pub async fn flex_stream_response<P, F>(
     request_manager: Arc<fusillade_arsenal::PostgresRequestManager<P>>,
     flex_input: fusillade::CreateFlexInput,
     request_id: uuid::Uuid,
     done_sentinel: bool,
     keystore: Option<crate::keystore::Keystore>,
+    live_relay: Option<LiveRelayConfig>,
     render: F,
 ) -> axum::response::Response
 where
@@ -88,15 +142,42 @@ where
     }
 
     let (tx, rx) = mpsc::channel::<Result<Event, std::convert::Infallible>>(FLEX_REPLAY_BUFFER);
+    let terminal = Arc::new(Terminal::new());
+
+    // 500ms when live streaming is off; the slower configured fallback once
+    // a relay is racing it.
+    let poll_interval = live_relay
+        .as_ref()
+        .map(|lr| lr.poll_fallback_interval)
+        .unwrap_or(std::time::Duration::from_millis(500));
+
+    if let Some(live_relay) = live_relay {
+        let tx = tx.clone();
+        let keystore = keystore.clone();
+        let terminal = terminal.clone();
+        tokio::spawn(run_live_relay(live_relay.relay, request_id, keystore, tx, terminal, done_sentinel));
+    }
 
     // Poll task: the HTTP response is already returning; this fills the stream
     // once the daemon reaches a terminal state. Until then the channel is idle
     // and axum's keep-alive holds the connection open.
+    //
+    // Races against `terminal.claimed_by_other()` so a relay-delivered
+    // response doesn't sit open until this task's own next poll tick.
     tokio::spawn(async move {
-        let poll_interval = std::time::Duration::from_millis(500);
         let timeout = std::time::Duration::from_secs(3600);
-        let result =
-            crate::inference::store::poll_until_terminal(&request_manager, request_id, poll_interval, timeout, keystore.as_ref()).await;
+
+        let result = tokio::select! {
+            biased;
+
+            _ = terminal.claimed_by_other() => return,
+
+            result = crate::inference::store::poll_until_terminal(&request_manager, request_id, poll_interval, timeout, keystore.as_ref()) => result,
+        };
+
+        if !terminal.claim() {
+            return;
+        }
 
         let frames = match &result {
             Ok(detail) => render(Ok(detail)),
@@ -121,4 +202,67 @@ where
     });
 
     Sse::new(ReceiverStream::new(rx)).keep_alive(KeepAlive::default()).into_response()
+}
+
+/// Subscribes to a request's relayed chunks and forwards them live,
+/// decrypting first when ZDR. Races against `terminal` so it never
+/// outlives the request even if the relay never produces a `done`.
+async fn run_live_relay(
+    relay: crate::chunk_relay::ChunkRelay,
+    request_id: uuid::Uuid,
+    keystore: Option<crate::keystore::Keystore>,
+    tx: mpsc::Sender<Result<Event, std::convert::Infallible>>,
+    terminal: Arc<Terminal>,
+    done_sentinel: bool,
+) {
+    // Non-destructive fetch; `None` for a non-ZDR request.
+    let zdr_key = match &keystore {
+        Some(ks) => ks.get(&zdr::key_id(&request_id, zdr::KeyKind::Response)).await.ok().flatten(),
+        None => None,
+    };
+
+    let mut stream = relay.subscribe(request_id);
+
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = terminal.claimed_by_other() => {
+                return;
+            }
+
+            msg = stream.next() => {
+                let Some(msg) = msg else {
+                    return; // relay dropped the subscriber; poll fallback covers it
+                };
+
+                if msg.done {
+                    if terminal.claim() && done_sentinel {
+                        let _ = tx.send(Ok(Event::default().data("[DONE]"))).await;
+                    }
+                    return;
+                }
+
+                let payload = match &zdr_key {
+                    Some(key) => match zdr::decrypt_body(key, &msg.data) {
+                        Ok(plaintext) => plaintext,
+                        Err(e) => {
+                            tracing::debug!(%request_id, error = %e, "failed to decrypt relayed chunk, skipping");
+                            continue;
+                        }
+                    },
+                    None => msg.data,
+                };
+
+                let Ok(parsed) = serde_json::from_str::<Value>(&payload) else {
+                    tracing::debug!(%request_id, "relayed chunk was not valid JSON, skipping");
+                    continue;
+                };
+
+                if tx.send(Ok(Event::default().data(parsed.to_string()))).await.is_err() {
+                    return; // client disconnected
+                }
+            }
+        }
+    }
 }

--- a/dwctl/src/inference/streaming.rs
+++ b/dwctl/src/inference/streaming.rs
@@ -11,10 +11,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use axum::response::sse::{Event, KeepAlive, Sse};
 use futures::StreamExt;
+use onwards::strict::schemas::chat_completions::{ChatCompletionChunk, normalize_chat_completion_chunk_value};
 use serde_json::Value;
 use tokio::sync::{Notify, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 
+use super::translation::responses::streaming::{StreamingEvent, StreamingState};
+use super::translation::responses::types::ResponsesRequest;
 use super::zdr;
 
 /// Buffer size for the flex replay channel: a finished request renders to a
@@ -29,6 +32,13 @@ pub struct LiveRelayConfig {
     /// Correctness fallback while the relay is primary — deliberately much
     /// slower than the 500ms used when live streaming is off.
     pub poll_fallback_interval: std::time::Duration,
+    /// `Some` on the Responses surface: the client's own request plus its
+    /// tracking id, used to reframe each relayed chunk into `response.*`
+    /// events. Relayed chunks are Chat Completions shaped (Responses reaches
+    /// `outbound_request` already translated to that shape — see its module
+    /// docs), so they need the same reframing `ResponsesStreamReframer` gives
+    /// the live warm path. `None` forwards chunks as-is (chat-completions).
+    pub responses_reframe: Option<(ResponsesRequest, String)>,
 }
 
 /// Ensures only one of {poll task, relay task} sends the terminal frame(s).
@@ -155,7 +165,15 @@ where
         let tx = tx.clone();
         let keystore = keystore.clone();
         let terminal = terminal.clone();
-        tokio::spawn(run_live_relay(live_relay.relay, request_id, keystore, tx, terminal, done_sentinel));
+        tokio::spawn(run_live_relay(
+            live_relay.relay,
+            request_id,
+            keystore,
+            tx,
+            terminal,
+            done_sentinel,
+            live_relay.responses_reframe,
+        ));
     }
 
     // Poll task: the HTTP response is already returning; this fills the stream
@@ -214,12 +232,21 @@ async fn run_live_relay(
     tx: mpsc::Sender<Result<Event, std::convert::Infallible>>,
     terminal: Arc<Terminal>,
     done_sentinel: bool,
+    responses_reframe: Option<(ResponsesRequest, String)>,
 ) {
     // Non-destructive fetch; `None` for a non-ZDR request.
     let zdr_key = match &keystore {
         Some(ks) => ks.get(&zdr::key_id(&request_id, zdr::KeyKind::Response)).await.ok().flatten(),
         None => None,
     };
+
+    // On the Responses surface, relayed chunks are Chat Completions shaped and
+    // need reframing into `response.*` events, mirroring `ResponsesStreamReframer`.
+    let mut reframe = responses_reframe.map(|(req, response_id)| {
+        let model = req.model.clone();
+        let state = StreamingState::new(&req, Some(&response_id));
+        (state, model, response_id)
+    });
 
     let mut stream = relay.subscribe(request_id);
 
@@ -237,8 +264,25 @@ async fn run_live_relay(
                 };
 
                 if msg.done {
-                    if terminal.claim() && done_sentinel {
-                        let _ = tx.send(Ok(Event::default().data("[DONE]"))).await;
+                    if !terminal.claim() {
+                        return;
+                    }
+                    match reframe.as_mut() {
+                        // Nothing in the raw relayed stream says "response
+                        // complete" — that only exists once reframed, so
+                        // finalize() (response.completed/output_item.done etc.)
+                        // has to run here rather than arriving as a message.
+                        Some((state, _, _)) => {
+                            for event in state.finalize() {
+                                if send_streaming_event(&tx, &event).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                        None if done_sentinel => {
+                            let _ = tx.send(Ok(Event::default().data("[DONE]"))).await;
+                        }
+                        None => {}
                     }
                     return;
                 }
@@ -254,15 +298,38 @@ async fn run_live_relay(
                     None => msg.data,
                 };
 
-                let Ok(parsed) = serde_json::from_str::<Value>(&payload) else {
+                let Ok(mut parsed) = serde_json::from_str::<Value>(&payload) else {
                     tracing::debug!(%request_id, "relayed chunk was not valid JSON, skipping");
                     continue;
                 };
 
-                if tx.send(Ok(Event::default().data(parsed.to_string()))).await.is_err() {
-                    return; // client disconnected
+                match reframe.as_mut() {
+                    Some((state, model, fallback_id)) => {
+                        normalize_chat_completion_chunk_value(&mut parsed, model, fallback_id);
+                        let Ok(chunk) = serde_json::from_value::<ChatCompletionChunk>(parsed) else {
+                            tracing::debug!(%request_id, "relayed chunk did not parse as a chat completion chunk, skipping");
+                            continue;
+                        };
+                        for event in state.process_chunk(&chunk) {
+                            if send_streaming_event(&tx, &event).await.is_err() {
+                                return;
+                            }
+                        }
+                    }
+                    None => {
+                        if tx.send(Ok(Event::default().data(parsed.to_string()))).await.is_err() {
+                            return; // client disconnected
+                        }
+                    }
                 }
             }
         }
     }
+}
+
+async fn send_streaming_event(tx: &mpsc::Sender<Result<Event, std::convert::Infallible>>, event: &StreamingEvent) -> Result<(), ()> {
+    let data = serde_json::to_string(event).unwrap_or_default();
+    tx.send(Ok(Event::default().event(event.event_type.clone()).data(data)))
+        .await
+        .map_err(|_| ())
 }

--- a/dwctl/src/inference/streaming.rs
+++ b/dwctl/src/inference/streaming.rs
@@ -181,6 +181,7 @@ where
         if !terminal.claim() {
             return;
         }
+        tracing::debug!(%request_id, "flex terminal claimed by: poll_fallback");
 
         let frames = match &result {
             Ok(detail) => render(Ok(detail)),
@@ -205,6 +206,21 @@ where
     });
 
     Sse::new(ReceiverStream::new(rx)).keep_alive(KeepAlive::default()).into_response()
+}
+
+/// Guarantees the relay's subscriber-registry entry is removed no matter
+/// which of `run_live_relay`'s exit paths fires (including task
+/// cancellation), so a request that never sees a `done` frame doesn't sit
+/// in the registry forever.
+struct UnsubscribeOnDrop<'a> {
+    relay: &'a crate::chunk_relay::ChunkRelay,
+    request_id: uuid::Uuid,
+}
+
+impl Drop for UnsubscribeOnDrop<'_> {
+    fn drop(&mut self) {
+        self.relay.unsubscribe(&self.request_id);
+    }
 }
 
 /// Subscribes to a request's relayed chunks and forwards them live,
@@ -234,6 +250,13 @@ async fn run_live_relay(
     });
 
     let mut stream = relay.subscribe(request_id);
+    // `subscribe`'s own doc note ("dropping the stream also works") only
+    // holds if the reader attempts another delivery to this subscriber.
+    // It won't, once the backend stops producing chunks. Losing the race
+    // below (poll_fallback claims first) then orphans this entry in the
+    // registry forever, diluting every future tick for every shard. Cover
+    // every exit path (not just poll losing) with an explicit unsubscribe.
+    let _unsub_guard = UnsubscribeOnDrop { relay: &relay, request_id };
 
     loop {
         tokio::select! {
@@ -252,6 +275,7 @@ async fn run_live_relay(
                     if !terminal.claim() {
                         return;
                     }
+                    tracing::debug!(%request_id, seq = msg.seq, "flex terminal claimed by: live_relay");
                     match reframe.as_mut() {
                         // Nothing in the raw stream says "response complete" —
                         // only finalize() produces that, so it runs here.

--- a/dwctl/src/inference/streaming.rs
+++ b/dwctl/src/inference/streaming.rs
@@ -38,7 +38,9 @@ pub struct LiveRelayConfig {
     pub responses_reframe: Option<(ResponsesRequest, String)>,
 }
 
-/// Ensures only one of {poll task, relay task} sends the terminal frame(s).
+/// Ensures only one of {poll task, relay task} ever sends output to the
+/// client, not just the terminal frame(s) — else the client can see the
+/// same content twice.
 struct Terminal {
     claimed: AtomicBool,
     notify: Notify,
@@ -258,11 +260,18 @@ async fn run_live_relay(
     // every exit path (not just poll losing) with an explicit unsubscribe.
     let _unsub_guard = UnsubscribeOnDrop { relay: &relay, request_id };
 
+    // Set once this task wins `terminal`'s claim; nothing may reach `tx`
+    // before that, or the client sees this partial stream plus poll's
+    // full replay.
+    let mut owns_terminal = false;
+
     loop {
         tokio::select! {
             biased;
 
-            _ = terminal.claimed_by_other() => {
+            // Guarded: once we own it, `claimed_by_other()` can't tell "by
+            // me" from "by someone else" and would fire immediately.
+            _ = terminal.claimed_by_other(), if !owns_terminal => {
                 return;
             }
 
@@ -272,7 +281,7 @@ async fn run_live_relay(
                 };
 
                 if msg.done {
-                    if !terminal.claim() {
+                    if !owns_terminal && !terminal.claim() {
                         return;
                     }
                     tracing::debug!(%request_id, seq = msg.seq, "flex terminal claimed by: live_relay");
@@ -310,6 +319,15 @@ async fn run_live_relay(
                     continue;
                 };
 
+                // Claim only once we're actually forwarding something —
+                // chunks dropped above never reach the client.
+                if !owns_terminal {
+                    if !terminal.claim() {
+                        return;
+                    }
+                    owns_terminal = true;
+                }
+
                 match reframe.as_mut() {
                     Some((state, model, fallback_id)) => {
                         normalize_chat_completion_chunk_value(&mut parsed, model, fallback_id);
@@ -339,4 +357,90 @@ async fn send_streaming_event(tx: &mpsc::Sender<Result<Event, std::convert::Infa
     tx.send(Ok(Event::default().event(event.event_type.clone()).data(data)))
         .await
         .map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::chunk_relay::{ChunkRelay, ChunkRelayConfig};
+
+    // Needs a real Redis; override TEST_REDIS_URL if `just redis-start`'s
+    // default doesn't apply — same convention as chunk_relay.rs's own tests.
+    fn test_relay_config() -> ChunkRelayConfig {
+        ChunkRelayConfig {
+            redis_url: std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string()),
+            stream_ttl_secs: 60,
+            maxlen: 2000,
+            publish_channel_capacity: 1024,
+            reader_poll_interval_ms: 20,
+            publish_workers: 2,
+            reader_workers: 2,
+        }
+    }
+
+    async fn recv_within(rx: &mut mpsc::Receiver<Result<Event, std::convert::Infallible>>, timeout: Duration) -> Option<Event> {
+        match tokio::time::timeout(timeout, rx.recv()).await {
+            Ok(Some(Ok(event))) => Some(event),
+            Ok(None) | Err(_) => None,
+        }
+    }
+
+    /// After forwarding real content, `run_live_relay` must already own
+    /// `terminal` — a concurrent claim attempt has to fail.
+    #[tokio::test]
+    async fn forwarding_a_chunk_wins_the_terminal_claim() {
+        let relay = ChunkRelay::from_config(&test_relay_config()).expect("relay should build against local redis");
+        let request_id = Uuid::new_v4();
+        let terminal = Arc::new(Terminal::new());
+        let (tx, mut rx) = mpsc::channel(16);
+
+        let handle = tokio::spawn(run_live_relay(relay.clone(), request_id, None, tx, terminal.clone(), true, None));
+
+        relay.publish_nonblocking(request_id, 0, r#"{"choices":[{"delta":{"content":"hi"}}]}"#);
+        assert!(
+            recv_within(&mut rx, Duration::from_secs(5)).await.is_some(),
+            "expected the content chunk to be forwarded"
+        );
+
+        assert!(
+            !terminal.claim(),
+            "live_relay must already own the terminal after forwarding real content"
+        );
+
+        relay.publish_done_nonblocking(request_id, 1);
+        assert!(
+            recv_within(&mut rx, Duration::from_secs(5)).await.is_some(),
+            "expected the [DONE] sentinel once live_relay's own done chunk lands"
+        );
+
+        handle.await.expect("run_live_relay task should not panic");
+    }
+
+    /// Once `poll_fallback` has claimed, `run_live_relay` must forward
+    /// nothing at all, not even a first chunk.
+    #[tokio::test]
+    async fn sends_nothing_once_poll_fallback_has_already_claimed() {
+        let relay = ChunkRelay::from_config(&test_relay_config()).expect("relay should build against local redis");
+        let request_id = Uuid::new_v4();
+        let terminal = Arc::new(Terminal::new());
+        let (tx, mut rx) = mpsc::channel(16);
+
+        assert!(terminal.claim(), "test setup: simulated poll_fallback should win the claim");
+
+        let handle = tokio::spawn(run_live_relay(relay.clone(), request_id, None, tx, terminal.clone(), true, None));
+
+        relay.publish_nonblocking(request_id, 0, r#"{"choices":[{"delta":{"content":"hi"}}]}"#);
+        relay.publish_done_nonblocking(request_id, 1);
+
+        assert!(
+            recv_within(&mut rx, Duration::from_secs(2)).await.is_none(),
+            "live_relay must not forward anything once poll_fallback already owns the terminal"
+        );
+
+        handle.await.expect("run_live_relay task should not panic");
+    }
 }

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -142,6 +142,7 @@ fn install_crypto_provider() {
 
 pub mod api;
 pub mod auth;
+pub mod chunk_relay;
 pub mod clickhouse;
 pub mod config;
 mod config_watcher;
@@ -313,6 +314,11 @@ where
     /// Encrypted key custody, built from `config.keystore`. `None` means it is
     /// not configured (ZDR flex disabled).
     pub keystore: Option<crate::keystore::Keystore>,
+    /// Flex live-streaming chunk relay, built from
+    /// `config.flex_live_streaming`. `None` means live streaming is
+    /// disabled or unconfigured — flex streaming falls back to the
+    /// existing poll-and-replay path.
+    pub chunk_relay: Option<crate::chunk_relay::ChunkRelay>,
 }
 
 impl<P> AppState<P>
@@ -2381,6 +2387,8 @@ pub async fn build_router(
         let daemon = &state.current_config().background_services.batch_daemon;
         let outbound_config = crate::inference::outbound_request::OutboundConfig {
             timeouts: crate::inference::outbound_request::StreamTimeouts::from_daemon_config(daemon),
+            relay: state.chunk_relay.clone(),
+            keystore: state.keystore.clone(),
         };
         onwards_router.layer(middleware::from_fn_with_state(
             outbound_config,
@@ -4153,6 +4161,14 @@ impl Application {
             Some(c) => Some(crate::keystore::Keystore::from_config(c).map_err(|e| anyhow::anyhow!("failed to initialise keystore: {e}"))?),
             None => None,
         };
+        // `None` unless both `enabled` and `chunk_relay` are set.
+        let chunk_relay = match (config.flex_live_streaming.enabled, config.flex_live_streaming.chunk_relay.as_ref()) {
+            (true, Some(c)) => Some(
+                crate::chunk_relay::ChunkRelay::from_config(c)
+                    .map_err(|e| anyhow::anyhow!("failed to initialise flex chunk relay: {e}"))?,
+            ),
+            _ => None,
+        };
         let response_store =
             Arc::new(crate::inference::store::FusilladeResponseStore::new(request_manager.clone()).with_keystore(keystore.clone()));
 
@@ -4300,6 +4316,8 @@ impl Application {
             unverified_requests_per_completion_hour: config.batches.unverified_requests_per_completion_hour,
             flex_completion_window: config.batches.async_requests.completion_window.clone(),
             keystore: bg_services.keystore.clone(),
+            chunk_relay: chunk_relay.clone(),
+            flex_poll_fallback_interval_ms: config.flex_live_streaming.poll_fallback_interval_ms,
             zdr_key_cache: bg_services.zdr_key_cache.clone(),
         };
 
@@ -4343,6 +4361,7 @@ impl Application {
             .limiters(limiters)
             .maybe_connections_encryption_key(bg_services.connections_encryption_key.clone())
             .maybe_keystore(bg_services.keystore.clone())
+            .maybe_chunk_relay(chunk_relay.clone())
             .response_store(response_store)
             .image_normalizer(image_normalizer)
             .build();
@@ -4385,6 +4404,36 @@ impl Application {
         // Apply middleware before path matching for tests
         let middleware = middleware::from_fn_with_state(self.app_state, admin_ai_proxy_middleware);
         let service = middleware.layer(self.router).into_make_service();
+        let server = axum_test::TestServer::new(service).expect("Failed to create test server");
+        (server, self.bg_services)
+    }
+
+    /// Like [`Application::into_test_server`], but also serves the app on a
+    /// real, already-bound socket — for tests where the fusillade daemon
+    /// needs to make a real loopback dispatch (its own HTTP client can't
+    /// reach axum_test's in-process mock transport). Caller must bind the
+    /// listener and set `config.host`/`config.port` from its resolved
+    /// address *before* constructing the `Application`, since
+    /// `loopback_base_url` is baked in then — see
+    /// `test::utils::create_test_app_with_real_loopback`.
+    #[cfg(test)]
+    pub fn into_test_server_on_real_socket(self, listener: TcpListener) -> (axum_test::TestServer, BackgroundServices) {
+        let middleware = middleware::from_fn_with_state(self.app_state, admin_ai_proxy_middleware);
+        let service = middleware.layer(self.router).into_make_service();
+
+        // Tied to bg_services' shutdown token, or this outlives the test's
+        // own shutdown call and races #[sqlx::test]'s database teardown.
+        let shutdown_token = self.bg_services.shutdown_token();
+        let real_socket_service = service.clone();
+        tokio::spawn(async move {
+            let result = axum::serve(listener, real_socket_service)
+                .with_graceful_shutdown(async move { shutdown_token.cancelled().await })
+                .await;
+            if let Err(e) = result {
+                tracing::warn!(error = %e, "test real-socket server exited");
+            }
+        });
+
         let server = axum_test::TestServer::new(service).expect("Failed to create test server");
         (server, self.bg_services)
     }

--- a/dwctl/src/test/flex_live_streaming.rs
+++ b/dwctl/src/test/flex_live_streaming.rs
@@ -114,7 +114,7 @@ async fn setup_flex_fixture(pool: &PgPool, live_streaming_enabled: bool) -> Flex
         enabled: DaemonEnabled::Always,
         claim_interval_ms: 50,
         max_retries: Some(0),
-        streamable_endpoints: vec!["/v1/chat/completions".to_string()],
+        streamable_endpoints: vec!["/v1/chat/completions".to_string(), "/v1/responses".to_string()],
         ..Default::default()
     };
     config.flex_live_streaming = FlexLiveStreamingConfig {
@@ -310,6 +310,68 @@ async fn flex_streaming_without_live_relay_still_replays_the_mega_delta(pool: Pg
 
     assert_eq!(response.status_code().as_u16(), 200);
     let deltas = parse_sse_content_deltas(&response.text());
+    assert_eq!(deltas, vec!["Hello world".to_string()], "flag off must behave exactly as before");
+
+    fixture.bg_services.shutdown().await;
+}
+
+async fn send_flex_responses_streaming_request(fixture: &FlexFixture) -> axum_test::TestResponse {
+    fixture
+        .server
+        .post("/ai/v1/responses")
+        .add_header("authorization", format!("Bearer {}", fixture.api_key))
+        .json(&serde_json::json!({
+            "model": "flex-live-alias",
+            "input": "Hello from flex live-streaming E2E",
+            "stream": true,
+            "service_tier": "flex"
+        }))
+        .await
+}
+
+// Keyed off the JSON payload's own "type" field, not the SSE "event:" line,
+// since axum emits fields in call order (data before event here) rather
+// than a fixed order.
+fn parse_response_output_text_deltas(text: &str) -> Vec<String> {
+    text.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+        .filter(|v| v["type"] == "response.output_text.delta")
+        .filter_map(|v| v["delta"].as_str().map(str::to_string))
+        .collect()
+}
+
+/// Same proof as the chat-completions test, on the Responses surface: real
+/// per-chunk `response.output_text.delta` events, not one delta replaying
+/// the whole answer.
+#[sqlx::test]
+#[test_log::test]
+async fn flex_live_streaming_delivers_real_incremental_response_deltas(pool: PgPool) {
+    let fixture = setup_flex_fixture(&pool, true).await;
+
+    let response = send_flex_responses_streaming_request(&fixture).await;
+
+    assert_eq!(response.status_code().as_u16(), 200);
+    let deltas = parse_response_output_text_deltas(&response.text());
+    assert_eq!(
+        deltas,
+        vec!["Hello".to_string(), " world".to_string()],
+        "expected the upstream's own per-chunk deltas on the Responses surface too"
+    );
+
+    fixture.bg_services.shutdown().await;
+}
+
+/// Control for the Responses surface: same mock, live streaming off.
+#[sqlx::test]
+#[test_log::test]
+async fn flex_responses_streaming_without_live_relay_still_replays_the_mega_delta(pool: PgPool) {
+    let fixture = setup_flex_fixture(&pool, false).await;
+
+    let response = send_flex_responses_streaming_request(&fixture).await;
+
+    assert_eq!(response.status_code().as_u16(), 200);
+    let deltas = parse_response_output_text_deltas(&response.text());
     assert_eq!(deltas, vec!["Hello world".to_string()], "flag off must behave exactly as before");
 
     fixture.bg_services.shutdown().await;

--- a/dwctl/src/test/flex_live_streaming.rs
+++ b/dwctl/src/test/flex_live_streaming.rs
@@ -329,9 +329,8 @@ async fn send_flex_responses_streaming_request(fixture: &FlexFixture) -> axum_te
         .await
 }
 
-// Keyed off the JSON payload's own "type" field, not the SSE "event:" line,
-// since axum emits fields in call order (data before event here) rather
-// than a fixed order.
+// Keyed off the "type" field, not the SSE "event:" line — axum emits
+// fields in call order here (data before event), not a fixed order.
 fn parse_response_output_text_deltas(text: &str) -> Vec<String> {
     text.lines()
         .filter_map(|line| line.strip_prefix("data: "))

--- a/dwctl/src/test/flex_live_streaming.rs
+++ b/dwctl/src/test/flex_live_streaming.rs
@@ -1,0 +1,316 @@
+//! End-to-end proof that flex live-streaming delivers real per-token
+//! deltas — not the poll-and-replay mega-delta — once
+//! `flex_live_streaming.enabled` is on, and that it's off unchanged.
+//!
+//! Asserts on content shape (small per-chunk deltas vs. one mega-delta),
+//! not timing: `TestServer` buffers the whole SSE body before the request
+//! future resolves, so inter-frame arrival can't be observed directly.
+//! Wall-clock time is checked too, as a corroborating signal only.
+
+use std::time::Duration;
+
+use axum_test::TestServer;
+use sqlx::PgPool;
+
+use crate::api::models::api_keys::ApiKeyResponse;
+use crate::api::models::deployments::DeployedModelResponse;
+use crate::api::models::groups::GroupResponse;
+use crate::api::models::inference_endpoints::InferenceEndpointResponse;
+use crate::api::models::users::Role;
+use crate::chunk_relay::ChunkRelayConfig;
+use crate::config::{DaemonConfig, DaemonEnabled, FlexLiveStreamingConfig};
+use crate::test::utils::{
+    add_auth_headers, create_test_admin_user, create_test_app_with_real_loopback, create_test_config, create_test_user,
+};
+
+fn test_redis_url() -> String {
+    std::env::var("TEST_REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string())
+}
+
+/// A real, socket-bound SSE mock server with real wall-clock gaps between
+/// frames — `wiremock` can't do this (its `Respond` trait returns one fixed
+/// `ResponseTemplate`, no mid-body delays).
+async fn start_slow_sse_mock_server(frames: Vec<(u64, String)>) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind mock server");
+    let addr = listener.local_addr().expect("mock server local addr");
+
+    let app = axum::Router::new().route(
+        "/v1/chat/completions",
+        axum::routing::post(move || {
+            let frames = frames.clone();
+            async move {
+                let stream = async_stream::stream! {
+                    for (delay_ms, frame) in frames {
+                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                        yield Ok::<_, std::convert::Infallible>(axum::body::Bytes::from(format!("data: {frame}\n\n")));
+                    }
+                };
+                axum::response::Response::builder()
+                    .header("content-type", "text/event-stream")
+                    .body(axum::body::Body::from_stream(stream))
+                    .unwrap()
+            }
+        }),
+    );
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("mock server serve");
+    });
+
+    format!("http://{addr}")
+}
+
+fn role_chunk() -> String {
+    r#"{"id":"chatcmpl-live","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}"#.to_string()
+}
+
+fn content_chunk(content: &str) -> String {
+    format!(
+        r#"{{"id":"chatcmpl-live","object":"chat.completion.chunk","created":1,"model":"m","choices":[{{"index":0,"delta":{{"content":"{content}"}},"finish_reason":null}}]}}"#
+    )
+}
+
+fn finish_chunk() -> String {
+    r#"{"id":"chatcmpl-live","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}"#.to_string()
+}
+
+/// Role chunk, two content chunks 150ms apart, a finish chunk, `[DONE]` —
+/// paced the way a real streaming provider paces tokens.
+fn mock_frames() -> Vec<(u64, String)> {
+    vec![
+        (0, role_chunk()),
+        (150, content_chunk("Hello")),
+        (150, content_chunk(" world")),
+        (150, finish_chunk()),
+        (0, "[DONE]".to_string()),
+    ]
+}
+
+fn parse_sse_content_deltas(text: &str) -> Vec<String> {
+    text.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter(|data| *data != "[DONE]")
+        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+        .filter_map(|v| v["choices"][0]["delta"]["content"].as_str().map(str::to_string))
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+struct FlexFixture {
+    server: TestServer,
+    // Held for the fixture's lifetime — dropping this stops the daemon.
+    bg_services: crate::BackgroundServices,
+    api_key: String,
+}
+
+async fn setup_flex_fixture(pool: &PgPool, live_streaming_enabled: bool) -> FlexFixture {
+    let mock_endpoint_url = start_slow_sse_mock_server(mock_frames()).await;
+
+    let mut config = create_test_config();
+    config.background_services.onwards_sync.enabled = true;
+    config.background_services.probe_scheduler.enabled = false;
+    config.background_services.leader_election.enabled = false;
+    config.background_services.batch_daemon = DaemonConfig {
+        enabled: DaemonEnabled::Always,
+        claim_interval_ms: 50,
+        max_retries: Some(0),
+        streamable_endpoints: vec!["/v1/chat/completions".to_string()],
+        ..Default::default()
+    };
+    config.flex_live_streaming = FlexLiveStreamingConfig {
+        enabled: live_streaming_enabled,
+        chunk_relay: Some(ChunkRelayConfig {
+            redis_url: test_redis_url(),
+            ..Default::default()
+        }),
+        // Much slower than the mock's ~450ms send time, so a fast test
+        // proves the relay delivered it, not a lucky poll tick.
+        poll_fallback_interval_ms: 5000,
+    };
+
+    let (server, bg_services) = create_test_app_with_real_loopback(pool.clone(), config).await;
+
+    let admin_user = create_test_admin_user(pool, Role::PlatformManager).await;
+    let admin_headers = add_auth_headers(&admin_user);
+    let regular_user = create_test_user(pool, Role::StandardUser).await;
+    let regular_headers = add_auth_headers(&regular_user);
+
+    let group_response = server
+        .post("/admin/api/v1/groups")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&serde_json::json!({
+            "name": format!("flex-live-streaming-{}", uuid::Uuid::new_v4()),
+            "description": "Flex live-streaming E2E"
+        }))
+        .await;
+    assert_eq!(group_response.status_code(), 201, "failed to create group");
+    let group: GroupResponse = group_response.json();
+
+    let add_user_response = server
+        .post(&format!("/admin/api/v1/groups/{}/users/{}", group.id, regular_user.id))
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .await;
+    assert_eq!(add_user_response.status_code(), 204, "failed to add user to group");
+
+    let credits_response = server
+        .post("/admin/api/v1/transactions")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&serde_json::json!({
+            "user_id": regular_user.id,
+            "transaction_type": "admin_grant",
+            "amount": 1000,
+            "source_id": admin_user.id,
+            "description": "Flex live-streaming E2E credits"
+        }))
+        .await;
+    assert_eq!(credits_response.status_code(), 201, "failed to grant credits");
+
+    let endpoint_response = server
+        .post("/admin/api/v1/endpoints")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&serde_json::json!({
+            "name": format!("flex-live-streaming-mock-{}", uuid::Uuid::new_v4()),
+            // onwards appends "/chat/completions" directly to this URL.
+            "url": format!("{mock_endpoint_url}/v1"),
+            "description": "Mock OpenAI-compatible endpoint for flex live-streaming E2E"
+        }))
+        .await;
+    assert_eq!(endpoint_response.status_code(), 201, "failed to create endpoint");
+    let endpoint: InferenceEndpointResponse = endpoint_response.json();
+
+    let deployment_response = server
+        .post("/admin/api/v1/models")
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .json(&serde_json::json!({
+            "type": "standard",
+            "model_name": "flex-live-model",
+            "alias": "flex-live-alias",
+            "description": "Flex live-streaming test deployment",
+            "hosted_on": endpoint.id,
+            "tariffs": [{
+                "name": "batch",
+                "input_price_per_token": "0.001",
+                "output_price_per_token": "0.003",
+                "api_key_purpose": "realtime"
+            }]
+        }))
+        .await;
+    assert_eq!(deployment_response.status_code(), 200, "failed to create deployment");
+    let deployment: DeployedModelResponse = deployment_response.json();
+
+    let add_deployment_response = server
+        .post(&format!("/admin/api/v1/groups/{}/models/{}", group.id, deployment.id))
+        .add_header(&admin_headers[0].0, &admin_headers[0].1)
+        .add_header(&admin_headers[1].0, &admin_headers[1].1)
+        .await;
+    assert_eq!(add_deployment_response.status_code(), 204, "failed to add deployment to group");
+
+    let api_key_response = server
+        .post(&format!("/admin/api/v1/users/{}/api-keys", regular_user.id))
+        .add_header(&regular_headers[0].0, &regular_headers[0].1)
+        .add_header(&regular_headers[1].0, &regular_headers[1].1)
+        .json(&serde_json::json!({
+            "name": "flex-live-streaming-key",
+            "description": "API key for flex live-streaming E2E",
+            "purpose": "realtime"
+        }))
+        .await;
+    assert_eq!(api_key_response.status_code(), 201, "failed to create API key");
+    let api_key: ApiKeyResponse = api_key_response.json();
+
+    bg_services.sync_onwards_config(pool).await.expect("sync onwards config");
+
+    for attempt in 0..50 {
+        let resp = server
+            .get("/ai/v1/models")
+            .add_header("authorization", format!("Bearer {}", api_key.key))
+            .await;
+        if resp.status_code() == 200 {
+            let body: serde_json::Value = resp.json();
+            let has_model = body["data"]
+                .as_array()
+                .is_some_and(|models| models.iter().any(|m| m["id"] == "flex-live-alias"));
+            if has_model {
+                break;
+            }
+        }
+        assert!(attempt < 49, "model never became routable");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    FlexFixture {
+        server,
+        bg_services,
+        api_key: api_key.key,
+    }
+}
+
+async fn send_flex_streaming_request(fixture: &FlexFixture) -> (axum_test::TestResponse, Duration) {
+    let started = std::time::Instant::now();
+    let response = fixture
+        .server
+        .post("/ai/v1/chat/completions")
+        .add_header("authorization", format!("Bearer {}", fixture.api_key))
+        .json(&serde_json::json!({
+            "model": "flex-live-alias",
+            "messages": [{"role": "user", "content": "Hello from flex live-streaming E2E"}],
+            "stream": true,
+            "service_tier": "flex"
+        }))
+        .await;
+    (response, started.elapsed())
+}
+
+#[sqlx::test]
+#[test_log::test]
+async fn flex_live_streaming_delivers_real_incremental_deltas(pool: PgPool) {
+    let fixture = setup_flex_fixture(&pool, true).await;
+
+    let (response, elapsed) = send_flex_streaming_request(&fixture).await;
+
+    assert_eq!(response.status_code().as_u16(), 200);
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .map_or("", |v| v.to_str().unwrap_or_default())
+        .to_string();
+    assert!(
+        content_type.starts_with("text/event-stream"),
+        "expected an SSE response, got {content_type:?}"
+    );
+
+    let deltas = parse_sse_content_deltas(&response.text());
+    assert_eq!(
+        deltas,
+        vec!["Hello".to_string(), " world".to_string()],
+        "expected the upstream's own per-chunk deltas, not a poll-fallback mega-delta"
+    );
+
+    assert!(
+        elapsed < Duration::from_millis(3000),
+        "expected the relay, not the 5000ms poll fallback, to deliver the answer; took {elapsed:?}"
+    );
+
+    fixture.bg_services.shutdown().await;
+}
+
+/// Control: same mock and setup, live streaming off — proves the assertion
+/// above is discriminating, not coincidental.
+#[sqlx::test]
+#[test_log::test]
+async fn flex_streaming_without_live_relay_still_replays_the_mega_delta(pool: PgPool) {
+    let fixture = setup_flex_fixture(&pool, false).await;
+
+    let (response, _elapsed) = send_flex_streaming_request(&fixture).await;
+
+    assert_eq!(response.status_code().as_u16(), 200);
+    let deltas = parse_sse_content_deltas(&response.text());
+    assert_eq!(deltas, vec!["Hello world".to_string()], "flag off must behave exactly as before");
+
+    fixture.bg_services.shutdown().await;
+}

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -1,6 +1,7 @@
 pub mod anthropic;
 pub mod cache_classifier;
 pub mod databases;
+pub mod flex_live_streaming;
 pub mod responses;
 pub mod sigterm_drain;
 pub mod sla;

--- a/dwctl/src/test/utils.rs
+++ b/dwctl/src/test/utils.rs
@@ -205,6 +205,27 @@ pub async fn create_test_app_with_config(
     app.into_test_server()
 }
 
+/// Like [`create_test_app_with_config`], but binds a real socket first (and
+/// points `config` at it) so the fusillade daemon's own HTTP client can
+/// make a real loopback dispatch — see `Application::into_test_server_on_real_socket`.
+pub async fn create_test_app_with_real_loopback(
+    pool: PgPool,
+    mut config: crate::config::Config,
+) -> (TestServer, crate::BackgroundServices) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind real loopback listener");
+    let real_addr = listener.local_addr().expect("real loopback listener addr");
+    config.host = real_addr.ip().to_string();
+    config.port = real_addr.port();
+
+    let app = crate::Application::new_with_pool(config, Some(pool), None)
+        .await
+        .expect("Failed to create application");
+
+    app.into_test_server_on_real_socket(listener)
+}
+
 pub fn create_test_config() -> crate::config::Config {
     // Use temp directory for test emails
     let temp_dir = std::env::temp_dir().join(format!("dwctl-test-emails-{}", std::process::id()));
@@ -376,6 +397,7 @@ pub fn create_test_config() -> crate::config::Config {
         cache: Default::default(),
         continuation: Default::default(),
         keystore: None,
+        flex_live_streaming: Default::default(),
     }
 }
 


### PR DESCRIPTION
## What

Flex `stream:true` requests currently fake streaming: dwctl polls the row every 500ms, then replays the finished answer as one synthetic mega-delta. This relays the real per-token SSE chunks the daemon already sees (previously discarded) to the client-holding pod live, over Redis Streams.

Off by default (`flex_live_streaming.enabled: false`). When off, behavior is unchanged.

**Companion infra PR**: [doublewordai/control-layer-chart#101](https://github.com/doublewordai/control-layer-chart/pull/101) adds the chunk-relay Redis this needs in production. Linear: [COR-648](https://linear.app/doubleword/issue/COR-648).

## Why

- Real incrementality for clients doing incremental UI or early cancellation.
- Slowing the poll once live delivery is primary addresses the DB egress pattern behind COR-555, as a side effect of this being broader in scope than that fix alone.

## How

- `chunk_relay.rs`: Redis Streams relay. Publish side is non-blocking (called from a synchronous fold loop that can't `.await`). Subscribe side uses one shared reader task doing a batched `XREAD` across all active subscribers, instead of one blocking connection per client.
- `Sink::absorb` (`outbound_request.rs`) publishes each chunk additively, alongside the existing fold-into-one-body step, never instead of it.
- ZDR requests are included, not excluded: chunks are encrypted with the same per-request key the existing ZDR flow already manages.
- `flex_stream_response` races a relay task against the existing poll task; whichever delivers the terminal frame(s) first wins, and the other stands down immediately.

## Scope

Chat-completions surface only (Responses API not wired), first-attempt-success only (retry re-emission and mid-stream model escalation not handled), disconnect/cancellation unchanged. All deferred deliberately for this pass.

## Testing

Full end-to-end test: real daemon, real Redis, a real socket-bound mock upstream with genuine inter-chunk delays (not wiremock, it can't stream with real timing). Proves live delivery matches the mock's actual send time rather than the poll fallback, and a paired control test proves the flag-off path is byte-for-byte unchanged. Also added a test helper (`into_test_server_on_real_socket`) since no existing test previously exercised a genuine daemon-initiated loopback dispatch.

2210/2210 existing tests pass, lint clean.

## Not yet confirmed

Production Redis topology (single instance vs. cluster) and real throughput numbers on the actual deployed instance, flagged as follow-up before any wider rollout, not blocking for this prototype.