### PR TITLE
feat(dwctl): connection-budget governor for autoscaled replicas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,7 +1946,7 @@ dependencies = [
  "serial_test",
  "sha2 0.11.0",
  "sqlx",
- "sqlx-pool-router 0.3.0",
+ "sqlx-pool-router 1.0.0",
  "tempfile",
  "test-log",
  "thiserror 2.0.18",
@@ -2396,7 +2396,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "sqlx-pool-router 0.3.0",
+ "sqlx-pool-router 1.0.0",
  "test-log",
  "tokio",
  "tokio-stream",
@@ -6473,7 +6473,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-pool-router"
-version = "0.3.0"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496d192e561ec3d96bc849e8e7cf803c1f5d13bc8a61082d3628472c3951cd34"
 dependencies = [
  "arc-swap",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,7 +1946,7 @@ dependencies = [
  "serial_test",
  "sha2 0.11.0",
  "sqlx",
- "sqlx-pool-router",
+ "sqlx-pool-router 0.3.0",
  "tempfile",
  "test-log",
  "thiserror 2.0.18",
@@ -2396,7 +2396,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "sqlx-pool-router",
+ "sqlx-pool-router 0.3.0",
  "test-log",
  "tokio",
  "tokio-stream",
@@ -4549,7 +4549,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "sqlx-pool-router",
+ "sqlx-pool-router 0.2.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6468,6 +6468,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e9b977ec33ab01a8c211001e3e72b5d5a4ef95ef0c16cbf661de859c2c66ba3"
 dependencies = [
+ "sqlx",
+]
+
+[[package]]
+name = "sqlx-pool-router"
+version = "0.3.0"
+dependencies = [
+ "arc-swap",
+ "async-stream",
+ "either",
+ "futures-util",
  "sqlx",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,3 @@ inherits = "test"
 debug = 0
 incremental = false
 
-# Local development of the pool-router 0.3 change; replaced by the published
-# version before merge.
-[patch.crates-io]
-sqlx-pool-router = { path = "/Users/peter/titan/sqlx-pool-router-worktrees/swappable-pools" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ resolver = "2"
 inherits = "test"
 debug = 0
 incremental = false
+
+# Local development of the pool-router 0.3 change; replaced by the published
+# version before merge.
+[patch.crates-io]
+sqlx-pool-router = { path = "/Users/peter/titan/sqlx-pool-router-worktrees/swappable-pools" }

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -154,7 +154,7 @@ async-stripe-billing = { version = "1.0.0-rc.0", features = [
   "billing_portal_session",
   "invoice_item",
 ] }
-sqlx-pool-router = "0.2.0"
+sqlx-pool-router = "0.3.0"
 minijinja = "2.15.1"
 multer = "3.1.0"
 ctor = "0.9"

--- a/dwctl/Cargo.toml
+++ b/dwctl/Cargo.toml
@@ -154,7 +154,7 @@ async-stripe-billing = { version = "1.0.0-rc.0", features = [
   "billing_portal_session",
   "invoice_item",
 ] }
-sqlx-pool-router = "0.3.0"
+sqlx-pool-router = "1.0"
 minijinja = "2.15.1"
 multer = "3.1.0"
 ctor = "0.9"

--- a/dwctl/migrations/139_replica_registry.sql
+++ b/dwctl/migrations/139_replica_registry.sql
@@ -1,0 +1,15 @@
+-- Live-replica registry for dividing per-role connection budgets across
+-- autoscaled pods. Postgres is the consensus substrate (same trust model as the
+-- advisory-lock leader election): a row is alive iff its heartbeat is within
+-- the liveness window, so every replica of a group converges on the same count
+-- within one heartbeat interval. Crashed pods never delete their row; the
+-- heartbeat loop sweeps rows that have been silent for a long time.
+CREATE TABLE replica_registry (
+    instance_id UUID PRIMARY KEY,
+    replica_group TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_heartbeat TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_replica_registry_group_heartbeat
+    ON replica_registry (replica_group, last_heartbeat DESC);

--- a/dwctl/src/api/handlers/api_keys.rs
+++ b/dwctl/src/api/handlers/api_keys.rs
@@ -1370,8 +1370,7 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(
-                pool.clone(),
+            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
         let proxy = axum_test::TestServer::new(router).unwrap();

--- a/dwctl/src/api/handlers/api_keys.rs
+++ b/dwctl/src/api/handlers/api_keys.rs
@@ -1370,7 +1370,8 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
+            .layer(axum::middleware::from_fn_with_state(
+                sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
         let proxy = axum_test::TestServer::new(router).unwrap();

--- a/dwctl/src/api/handlers/batches.rs
+++ b/dwctl/src/api/handlers/batches.rs
@@ -1155,7 +1155,7 @@ async fn reserve_capacity_for_batch<P: PoolProvider>(
 
     // Use the write pool for the reservation transaction
     let pool = state.db.write();
-    reserve_capacity(pool, &*state.request_manager, &input).await.map_err(|e| match e {
+    reserve_capacity(&pool, &*state.request_manager, &input).await.map_err(|e| match e {
         CapacityError::InsufficientCapacity { completion_window, models } => Error::TooManyRequests {
             message: format!(
                 "Insufficient capacity for {} completion window. The following models are currently at capacity: {}. Try again later or use a longer completion window.",
@@ -1167,7 +1167,7 @@ async fn reserve_capacity_for_batch<P: PoolProvider>(
 }
 
 async fn release_capacity_reservations<P: PoolProvider>(state: &AppState<P>, reservation_ids: &[Uuid]) -> Result<()> {
-    super::sla_capacity::release_reservations(state.db.write(), reservation_ids)
+    super::sla_capacity::release_reservations(&state.db.write(), reservation_ids)
         .await
         .map_err(|msg| Error::Internal { operation: msg })
 }
@@ -1379,7 +1379,7 @@ pub async fn get_batch_analytics<P: PoolProvider>(
     // hasn't been folded yet (brand new / no completed requests), not that data aged out, so
     // return a zero-valued payload rather than 404. Ownership/existence is already enforced
     // above, and platform managers expect to see metrics for any batch they can access.
-    let analytics = crate::db::handlers::analytics::get_batch_analytics(state.db.read(), &batch_id)
+    let analytics = crate::db::handlers::analytics::get_batch_analytics(&state.db.read(), &batch_id)
         .await
         .map_err(|e| Error::Internal {
             operation: format!("fetch batch analytics: {}", e),
@@ -1620,7 +1620,7 @@ pub async fn cancel_batch<P: PoolProvider>(
     tracing::debug!("Batch {} cancelled", batch_id);
 
     // Fetch creator email for the response
-    let creator_email = fetch_creator_email(state.db.read(), &batch).await;
+    let creator_email = fetch_creator_email(&state.db.read(), &batch).await;
     Ok(Json(to_batch_response_with_email(batch, creator_email.as_deref())))
 }
 
@@ -1773,7 +1773,7 @@ pub async fn retry_failed_batch_requests<P: PoolProvider>(
         })?;
 
     // Fetch creator email for the response
-    let creator_email = fetch_creator_email(state.db.read(), &batch).await;
+    let creator_email = fetch_creator_email(&state.db.read(), &batch).await;
     Ok(Json(to_batch_response_with_email(batch, creator_email.as_deref())))
 }
 
@@ -1887,7 +1887,7 @@ pub async fn retry_specific_requests<P: PoolProvider>(
         })?;
 
     // Fetch creator email for the response
-    let creator_email = fetch_creator_email(state.db.read(), &batch).await;
+    let creator_email = fetch_creator_email(&state.db.read(), &batch).await;
     Ok(Json(to_batch_response_with_email(batch, creator_email.as_deref())))
 }
 
@@ -2104,7 +2104,7 @@ pub async fn list_batches<P: PoolProvider>(
 
     // Fetch analytics in bulk if requested
     let analytics_map: HashMap<Uuid, BatchAnalytics> = if include_analytics && !batches.is_empty() {
-        crate::db::handlers::analytics::get_batches_analytics_bulk(state.db.read(), &batch_ids)
+        crate::db::handlers::analytics::get_batches_analytics_bulk(&state.db.read(), &batch_ids)
             .await
             .map_err(|e| Error::Internal {
                 operation: format!("fetch bulk batch analytics: {}", e),

--- a/dwctl/src/api/handlers/deployments.rs
+++ b/dwctl/src/api/handlers/deployments.rs
@@ -451,7 +451,7 @@ pub async fn list_deployed_models<P: PoolProvider>(
 
     // Use ModelEnricher to add requested data
     let enricher = DeployedModelEnricher {
-        db: state.db.read(),
+        db: &state.db.read(),
         include_groups,
         include_metrics,
         include_status,
@@ -1071,7 +1071,7 @@ pub async fn get_deployed_model<P: PoolProvider>(
 
     // Use ModelEnricher to add related data
     let enricher = DeployedModelEnricher {
-        db: state.db.read(),
+        db: &state.db.read(),
         include_groups,
         include_metrics,
         include_status,

--- a/dwctl/src/api/handlers/files.rs
+++ b/dwctl/src/api/handlers/files.rs
@@ -1158,7 +1158,7 @@ pub async fn upload_file<P: PoolProvider>(
         buffer_size: config.batches.files.upload_buffer_size,
         normalizer,
         normalizer_mode,
-        access_pool: Some(state.db.write().clone()),
+        access_pool: Some(state.db.write().into_inner()),
         // image_access is attributed to the acting human plus, for org-context
         // uploads, the owning org — so org members can view org-key images
         // while a personal upload stays private to the user. This is distinct

--- a/dwctl/src/api/handlers/inference_endpoints.rs
+++ b/dwctl/src/api/handlers/inference_endpoints.rs
@@ -260,7 +260,7 @@ pub async fn update_inference_endpoint<P: PoolProvider>(
         let endpoint = repo.update(id, &db_request).await?;
 
         // Perform background sync after successful update
-        match endpoint_sync::synchronize_endpoint(endpoint.id, state.db.write().clone()).await {
+        match endpoint_sync::synchronize_endpoint(endpoint.id, state.db.write().into_inner()).await {
             Ok(sync_result) => {
                 tracing::debug!(
                     "Auto-sync after endpoint {} update: {} changes made",
@@ -593,7 +593,7 @@ pub async fn synchronize_endpoint<P: PoolProvider>(
     _: RequiresPermission<resource::Endpoints, operation::UpdateAll>,
 ) -> Result<Json<endpoint_sync::EndpointSyncResponse>> {
     // Perform synchronization
-    let response = endpoint_sync::synchronize_endpoint(id, state.db.write().clone()).await?;
+    let response = endpoint_sync::synchronize_endpoint(id, state.db.write().into_inner()).await?;
 
     tracing::debug!("Successfully synchronized endpoint {} with {} changes", id, response.changes_made);
     Ok(Json(response))

--- a/dwctl/src/api/handlers/payments.rs
+++ b/dwctl/src/api/handlers/payments.rs
@@ -398,7 +398,7 @@ pub async fn process_payment<P: PoolProvider>(
     };
 
     // Process the payment session using the provider trait
-    match provider.process_payment_session(state.db.write(), &id, &config.credits).await {
+    match provider.process_payment_session(&state.db.write(), &id, &config.credits).await {
         Ok(()) => Ok(Json(json!({
             "message": "Payment processed successfully"
         }))
@@ -489,7 +489,7 @@ pub async fn webhook_handler<P: PoolProvider>(
     tracing::trace!("Received webhook event: {}", event.event_type);
 
     // Process the webhook event
-    match provider.process_webhook_event(state.db.write(), &event, &config.credits).await {
+    match provider.process_webhook_event(&state.db.write(), &event, &config.credits).await {
         Ok(()) => {
             tracing::trace!("Successfully processed webhook event: {}", event.event_type);
             StatusCode::OK
@@ -753,7 +753,7 @@ pub async fn process_auto_topup<P: PoolProvider>(
         }
     };
 
-    let setup_result = match provider.process_auto_topup_session(state.db.write(), &id).await {
+    let setup_result = match provider.process_auto_topup_session(&state.db.write(), &id).await {
         Ok(result) => result,
         Err(e) => match e {
             payment_providers::PaymentError::PaymentNotCompleted => {

--- a/dwctl/src/api/handlers/probes.rs
+++ b/dwctl/src/api/handlers/probes.rs
@@ -74,8 +74,8 @@ pub async fn list_probes(
     Query(query): Query<ProbesQuery>,
 ) -> Result<Json<Vec<Probe>>, Error> {
     let probes = match query.status.as_deref() {
-        Some("active") => ProbeManager::list_active_probes(&state.db.write()).await?,
-        _ => ProbeManager::list_probes(&state.db.write()).await?,
+        Some("active") => ProbeManager::list_active_probes(&state.db.read()).await?,
+        _ => ProbeManager::list_probes(&state.db.read()).await?,
     };
     Ok(Json(probes))
 }
@@ -108,7 +108,7 @@ pub async fn get_probe(
     _: RequiresPermission<resource::Probes, operation::ReadAll>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Probe>, Error> {
-    let probe = ProbeManager::get_probe(&state.db.write(), id).await?;
+    let probe = ProbeManager::get_probe(&state.db.read(), id).await?;
     Ok(Json(probe))
 }
 
@@ -346,7 +346,7 @@ pub async fn get_probe_results(
     Path(id): Path<Uuid>,
     Query(query): Query<ResultsQuery>,
 ) -> Result<Json<Vec<ProbeResult>>, Error> {
-    let results = ProbeManager::get_probe_results(&state.db.write(), id, query.start_time, query.end_time, query.limit).await?;
+    let results = ProbeManager::get_probe_results(&state.db.read(), id, query.start_time, query.end_time, query.limit).await?;
     Ok(Json(results))
 }
 
@@ -380,7 +380,7 @@ pub async fn get_statistics(
     Path(id): Path<Uuid>,
     Query(query): Query<StatsQuery>,
 ) -> Result<Json<ProbeStatistics>, Error> {
-    let stats = ProbeManager::get_statistics(&state.db.write(), id, query.start_time, query.end_time).await?;
+    let stats = ProbeManager::get_statistics(&state.db.read(), id, query.start_time, query.end_time).await?;
     Ok(Json(stats))
 }
 

--- a/dwctl/src/api/handlers/probes.rs
+++ b/dwctl/src/api/handlers/probes.rs
@@ -42,7 +42,7 @@ pub async fn create_probe(
     _: RequiresPermission<resource::Probes, operation::CreateAll>,
     Json(probe): Json<CreateProbe>,
 ) -> Result<(StatusCode, Json<Probe>), Error> {
-    let created = ProbeManager::create_probe(&state.db, probe).await?;
+    let created = ProbeManager::create_probe(&state.db.write(), probe).await?;
     Ok((StatusCode::CREATED, Json(created)))
 }
 
@@ -74,8 +74,8 @@ pub async fn list_probes(
     Query(query): Query<ProbesQuery>,
 ) -> Result<Json<Vec<Probe>>, Error> {
     let probes = match query.status.as_deref() {
-        Some("active") => ProbeManager::list_active_probes(&state.db).await?,
-        _ => ProbeManager::list_probes(&state.db).await?,
+        Some("active") => ProbeManager::list_active_probes(&state.db.write()).await?,
+        _ => ProbeManager::list_probes(&state.db.write()).await?,
     };
     Ok(Json(probes))
 }
@@ -108,7 +108,7 @@ pub async fn get_probe(
     _: RequiresPermission<resource::Probes, operation::ReadAll>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Probe>, Error> {
-    let probe = ProbeManager::get_probe(&state.db, id).await?;
+    let probe = ProbeManager::get_probe(&state.db.write(), id).await?;
     Ok(Json(probe))
 }
 
@@ -140,7 +140,7 @@ pub async fn delete_probe(
     _: RequiresPermission<resource::Probes, operation::DeleteAll>,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, Error> {
-    ProbeManager::delete_probe(&state.db, id).await?;
+    ProbeManager::delete_probe(&state.db.write(), id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -172,7 +172,7 @@ pub async fn activate_probe(
     _: RequiresPermission<resource::Probes, operation::UpdateAll>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Probe>, Error> {
-    let probe = ProbeManager::activate_probe(&state.db, id).await?;
+    let probe = ProbeManager::activate_probe(&state.db.write(), id).await?;
     Ok(Json(probe))
 }
 
@@ -204,7 +204,7 @@ pub async fn deactivate_probe(
     _: RequiresPermission<resource::Probes, operation::UpdateAll>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Probe>, Error> {
-    let probe = ProbeManager::deactivate_probe(&state.db, id).await?;
+    let probe = ProbeManager::deactivate_probe(&state.db.write(), id).await?;
     Ok(Json(probe))
 }
 
@@ -239,7 +239,7 @@ pub async fn update_probe(
     Path(id): Path<Uuid>,
     Json(update): Json<UpdateProbeRequest>,
 ) -> Result<Json<Probe>, Error> {
-    let probe = ProbeManager::update_probe(&state.db, id, update).await?;
+    let probe = ProbeManager::update_probe(&state.db.write(), id, update).await?;
     Ok(Json(probe))
 }
 
@@ -272,7 +272,7 @@ pub async fn execute_probe(
     Path(id): Path<Uuid>,
 ) -> Result<(StatusCode, Json<ProbeResult>), Error> {
     let config = state.current_config();
-    let result = ProbeManager::execute_probe(&state.db, id, &config).await?;
+    let result = ProbeManager::execute_probe(&state.db.write(), id, &config).await?;
     Ok((StatusCode::CREATED, Json(result)))
 }
 
@@ -312,7 +312,7 @@ pub async fn test_probe(
         (None, None, None)
     };
 
-    let result = ProbeManager::test_probe(&state.db, deployment_id, &config, http_method, request_path, request_body).await?;
+    let result = ProbeManager::test_probe(&state.db.write(), deployment_id, &config, http_method, request_path, request_body).await?;
     Ok((StatusCode::OK, Json(result)))
 }
 
@@ -346,7 +346,7 @@ pub async fn get_probe_results(
     Path(id): Path<Uuid>,
     Query(query): Query<ResultsQuery>,
 ) -> Result<Json<Vec<ProbeResult>>, Error> {
-    let results = ProbeManager::get_probe_results(&state.db, id, query.start_time, query.end_time, query.limit).await?;
+    let results = ProbeManager::get_probe_results(&state.db.write(), id, query.start_time, query.end_time, query.limit).await?;
     Ok(Json(results))
 }
 
@@ -380,7 +380,7 @@ pub async fn get_statistics(
     Path(id): Path<Uuid>,
     Query(query): Query<StatsQuery>,
 ) -> Result<Json<ProbeStatistics>, Error> {
-    let stats = ProbeManager::get_statistics(&state.db, id, query.start_time, query.end_time).await?;
+    let stats = ProbeManager::get_statistics(&state.db.write(), id, query.start_time, query.end_time).await?;
     Ok(Json(stats))
 }
 

--- a/dwctl/src/api/handlers/recompute.rs
+++ b/dwctl/src/api/handlers/recompute.rs
@@ -122,7 +122,7 @@ pub async fn recompute_usage<P: PoolProvider>(
     // Absent when caching is disabled, in which case rows simply carry no reconstruction.
     let cfg = state.current_config();
     let classifier = cfg.cache.enabled.then(|| {
-        let pool = state.db.read().clone();
+        let pool = state.db.read().into_inner();
         crate::prompt_cache::Classifier::new(
             crate::prompt_cache::PrincipalResolver::new(pool.clone()),
             crate::prompt_cache::ModelConfigResolver::new(pool.clone()),
@@ -145,7 +145,7 @@ pub async fn recompute_usage<P: PoolProvider>(
         (!cfg.cache.tokenizer_url.is_empty()).then(|| crate::prompt_cache::TokenizerClient::new(cfg.cache.tokenizer_url.clone()));
 
     // The read pool, deliberately: this path has no write handle at all.
-    let report = crate::recompute::recompute_corpus(state.db.read(), &filter, flat_tier, classifier.as_ref(), tokenizer.as_ref())
+    let report = crate::recompute::recompute_corpus(&state.db.read(), &filter, flat_tier, classifier.as_ref(), tokenizer.as_ref())
         .await
         .map_err(|e| Error::Internal {
             operation: format!("recompute usage: {e}"),

--- a/dwctl/src/api/handlers/requests.rs
+++ b/dwctl/src/api/handlers/requests.rs
@@ -86,7 +86,7 @@ pub async fn list_requests<P: PoolProvider>(
     };
 
     // Query the http_analytics table - use read replica for analytics
-    let entries = list_http_analytics(state.db.read(), skip, limit, query.order_desc.unwrap_or(true), filter).await?;
+    let entries = list_http_analytics(&state.db.read(), skip, limit, query.order_desc.unwrap_or(true), filter).await?;
 
     Ok(Json(ListAnalyticsResponse { entries }))
 }
@@ -118,7 +118,7 @@ pub async fn aggregate_requests<P: PoolProvider>(
     let model_filter = query.model.as_deref();
 
     // Get aggregated analytics data from http_analytics table - use read replica for analytics
-    let response = get_requests_aggregate(state.db.read(), time_range_start, time_range_end, model_filter).await?;
+    let response = get_requests_aggregate(&state.db.read(), time_range_start, time_range_end, model_filter).await?;
 
     Ok(Json(response))
 }
@@ -164,7 +164,7 @@ pub async fn aggregate_by_user<P: PoolProvider>(
     let start_date = query.start_date.unwrap_or_else(|| end_date - Duration::hours(24));
 
     // Get usage data from http_analytics table - use read replica for analytics
-    let usage_data = get_model_user_usage(state.db.read(), &model_alias, start_date, end_date).await?;
+    let usage_data = get_model_user_usage(&state.db.read(), &model_alias, start_date, end_date).await?;
 
     Ok(Json(usage_data))
 }
@@ -248,10 +248,11 @@ pub async fn get_usage<P: PoolProvider>(
         let max_start = end_date - Duration::days(180);
         let start_date = if start < max_start { max_start } else { start };
 
+        let db = state.db.read();
         tokio::try_join!(
-            get_user_batch_count_for_range(state.db.read(), target_user_id, start_date, end_date),
-            get_user_model_breakdown_for_range(state.db.read(), target_user_id, start_date, end_date),
-            get_realtime_tariffs(state.db.read()),
+            get_user_batch_count_for_range(&db, target_user_id, start_date, end_date),
+            get_user_model_breakdown_for_range(&db, target_user_id, start_date, end_date),
+            get_realtime_tariffs(&db),
         )?
     } else {
         // All-time usage combines two pre-aggregated tables:
@@ -279,12 +280,13 @@ pub async fn get_usage<P: PoolProvider>(
         // synchronous fold, and only when the caller explicitly asks via
         // ?refresh=true (otherwise the usage-refresh daemon keeps it current).
         if refresh {
-            refresh_user_model_usage_daily(state.db.write()).await?;
+            refresh_user_model_usage_daily(&state.db.write()).await?;
         }
+        let db = state.db.read();
         let (batch_stats, by_model, tariffs) = tokio::try_join!(
-            get_user_batch_counts(state.db.read(), target_user_id),
-            get_user_model_breakdown(state.db.read(), target_user_id),
-            get_realtime_tariffs(state.db.read()),
+            get_user_batch_counts(&db, target_user_id),
+            get_user_model_breakdown(&db, target_user_id),
+            get_realtime_tariffs(&db),
         )?;
         (batch_stats.0, by_model, tariffs)
     };

--- a/dwctl/src/auth/current_user.rs
+++ b/dwctl/src/auth/current_user.rs
@@ -104,7 +104,7 @@ async fn try_proxy_header_auth<P: sqlx_pool_router::PoolProvider + Clone + Send 
     state: &crate::AppState<P>,
 ) -> Option<Result<AuthSuccess>> {
     let config = state.current_config();
-    let db: &PgPool = state.db.write();
+    let db: &PgPool = &state.db.write();
     tracing::trace!("Trying proxy header auth, config: {:?}", config.auth.proxy_header);
     // Extract external_user_id from header_name (required)
     let external_user_id = parts
@@ -650,12 +650,12 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
         let mut any_auth_attempted = false;
 
         // Try API key authentication first (most specific)
-        match try_api_key_auth(parts, state.db.read()).await {
+        match try_api_key_auth(parts, &state.db.read()).await {
             Some(Ok((mut user, last_login))) => {
                 debug!("Authentication successful via API key");
                 trace!("Authenticated user: {}", user.id);
-                populate_org_context(&mut user, parts, state.db.read()).await;
-                maybe_update_last_login(user.id, last_login, state.db.write());
+                populate_org_context(&mut user, parts, &state.db.read()).await;
+                maybe_update_last_login(user.id, last_login, &state.db.write());
                 return Ok(user);
             }
             Some(Err(e)) => {
@@ -671,12 +671,12 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
         // Native authentication (JWT sessions)
         let config = state.current_config();
         if config.auth.native.enabled {
-            match try_jwt_session_auth(parts, &config, state.db.read()).await {
+            match try_jwt_session_auth(parts, &config, &state.db.read()).await {
                 Some(Ok((mut user, last_login))) => {
                     debug!("Authentication successful via JWT session");
                     trace!("Authenticated user: {}", user.id);
-                    populate_org_context(&mut user, parts, state.db.read()).await;
-                    maybe_update_last_login(user.id, last_login, state.db.write());
+                    populate_org_context(&mut user, parts, &state.db.read()).await;
+                    maybe_update_last_login(user.id, last_login, &state.db.write());
                     return Ok(user);
                 }
                 Some(Err(e)) => {
@@ -696,8 +696,8 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
                 Some(Ok((mut user, last_login))) => {
                     debug!("Authentication successful via proxy header");
                     trace!("Authenticated user: {}", user.id);
-                    populate_org_context(&mut user, parts, state.db.read()).await;
-                    maybe_update_last_login(user.id, last_login, state.db.write());
+                    populate_org_context(&mut user, parts, &state.db.read()).await;
+                    maybe_update_last_login(user.id, last_login, &state.db.write());
                     return Ok(user);
                 }
                 Some(Err(e)) => {

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -622,14 +622,16 @@ impl DatabaseConfig {
     /// Whether any governed pool declares a `total_max_connections`. When
     /// false the replica governor stays fully dormant: no registry rows, no
     /// heartbeats, pools sized from `max_connections` exactly as before.
+    ///
+    /// Governed pools are `main` and `fusillade` (primaries and replicas).
+    /// `outlet` is not: outlet-postgres pins the pool it is built with, so it
+    /// cannot follow a swap yet. `underway` is per-pod by design.
     pub fn connection_budget_enabled(&self) -> bool {
         let governed = [
             self.main_pool_settings(),
             self.main_replica_pool_settings(),
             self.fusillade().pool_settings(),
             self.fusillade().replica_pool_settings(),
-            self.outlet().pool_settings(),
-            self.outlet().replica_pool_settings(),
         ];
         governed.iter().any(|s| s.total_max_connections.is_some())
     }

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -286,8 +286,17 @@ impl Default for ResponsesConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct PoolSettings {
-    /// Maximum number of connections in the pool
+    /// Maximum number of connections in the pool (per pod).
+    ///
+    /// Ignored for sizing when `total_max_connections` is set; kept so the
+    /// same config still parses on images without the replica governor.
     pub max_connections: u32,
+    /// Connection budget shared by ALL live replicas of this pod's
+    /// `database.replica_group`. Each pod sizes this pool at
+    /// `total / live_replicas` and re-divides at runtime as replicas come and
+    /// go (see `replica_governor`). Takes precedence over `max_connections`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_max_connections: Option<u32>,
     /// Minimum number of idle connections to maintain
     pub min_connections: u32,
     /// Maximum time to wait for a connection (seconds)
@@ -303,6 +312,7 @@ impl Default for PoolSettings {
     fn default() -> Self {
         Self {
             max_connections: 10,
+            total_max_connections: None,
             min_connections: 0,
             acquire_timeout_secs: 30,
             idle_timeout_secs: 600,  // 10 minutes
@@ -374,6 +384,7 @@ pub fn default_fusillade_component() -> ComponentDb {
         name: "fusillade".into(),
         pool: PoolSettings {
             max_connections: 20,
+            total_max_connections: None,
             min_connections: 2,
             acquire_timeout_secs: 30,
             idle_timeout_secs: 600,
@@ -389,6 +400,7 @@ pub fn default_outlet_component() -> ComponentDb {
         name: "outlet".into(),
         pool: PoolSettings {
             max_connections: 5,
+            total_max_connections: None,
             min_connections: 0,
             acquire_timeout_secs: 30,
             idle_timeout_secs: 600,
@@ -442,6 +454,12 @@ pub enum DatabaseConfig {
         /// holds long-lived PgListener connections)
         #[serde(default = "default_underway_pool")]
         underway_pool: PoolSettings,
+        /// Replica group for connection-budget division: pods with the same
+        /// group share every `total_max_connections` in this config equally.
+        /// Set per Deployment (the Helm chart injects
+        /// `DWCTL_DATABASE__REPLICA_GROUP`).
+        #[serde(default = "default_replica_group")]
+        replica_group: String,
     },
     /// Use external PostgreSQL database
     External {
@@ -467,7 +485,19 @@ pub enum DatabaseConfig {
         /// holds long-lived PgListener connections)
         #[serde(default = "default_underway_pool")]
         underway_pool: PoolSettings,
+        /// Replica group for connection-budget division: pods with the same
+        /// group share every `total_max_connections` in this config equally.
+        /// Set per Deployment (the Helm chart injects
+        /// `DWCTL_DATABASE__REPLICA_GROUP`).
+        #[serde(default = "default_replica_group")]
+        replica_group: String,
     },
+}
+
+/// Replica group used when none is configured. Every pod without an explicit
+/// group shares one budget, which is the safe reading of "no groups".
+pub fn default_replica_group() -> String {
+    "default".to_string()
 }
 
 impl Default for DatabaseConfig {
@@ -483,6 +513,7 @@ impl Default for DatabaseConfig {
                 fusillade: default_fusillade_component(),
                 outlet: default_outlet_component(),
                 underway_pool: default_underway_pool(),
+                replica_group: default_replica_group(),
             }
         }
         #[cfg(not(feature = "embedded-db"))]
@@ -495,6 +526,7 @@ impl Default for DatabaseConfig {
                 fusillade: default_fusillade_component(),
                 outlet: default_outlet_component(),
                 underway_pool: default_underway_pool(),
+                replica_group: default_replica_group(),
             }
         }
     }
@@ -577,6 +609,29 @@ impl DatabaseConfig {
             DatabaseConfig::Embedded { underway_pool, .. } => underway_pool,
             DatabaseConfig::External { underway_pool, .. } => underway_pool,
         }
+    }
+
+    /// Replica group this pod counts itself in for connection-budget division.
+    pub fn replica_group(&self) -> &str {
+        match self {
+            DatabaseConfig::Embedded { replica_group, .. } => replica_group,
+            DatabaseConfig::External { replica_group, .. } => replica_group,
+        }
+    }
+
+    /// Whether any governed pool declares a `total_max_connections`. When
+    /// false the replica governor stays fully dormant: no registry rows, no
+    /// heartbeats, pools sized from `max_connections` exactly as before.
+    pub fn connection_budget_enabled(&self) -> bool {
+        let governed = [
+            self.main_pool_settings(),
+            self.main_replica_pool_settings(),
+            self.fusillade().pool_settings(),
+            self.fusillade().replica_pool_settings(),
+            self.outlet().pool_settings(),
+            self.outlet().replica_pool_settings(),
+        ];
+        governed.iter().any(|s| s.total_max_connections.is_some())
     }
 }
 
@@ -2891,6 +2946,7 @@ impl Config {
             let fusillade = config.database.fusillade().clone();
             let outlet = config.database.outlet().clone();
             let underway_pool = config.database.underway_pool_settings().clone();
+            let replica_group = config.database.replica_group().to_string();
 
             // Preserve original replica_pool if it was explicitly configured (not using fallback)
             let original_replica_pool = match &config.database {
@@ -2909,6 +2965,7 @@ impl Config {
                 fusillade,
                 outlet,
                 underway_pool,
+                replica_group,
             };
         } else if let Some(replica_url) = config.database_replica_url.take() {
             // Only replica_url is set via environment variable, apply it to existing config

--- a/dwctl/src/connections/sync.rs
+++ b/dwctl/src/connections/sync.rs
@@ -79,7 +79,7 @@ pub async fn build_sync_connection_job<P: PoolProvider + Clone + Send + Sync + '
                     "SyncConnectionJob failed"
                 );
                 // Mark the sync operation as failed
-                if let Ok(mut conn) = cx.state.dwctl_pool.acquire().await {
+                if let Ok(mut conn) = cx.state.dwctl_pool.write().acquire().await {
                     let _ = crate::db::handlers::connections::SyncOperations::new(&mut conn)
                         .update_status(input.sync_id, "failed")
                         .await;
@@ -117,7 +117,7 @@ pub async fn build_ingest_file_job<P: PoolProvider + Clone + Send + Sync + 'stat
                         "IngestFileJob failed"
                     );
                     // Mark entry as failed, then check if sync is complete
-                    if let Ok(mut conn) = cx.state.dwctl_pool.acquire().await {
+                    if let Ok(mut conn) = cx.state.dwctl_pool.write().acquire().await {
                         let _ = crate::db::handlers::connections::SyncEntries::new(&mut conn)
                             .update_status(input.sync_entry_id, "failed", Some(&e.to_string()))
                             .await;
@@ -164,7 +164,7 @@ pub async fn build_activate_batch_job<P: PoolProvider + Clone + Send + Sync + 's
             match run_activate_batch(&cx.state, &input).await {
                 Ok(()) => {
                     // Check if sync is now complete
-                    if let Ok(mut conn) = cx.state.dwctl_pool.acquire().await {
+                    if let Ok(mut conn) = cx.state.dwctl_pool.write().acquire().await {
                         let _ = crate::db::handlers::connections::SyncOperations::new(&mut conn)
                             .try_complete(input.sync_id)
                             .await;
@@ -191,7 +191,7 @@ pub async fn build_activate_batch_job<P: PoolProvider + Clone + Send + Sync + 's
                     }
 
                     // Fatal — mark entry as failed and update sync counters
-                    if let Ok(mut conn) = cx.state.dwctl_pool.acquire().await {
+                    if let Ok(mut conn) = cx.state.dwctl_pool.write().acquire().await {
                         let _ = crate::db::handlers::connections::SyncEntries::new(&mut conn)
                             .update_status(input.sync_entry_id, "failed", Some(&e.to_string()))
                             .await;
@@ -229,7 +229,7 @@ async fn run_sync_connection<P: PoolProvider + Clone + Send + Sync + 'static>(
 
     // 1. Load connection and decrypt config
     let (connection, config_json) = {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         let connection = Connections::new(&mut conn)
             .get_by_id(input.connection_id)
             .await?
@@ -245,13 +245,13 @@ async fn run_sync_connection<P: PoolProvider + Clone + Send + Sync + 'static>(
 
     // 2. Update sync status to listing
     {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         SyncOperations::new(&mut conn).update_status(input.sync_id, "listing").await?;
     }
 
     // 3. Load sync operation to get strategy
     let sync_op = {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         SyncOperations::new(&mut conn)
             .get_by_id(input.sync_id)
             .await?
@@ -301,7 +301,7 @@ async fn run_sync_connection<P: PoolProvider + Clone + Send + Sync + 'static>(
             files.iter().map(|f| (f.key.clone(), f.last_modified)).collect();
 
         let already_synced = {
-            let mut conn = dwctl.acquire().await?;
+            let mut conn = dwctl.write().acquire().await?;
             SyncEntries::new(&mut conn)
                 .find_existing(input.connection_id, &keys_and_dates)
                 .await?
@@ -324,7 +324,7 @@ async fn run_sync_connection<P: PoolProvider + Clone + Send + Sync + 'static>(
         new_files.iter().map(|f| (f.key.clone(), f.last_modified, f.size_bytes)).collect();
 
     let entries = {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         SyncEntries::new(&mut conn)
             .bulk_create(input.sync_id, input.connection_id, &entry_data)
             .await?
@@ -332,7 +332,7 @@ async fn run_sync_connection<P: PoolProvider + Clone + Send + Sync + 'static>(
 
     // 7. Update sync operation counters
     {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         SyncOperations::new(&mut conn)
             .update_counters(input.sync_id, Some(files_found), Some(files_skipped), None, None, None)
             .await?;
@@ -358,7 +358,7 @@ async fn run_sync_connection<P: PoolProvider + Clone + Send + Sync + 'static>(
 
     if entries.is_empty() {
         // Nothing to ingest — mark sync as completed
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         SyncOperations::new(&mut conn).update_status(input.sync_id, "completed").await?;
     }
 
@@ -385,7 +385,7 @@ pub(crate) async fn run_ingest_file<P: PoolProvider + Clone + Send + Sync + 'sta
 
     // 1. Mark entry as ingesting
     {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         let updated = SyncEntries::new(&mut conn)
             .update_status(input.sync_entry_id, "ingesting", None)
             .await?;
@@ -397,7 +397,7 @@ pub(crate) async fn run_ingest_file<P: PoolProvider + Clone + Send + Sync + 'sta
 
     // 2. Load connection and build provider
     let (connection, config_json) = {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         let connection = Connections::new(&mut conn)
             .get_by_id(input.connection_id)
             .await?
@@ -414,7 +414,7 @@ pub(crate) async fn run_ingest_file<P: PoolProvider + Clone + Send + Sync + 'sta
 
     // 3. Load sync config for this operation
     let sync_op = {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         SyncOperations::new(&mut conn)
             .get_by_id(input.sync_id)
             .await?
@@ -446,7 +446,7 @@ pub(crate) async fn run_ingest_file<P: PoolProvider + Clone + Send + Sync + 'sta
         let owner_id = connection.user_id;
         let triggered_by = sync_op.triggered_by;
 
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         let (_secret, key_id) = ApiKeys::new(&mut conn)
             .get_or_create_hidden_key_with_id(owner_id, ApiKeyPurpose::Batch, triggered_by)
             .await
@@ -791,7 +791,7 @@ pub(crate) async fn run_ingest_file<P: PoolProvider + Clone + Send + Sync + 'sta
                 Some(serde_json::json!(errors))
             };
 
-            let mut conn = dwctl.acquire().await?;
+            let mut conn = dwctl.write().acquire().await?;
             let updated = SyncEntries::new(&mut conn)
                 .set_ingested(
                     input.sync_entry_id,
@@ -875,7 +875,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
 
     // 1. Mark entry as activating — abort if entry was soft-deleted
     {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         let updated = SyncEntries::new(&mut conn)
             .update_status(input.sync_entry_id, "activating", None)
             .await?;
@@ -887,7 +887,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
 
     // 2. Load sync config
     let sync_op = {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         SyncOperations::new(&mut conn)
             .get_by_id(input.sync_id)
             .await?
@@ -910,7 +910,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
     // 3. Load sync entry early — needed for retry detection (batch_id already set)
     //    and for provenance metadata / validation errors later.
     let sync_entry = {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         SyncEntries::new(&mut conn)
             .get_by_id(input.sync_entry_id)
             .await?
@@ -937,7 +937,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
         use crate::db::handlers::users::Users;
 
         let (owner_id, owner_verified) = {
-            let mut conn = dwctl.acquire().await?;
+            let mut conn = dwctl.write().acquire().await?;
             let owner_id = crate::db::handlers::connections::Connections::new(&mut conn)
                 .get_by_id(input.connection_id)
                 .await?
@@ -964,7 +964,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
                     "Skipped — this file wasn't batched because it would exceed your unverified \
                      upload limit. It will be retried automatically on your next sync. {message}"
                 );
-                let mut conn = dwctl.acquire().await?;
+                let mut conn = dwctl.write().acquire().await?;
                 SyncEntries::new(&mut conn)
                     .update_status(input.sync_entry_id, "skipped", Some(&entry_message))
                     .await?;
@@ -1030,12 +1030,12 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
             let model_aliases: Vec<String> = file_model_counts.keys().cloned().collect();
 
             let batch_model_info = {
-                let mut conn = dwctl.acquire().await?;
+                let mut conn = dwctl.write().acquire().await?;
                 Deployments::new(&mut conn).get_batch_model_info(&model_aliases).await?
             };
 
             let model_ids_by_alias = {
-                let mut conn = dwctl.acquire().await?;
+                let mut conn = dwctl.write().acquire().await?;
                 Deployments::new(&mut conn).get_model_ids_by_aliases(&model_aliases).await?
             };
 
@@ -1061,7 +1061,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
                 include_pending_counts: config.batches.pending_capacity_counts_enabled,
             };
 
-            match reserve_capacity(dwctl, &*state.request_manager, &cap_input).await {
+            match reserve_capacity(&dwctl.write(), &*state.request_manager, &cap_input).await {
                 Ok(ids) => ids,
                 Err(CapacityError::InsufficientCapacity { completion_window, models }) => {
                     return Err(ActivateError::Retryable(format!(
@@ -1086,7 +1086,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
             if !ids.is_empty() {
                 if let Ok(handle) = tokio::runtime::Handle::try_current() {
                     handle.spawn(async move {
-                        if let Err(e) = crate::api::handlers::sla_capacity::release_reservations(&pool, &ids).await {
+                        if let Err(e) = crate::api::handlers::sla_capacity::release_reservations(&pool.write(), &ids).await {
                             tracing::warn!(error = %e, "Failed to release capacity reservations — will expire via TTL");
                         }
                     });
@@ -1102,7 +1102,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
         use crate::db::handlers::api_keys::ApiKeys;
         use crate::db::models::api_keys::ApiKeyPurpose;
 
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         let connection = crate::db::handlers::connections::Connections::new(&mut conn)
             .get_by_id(input.connection_id)
             .await?
@@ -1168,7 +1168,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
         // persist fails transiently after create_batch_record succeeded.
         let mut persist_err = None;
         for attempt in 0..3 {
-            match dwctl.acquire().await {
+            match dwctl.write().acquire().await {
                 Ok(mut conn) => {
                     match sqlx::query!(
                         "UPDATE sync_entries SET batch_id = $2 WHERE id = $1 AND status != 'deleted'",
@@ -1248,7 +1248,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
     // Populate succeeded — requests are now in fusillade's pending queue and counted
     // by the capacity system. Release reservations immediately to avoid double-counting,
     // then defuse the guard so it doesn't release again on drop.
-    match crate::api::handlers::sla_capacity::release_reservations(&state.dwctl_pool, &reservation_ids).await {
+    match crate::api::handlers::sla_capacity::release_reservations(&state.dwctl_pool.write(), &reservation_ids).await {
         Ok(()) => {
             scopeguard::ScopeGuard::into_inner(release_guard);
         }
@@ -1276,7 +1276,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
                 sqlx::query_scalar("SELECT id FROM fusillade.request_templates WHERE file_id = $1 AND line_number = ANY($2)")
                     .bind(input.file_id)
                     .bind(&error_indices)
-                    .fetch_all(fusillade_pool)
+                    .fetch_all(&fusillade_pool)
                     .await
                     .map_err(|e| ActivateError::Retryable(format!("query templates: {e}")))?;
 
@@ -1287,7 +1287,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
                 .bind("Request failed validation during ingestion — check sync entry for details")
                 .bind(batch_id)
                 .bind(&template_ids)
-                .execute(fusillade_pool)
+                .execute(&fusillade_pool)
                 .await
                 .map_err(|e| ActivateError::Retryable(format!("fail invalid requests: {e}")))?;
 
@@ -1302,7 +1302,7 @@ pub(crate) async fn run_activate_batch<P: PoolProvider + Clone + Send + Sync + '
 
     // 9. Update sync entry with batch_id and activated status
     {
-        let mut conn = dwctl.acquire().await?;
+        let mut conn = dwctl.write().acquire().await?;
         SyncEntries::new(&mut conn).set_activated(input.sync_entry_id, batch_id).await?;
         SyncOperations::new(&mut conn)
             .increment_counter(input.sync_id, "batches_created")
@@ -1364,7 +1364,7 @@ mod tests {
 
         crate::tasks::TaskState {
             request_manager,
-            dwctl_pool: pool,
+            dwctl_pool: sqlx_pool_router::DynPools::new(pool),
             config: crate::SharedConfig::new(config),
             encryption_key: None,
             ingest_file_job: std::sync::Arc::new(std::sync::OnceLock::new()),

--- a/dwctl/src/continuation/layer.rs
+++ b/dwctl/src/continuation/layer.rs
@@ -42,7 +42,6 @@ use bytes::Bytes;
 use futures::StreamExt;
 use http_body_util::BodyExt;
 use serde_json::Value;
-use sqlx::PgPool;
 use tracing::{debug, warn};
 
 use crate::config::ContinuationConfig;
@@ -89,16 +88,16 @@ impl ContinuationState {
     pub async fn build(
         cfg: &ContinuationConfig,
         cache_tokenizer_url: &str,
-        pool: PgPool,
+        pools: sqlx_pool_router::DynPools,
         resume_target: Router,
         body_limit: usize,
     ) -> anyhow::Result<Self> {
-        let key_secret = super::provision_global_key(&pool).await?;
+        let key_secret = super::provision_global_key(&pools.write()).await?;
         let tokenizer_url = cfg.tokenizer_url.clone().unwrap_or_else(|| cache_tokenizer_url.to_string());
         let routes = Arc::new(ContinuationRoutes::new());
         // Seed synchronously so the first request after boot sees the real set
         // rather than waiting up to one poll interval.
-        if let Err(e) = routes.refresh(&pool).await {
+        if let Err(e) = routes.refresh(&pools.write()).await {
             crate::background_error!(
                 crate::metrics::errors::component::CONTINUATION,
                 "route_seed",
@@ -107,7 +106,7 @@ impl ContinuationState {
                 "Initial continuation route load failed; the poller will retry"
             );
         }
-        Arc::clone(&routes).spawn_poller(pool.clone());
+        Arc::clone(&routes).spawn_poller(pools.clone());
 
         Ok(Self {
             cfg: Arc::new(cfg.clone()),
@@ -115,7 +114,7 @@ impl ContinuationState {
             tokenizer: RenderClient::new(tokenizer_url, Duration::from_secs(cfg.resume_deadline_secs)),
             resume_target,
             routes,
-            purposes: PurposeResolver::new(pool),
+            purposes: PurposeResolver::new(pools),
             inflight: Arc::new(InflightLimiter::new(cfg.max_inflight_per_model)),
             body_limit,
         })

--- a/dwctl/src/continuation/mod.rs
+++ b/dwctl/src/continuation/mod.rs
@@ -314,13 +314,13 @@ impl ContinuationRoutes {
     /// Spawn the refresh poller. A failed refresh keeps the previous set (a DB
     /// blip must not silently disable resume) and is reported through
     /// `background_error!` so it lands on the unified error metric.
-    pub fn spawn_poller(self: Arc<Self>, pool: PgPool) {
+    pub fn spawn_poller(self: Arc<Self>, pools: sqlx_pool_router::DynPools) {
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(ROUTE_REFRESH_INTERVAL);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 ticker.tick().await;
-                if let Err(e) = self.refresh(&pool).await {
+                if let Err(e) = self.refresh(&pools.write()).await {
                     crate::background_error!(
                         component::CONTINUATION,
                         "route_refresh",
@@ -402,14 +402,15 @@ impl Drop for InflightGuard {
 /// bounds the cost of key probing.
 #[derive(Clone)]
 pub struct PurposeResolver {
-    pool: PgPool,
+    /// Live provider (not a pinned pool): survives runtime pool swaps.
+    pools: sqlx_pool_router::DynPools,
     l1: Cache<String, Option<ApiKeyPurpose>>,
 }
 
 impl PurposeResolver {
-    pub fn new(pool: PgPool) -> Self {
+    pub fn new(pools: impl sqlx_pool_router::PoolProvider) -> Self {
         Self {
-            pool,
+            pools: sqlx_pool_router::DynPools::new(pools),
             l1: Cache::builder()
                 .max_capacity(100_000)
                 .time_to_live(Duration::from_secs(3600))
@@ -426,7 +427,7 @@ impl PurposeResolver {
         // sail past a disabled batch gate for an hour. The failed request
         // still resolves to None (one-off misclassification, fail-open on the
         // origin gate only); the next request retries the lookup.
-        let Ok(mut conn) = self.pool.acquire().await else {
+        let Ok(mut conn) = self.pools.write().acquire().await else {
             return None;
         };
         let looked_up = ApiKeys::new(&mut conn).get_user_info_by_secret(token).await;

--- a/dwctl/src/db/handlers/api_keys.rs
+++ b/dwctl/src/db/handlers/api_keys.rs
@@ -2576,6 +2576,7 @@ mod tests {
                 fusillade: crate::config::default_fusillade_component(),
                 outlet: crate::config::default_outlet_component(),
                 underway_pool: crate::config::default_underway_pool(),
+                replica_group: crate::config::default_replica_group(),
             },
             slow_statement_threshold_ms: 1000,
             admin_email: "admin@example.org".to_string(),

--- a/dwctl/src/db/pools.rs
+++ b/dwctl/src/db/pools.rs
@@ -6,7 +6,6 @@
 use std::time::Duration;
 
 use metrics::gauge;
-use sqlx::PgPool;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
@@ -28,7 +27,9 @@ impl Default for PoolMetricsConfig {
 /// A named pool for metrics labeling
 pub struct LabeledPool {
     pub name: &'static str,
-    pub pool: PgPool,
+    /// Live provider: the sampler reads the *current* pool each tick, so a
+    /// runtime pool swap (connection-budget re-division) is reflected.
+    pub pool: sqlx_pool_router::DynPools,
 }
 
 /// Start the pool metrics sampler background task.
@@ -51,12 +52,6 @@ pub async fn run_pool_metrics_sampler(
         config.sample_interval
     );
 
-    // Record max connections once at startup (it doesn't change)
-    for labeled in &pools {
-        let max = labeled.pool.options().get_max_connections();
-        gauge!("dwctl_db_pool_connections_max", "pool" => labeled.name.to_string()).set(max as f64);
-    }
-
     let mut interval = tokio::time::interval(config.sample_interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -68,9 +63,16 @@ pub async fn run_pool_metrics_sampler(
             }
             _ = interval.tick() => {
                 for labeled in &pools {
-                    let size = labeled.pool.size();
-                    let idle = labeled.pool.num_idle();
+                    // Re-read the pool each tick: the governor may have swapped
+                    // it for one with a different max since the last sample.
+                    let current = labeled.pool.write();
+                    let max = current.options().get_max_connections();
+                    let size = current.size();
+                    let idle = current.num_idle();
                     let in_use = size as usize - idle;
+
+                    gauge!("dwctl_db_pool_connections_max", "pool" => labeled.name.to_string())
+                        .set(max as f64);
 
                     gauge!("dwctl_db_pool_connections_total", "pool" => labeled.name.to_string())
                         .set(size as f64);
@@ -100,13 +102,13 @@ mod tests {
     use std::time::Duration;
 
     #[sqlx::test]
-    async fn test_pool_metrics_sampler_runs_and_shuts_down(pool: PgPool) {
+    async fn test_pool_metrics_sampler_runs_and_shuts_down(pool: sqlx::PgPool) {
         let shutdown = CancellationToken::new();
         let shutdown_clone = shutdown.clone();
 
         let pools = vec![LabeledPool {
             name: "test",
-            pool: pool.clone(),
+            pool: sqlx_pool_router::DynPools::new(pool.clone()),
         }];
 
         let config = PoolMetricsConfig {

--- a/dwctl/src/error_enrichment.rs
+++ b/dwctl/src/error_enrichment.rs
@@ -59,7 +59,11 @@ struct ChatRequest {
 /// - 403 Forbidden errors (cap window rolled, reinstatement pending) → retriable 429
 ///   plus a demand-driven config resync so the retry succeeds within seconds
 #[instrument(name = "dwctl.error_enrichment", skip_all, fields(http.request.method = %request.method(), url.path = %request.uri().path(), url.query = request.uri().query().unwrap_or("")))]
-pub async fn error_enrichment_middleware(State(pools): State<sqlx_pool_router::DynPools>, request: Request<Body>, next: Next) -> Response<Body> {
+pub async fn error_enrichment_middleware(
+    State(pools): State<sqlx_pool_router::DynPools>,
+    request: Request<Body>,
+    next: Next,
+) -> Response<Body> {
     // Extract API key from request headers before passing to onwards
     let api_key = request
         .headers()
@@ -644,7 +648,8 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
+            .layer(axum::middleware::from_fn_with_state(
+                sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 
@@ -783,7 +788,8 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
+            .layer(axum::middleware::from_fn_with_state(
+                sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
         let server = axum_test::TestServer::new(router).expect("Failed to create test server");
@@ -982,7 +988,8 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
+            .layer(axum::middleware::from_fn_with_state(
+                sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 
@@ -1021,7 +1028,8 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
+            .layer(axum::middleware::from_fn_with_state(
+                sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 
@@ -1049,7 +1057,8 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
+            .layer(axum::middleware::from_fn_with_state(
+                sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 
@@ -1134,7 +1143,8 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
+            .layer(axum::middleware::from_fn_with_state(
+                sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 
@@ -1396,7 +1406,8 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
+            .layer(axum::middleware::from_fn_with_state(
+                sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 

--- a/dwctl/src/error_enrichment.rs
+++ b/dwctl/src/error_enrichment.rs
@@ -59,7 +59,7 @@ struct ChatRequest {
 /// - 403 Forbidden errors (cap window rolled, reinstatement pending) → retriable 429
 ///   plus a demand-driven config resync so the retry succeeds within seconds
 #[instrument(name = "dwctl.error_enrichment", skip_all, fields(http.request.method = %request.method(), url.path = %request.uri().path(), url.query = request.uri().query().unwrap_or("")))]
-pub async fn error_enrichment_middleware(State(pool): State<PgPool>, request: Request<Body>, next: Next) -> Response<Body> {
+pub async fn error_enrichment_middleware(State(pools): State<sqlx_pool_router::DynPools>, request: Request<Body>, next: Next) -> Response<Body> {
     // Extract API key from request headers before passing to onwards
     let api_key = request
         .headers()
@@ -98,7 +98,7 @@ pub async fn error_enrichment_middleware(State(pool): State<PgPool>, request: Re
         // One lookup of the key's owner + purpose, reused by the checks below so
         // a 403 does not fan out into several by-secret queries. None for an
         // unknown/invalid token, in which case the checks fall through.
-        let key_info = get_api_key_user_and_purpose(pool.clone(), &key).await.ok().flatten();
+        let key_info = get_api_key_user_and_purpose(pools.write().into_inner(), &key).await.ok().flatten();
 
         // Order matters: the more fundamental the failure, the earlier it runs, so
         // when several conditions could explain the 403 we surface the one that's
@@ -138,7 +138,7 @@ pub async fn error_enrichment_middleware(State(pool): State<PgPool>, request: Re
         // 1. Model access via group membership
         if let Some(model) = &model_name
             && let Some((user_id, _)) = key_info.as_ref()
-            && let Ok(has_access) = check_user_has_model_access(pool.clone(), *user_id, model).await
+            && let Ok(has_access) = check_user_has_model_access(pools.write().into_inner(), *user_id, model).await
             && !has_access
         {
             return Error::ModelAccessDenied {
@@ -153,7 +153,7 @@ pub async fn error_enrichment_middleware(State(pool): State<PgPool>, request: Re
 
         // 2. Modality blocked by a traffic routing rule on this model.
         if let Some(model) = &model_name
-            && let Ok(Some(purpose)) = check_modality_blocked(pool.clone(), &key, model).await
+            && let Ok(Some(purpose)) = check_modality_blocked(pools.write().into_inner(), &key, model).await
         {
             return Error::ModalityAccessDenied {
                 model_name: model.clone(),
@@ -164,7 +164,7 @@ pub async fn error_enrichment_middleware(State(pool): State<PgPool>, request: Re
         }
 
         // 3. Insufficient balance.
-        if let Ok(balance) = get_balance_of_api_key(pool.clone(), &key).await
+        if let Ok(balance) = get_balance_of_api_key(pools.write().into_inner(), &key).await
             && balance <= Decimal::ZERO
         {
             return Error::InsufficientCredits {
@@ -180,7 +180,7 @@ pub async fn error_enrichment_middleware(State(pool): State<PgPool>, request: Re
         //    post-boundary lag: a key whose window has rolled but which the
         //    periodic fallback sync hasn't readmitted yet is never reported
         //    as "cap exceeded".
-        if let Ok(Some(cap)) = get_spend_cap_state(pool.clone(), &key).await
+        if let Ok(Some(cap)) = get_spend_cap_state(pools.write().into_inner(), &key).await
             && cap.window_spend >= cap.limit
         {
             if cap.window_current {
@@ -215,7 +215,7 @@ pub async fn error_enrichment_middleware(State(pool): State<PgPool>, request: Re
             // into a resync storm by a burst of 403s; if the notify is
             // throttled or lost, the periodic fallback sync readmits within
             // one interval anyway).
-            maybe_fire_boundary_resync(&pool).await;
+            maybe_fire_boundary_resync(&pools.write()).await;
 
             // And tell the triggering request the truth: its cap has reset
             // and the key is being reinstated. 429 deliberately, because it
@@ -644,8 +644,7 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(
-                pool.clone(),
+            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 
@@ -784,8 +783,7 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(
-                pool.clone(),
+            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
         let server = axum_test::TestServer::new(router).expect("Failed to create test server");
@@ -984,8 +982,7 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(
-                pool.clone(),
+            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 
@@ -1024,8 +1021,7 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(
-                pool.clone(),
+            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 
@@ -1053,8 +1049,7 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(
-                pool.clone(),
+            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 
@@ -1139,8 +1134,7 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(
-                pool.clone(),
+            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 
@@ -1402,8 +1396,7 @@ mod tests {
                         .unwrap()
                 }),
             )
-            .layer(axum::middleware::from_fn_with_state(
-                pool.clone(),
+            .layer(axum::middleware::from_fn_with_state(sqlx_pool_router::DynPools::new(pool.clone()),
                 crate::error_enrichment::error_enrichment_middleware,
             ));
 

--- a/dwctl/src/inference/engine/outlet_handler.rs
+++ b/dwctl/src/inference/engine/outlet_handler.rs
@@ -14,7 +14,6 @@
 
 use chrono::{DateTime, Utc};
 use outlet::{RequestData, RequestHandler, ResponseData};
-use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::writer::{RawCompletedRequest, RequestsWriterSender};
@@ -30,12 +29,16 @@ use crate::inference::store::{ONWARDS_RESPONSE_ID_HEADER, lookup_created_by};
 #[derive(Clone)]
 pub struct FusilladeOutletHandler {
     sender: RequestsWriterSender,
-    dwctl_pool: PgPool,
+    /// Live provider (not a pinned pool): survives runtime pool swaps.
+    dwctl_pool: sqlx_pool_router::DynPools,
 }
 
 impl FusilladeOutletHandler {
-    pub fn new(sender: RequestsWriterSender, dwctl_pool: PgPool) -> Self {
-        Self { sender, dwctl_pool }
+    pub fn new(sender: RequestsWriterSender, dwctl_pool: impl sqlx_pool_router::PoolProvider) -> Self {
+        Self {
+            sender,
+            dwctl_pool: sqlx_pool_router::DynPools::new(dwctl_pool),
+        }
     }
 
     /// Extract the onwards response ID from request headers, if present.
@@ -139,7 +142,7 @@ impl FusilladeOutletHandler {
                 return None;
             }
         };
-        let created_by = lookup_created_by(&self.dwctl_pool, Some(&api_key)).await;
+        let created_by = lookup_created_by(&self.dwctl_pool.write(), Some(&api_key)).await;
         match created_by {
             Some(uid) if !uid.is_empty() => Some((api_key, uid)),
             _ => {

--- a/dwctl/src/inference/image_normalizer_middleware.rs
+++ b/dwctl/src/inference/image_normalizer_middleware.rs
@@ -68,7 +68,7 @@ pub struct ImageNormalizerMiddlewareState {
     /// bearer-token API key for `image_access` bookkeeping, and (b) by the
     /// per-user-mode lookup once the opt-in flag is wired through.
     /// `None` disables both (useful in tests).
-    pub pool: Option<PgPool>,
+    pub pool: Option<sqlx_pool_router::DynPools>,
 }
 
 /// Extract the Bearer token from `Authorization`, case-insensitive.
@@ -139,7 +139,7 @@ pub async fn image_normalizer_middleware(
     // `image_access` bookkeeping, not for mode selection — best-effort,
     // never blocks the request.
     let attribution_for_access = match (state.pool.as_ref(), extract_bearer_token(&request)) {
-        (Some(pool), Some(bearer)) => crate::api::handlers::images::resolve_image_attribution(pool, &bearer).await,
+        (Some(pool), Some(bearer)) => crate::api::handlers::images::resolve_image_attribution(&pool.write(), &bearer).await,
         _ => None,
     };
 
@@ -178,7 +178,7 @@ pub async fn image_normalizer_middleware(
                 let bytes_len = ingested.bytes_len;
                 let token = ingested.token;
                 tokio::spawn(async move {
-                    crate::api::handlers::images::record_image_access(&pool, attribution, token, &mime, bytes_len).await;
+                    crate::api::handlers::images::record_image_access(&pool.write(), attribution, token, &mime, bytes_len).await;
                 });
             }
             Ok::<String, NormalizeError>(signed.url)

--- a/dwctl/src/inference/middleware.rs
+++ b/dwctl/src/inference/middleware.rs
@@ -49,7 +49,8 @@ pub struct InferenceMiddlewareState<P: PoolProvider + Clone = sqlx_pool_router::
     /// responses→chat completions conversion.
     pub loopback_base_url: String,
     /// dwctl database pool for model access validation.
-    pub dwctl_pool: sqlx::PgPool,
+    /// Live provider (not a pinned pool): survives runtime pool swaps.
+    pub dwctl_pool: sqlx_pool_router::DynPools,
     /// Fusillade-backed response store. Used by the control plane here for
     /// `previous_response_id` hydration, and by `GET /v1/responses/{id}`.
     pub response_store: Arc<super::store::FusilladeResponseStore<P>>,
@@ -255,7 +256,7 @@ pub async fn inference_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
                     .unwrap();
             }
             Some(key) => {
-                if let Err(msg) = crate::error_enrichment::validate_api_key_model_access(state.dwctl_pool.clone(), key, model).await {
+                if let Err(msg) = crate::error_enrichment::validate_api_key_model_access(state.dwctl_pool.write().into_inner(), key, model).await {
                     return Response::builder()
                         .status(StatusCode::FORBIDDEN)
                         .header("content-type", "application/json")
@@ -269,7 +270,7 @@ pub async fn inference_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
     }
 
     if matches!(service_tier, ServiceTier::Background) {
-        match api_key_creator_can_run_background(&state.dwctl_pool, api_key.as_deref()).await {
+        match api_key_creator_can_run_background(&state.dwctl_pool.write(), api_key.as_deref()).await {
             Ok(Some(true)) => {}
             Ok(Some(false)) => {
                 return Response::builder()
@@ -312,12 +313,12 @@ pub async fn inference_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
     // exist before returning 202). Flex uses the key owner's hidden batch key
     // below, so resolving it there also supplies the attribution target.
     let created_by = if background && matches!(service_tier, ServiceTier::Realtime) {
-        response_store::lookup_created_by(&state.dwctl_pool, api_key.as_deref()).await
+        response_store::lookup_created_by(&state.dwctl_pool.write(), api_key.as_deref()).await
     } else {
         None
     };
     let queued_batch_key = if is_daemon_processed {
-        match resolve_flex_batch_api_key(&state.dwctl_pool, api_key.as_deref()).await {
+        match resolve_flex_batch_api_key(&state.dwctl_pool.write(), api_key.as_deref()).await {
             Ok(Some(key)) => Some(key),
             Ok(None) => {
                 tracing::warn!(service_tier = %service_tier, "Queued API key disappeared before hidden batch-key resolution");
@@ -437,10 +438,10 @@ pub async fn inference_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
                 // keys), mirroring how CurrentUser is derived, so the console's
                 // org-scoped image-view authorization lines up.
                 let attribution = match api_key.as_deref() {
-                    Some(key) => crate::api::handlers::images::resolve_image_attribution(&state.dwctl_pool, key).await,
+                    Some(key) => crate::api::handlers::images::resolve_image_attribution(&state.dwctl_pool.write(), key).await,
                     None => None,
                 };
-                let access_pool = Some(state.dwctl_pool.clone());
+                let access_pool = Some(state.dwctl_pool.write().into_inner());
                 match normalize_value_to_tokens(&mut request_value, &state.image_normalizer, access_pool, attribution).await {
                     Ok(n) => {
                         if n > 0 {

--- a/dwctl/src/inference/middleware.rs
+++ b/dwctl/src/inference/middleware.rs
@@ -256,7 +256,9 @@ pub async fn inference_middleware<P: PoolProvider + Clone + Send + Sync + 'stati
                     .unwrap();
             }
             Some(key) => {
-                if let Err(msg) = crate::error_enrichment::validate_api_key_model_access(state.dwctl_pool.write().into_inner(), key, model).await {
+                if let Err(msg) =
+                    crate::error_enrichment::validate_api_key_model_access(state.dwctl_pool.write().into_inner(), key, model).await
+                {
                     return Response::builder()
                         .status(StatusCode::FORBIDDEN)
                         .header("content-type", "application/json")

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -167,6 +167,7 @@ mod probes;
 pub mod prompt_cache;
 pub mod reasoning;
 mod recompute;
+pub mod replica_governor;
 mod request_logging;
 pub mod sample_files;
 mod static_assets;
@@ -653,18 +654,30 @@ pub async fn seed_database(sources: &[config::ModelSource], db: &PgPool) -> Resu
 }
 
 /// Setup database connections, run migrations, and initialize data
-/// Returns: (embedded_db, main_pools, fusillade_pools, outlet_pools)
+/// Returns: (embedded_db, main_pools, fusillade_pools, outlet_pools, governance)
+///
+/// `governance` is `Some` only when the config declares a connection budget
+/// (`total_max_connections` on some pool): the pod has then already joined its
+/// replica group and every pool was sized at its share; the background
+/// services keep it that way (see `replica_governor`).
 ///
 /// If `pool` is provided, it will be used directly instead of creating a new connection.
 /// This is useful for tests where sqlx::test provides a pool.
+#[allow(clippy::type_complexity)]
 async fn setup_database(
     config: &Config,
     pool: Option<PgPool>,
-) -> anyhow::Result<(Option<db::embedded::EmbeddedDatabase>, DbPools, DbPools, Option<DbPools>)> {
+) -> anyhow::Result<(
+    Option<db::embedded::EmbeddedDatabase>,
+    DbPools,
+    DbPools,
+    Option<DbPools>,
+    Option<replica_governor::PoolGovernance>,
+)> {
     let slow_threshold = std::time::Duration::from_millis(config.slow_statement_threshold_ms);
 
     // If a pool is provided (e.g., from tests), create a TestDbPools which will create a read-only replica
-    let (embedded_db, pool, test_replica_pool) = if let Some(existing_pool) = pool {
+    let (embedded_db, pool, test_replica_pool, governance_seed) = if let Some(existing_pool) = pool {
         info!("Using provided database pool with TestDbPools for read/write separation");
 
         // Create TestDbPools which creates a read-only replica for testing
@@ -673,8 +686,8 @@ async fn setup_database(
             .expect("Failed to create TestDbPools");
 
         // Extract the write and read pools to create a DbPools with proper read/write separation
-        let replica_pool = test_pools.read().clone();
-        (None, existing_pool, Some(replica_pool))
+        let replica_pool = test_pools.read().into_inner();
+        (None, existing_pool, Some(replica_pool), None)
     } else {
         // Database connection - handle both embedded and external
         let (_embedded_db, database_url) = match &config.database {
@@ -707,26 +720,45 @@ async fn setup_database(
 
         let main_settings = config.database.main_pool_settings();
         let connect_opts = PgConnectOptions::from_str(&database_url)?.log_slow_statements(log::LevelFilter::Warn, slow_threshold);
-        let pool = sqlx::postgres::PgPoolOptions::new()
-            .max_connections(main_settings.max_connections)
-            .min_connections(main_settings.min_connections)
-            .acquire_timeout(std::time::Duration::from_secs(main_settings.acquire_timeout_secs))
-            .idle_timeout(if main_settings.idle_timeout_secs > 0 {
-                Some(std::time::Duration::from_secs(main_settings.idle_timeout_secs))
-            } else {
-                None
+
+        // Connection-budget governance (dormant unless some pool declares a
+        // total): join the replica group BEFORE sizing any pool, so a pod that
+        // boots into an existing group starts at its fair share rather than
+        // grabbing the whole budget. A 1-connection bootstrap pool runs the
+        // migrations first (idempotent; the main pool re-runs them below) so
+        // the registry table exists on the very first deploy.
+        let governance_seed = if config.database.connection_budget_enabled() {
+            let instance_id = uuid::Uuid::new_v4();
+            let group = config.database.replica_group().to_string();
+            let bootstrap = sqlx::postgres::PgPoolOptions::new()
+                .max_connections(1)
+                .connect_with(connect_opts.clone())
+                .await?;
+            migrator().run(&bootstrap).await?;
+            let initial_live =
+                replica_governor::register_and_count(&bootstrap, instance_id, &group, replica_governor::LIVENESS_WINDOW).await?;
+            bootstrap.close().await;
+            info!(%instance_id, group, live_replicas = initial_live, "Joined replica group for connection-budget division");
+            Some(replica_governor::GovernanceSeed {
+                instance_id,
+                group,
+                initial_live,
             })
-            .max_lifetime(if main_settings.max_lifetime_secs > 0 {
-                Some(std::time::Duration::from_secs(main_settings.max_lifetime_secs))
-            } else {
-                None
-            })
+        } else {
+            None
+        };
+        let live = governance_seed.as_ref().map_or(1, |seed| seed.initial_live);
+
+        let pool = replica_governor::pool_options(main_settings, replica_governor::effective_max(main_settings, live))
             .connect_with(connect_opts)
             .await?;
-        (_embedded_db, pool, None)
+        (_embedded_db, pool, None, governance_seed)
     };
 
     migrator().run(&pool).await?;
+
+    let live = governance_seed.as_ref().map_or(1, |seed| seed.initial_live);
+    let mut governed: Vec<replica_governor::GovernedPool> = Vec::new();
 
     // Create replica pool if configured (or use test replica if in test mode)
     let db_pools = if let Some(test_replica) = test_replica_pool {
@@ -736,20 +768,7 @@ async fn setup_database(
         info!("Setting up read replica pool");
         let replica_settings = config.database.main_replica_pool_settings();
         let replica_opts = PgConnectOptions::from_str(replica_url)?.log_slow_statements(log::LevelFilter::Warn, slow_threshold);
-        let replica_pool = sqlx::postgres::PgPoolOptions::new()
-            .max_connections(replica_settings.max_connections)
-            .min_connections(replica_settings.min_connections)
-            .acquire_timeout(std::time::Duration::from_secs(replica_settings.acquire_timeout_secs))
-            .idle_timeout(if replica_settings.idle_timeout_secs > 0 {
-                Some(std::time::Duration::from_secs(replica_settings.idle_timeout_secs))
-            } else {
-                None
-            })
-            .max_lifetime(if replica_settings.max_lifetime_secs > 0 {
-                Some(std::time::Duration::from_secs(replica_settings.max_lifetime_secs))
-            } else {
-                None
-            })
+        let replica_pool = replica_governor::pool_options(replica_settings, replica_governor::effective_max(replica_settings, live))
             .connect_with(replica_opts)
             .await?;
         DbPools::with_replica(pool, replica_pool)
@@ -757,8 +776,25 @@ async fn setup_database(
         DbPools::new(pool)
     };
 
+    if governance_seed.is_some() {
+        governed.push(replica_governor::GovernedPool {
+            name: "main",
+            primary: (
+                config.database.main_pool_settings().clone(),
+                db_pools.write().connect_options().as_ref().clone(),
+            ),
+            replica: db_pools.has_replica().then(|| {
+                (
+                    config.database.main_replica_pool_settings().clone(),
+                    db_pools.read().connect_options().as_ref().clone(),
+                )
+            }),
+            target: db_pools.clone(),
+        });
+    }
+
     // Get connection options from the main pool to create schema-based child pools
-    let main_connect_opts = db_pools.connect_options().as_ref().clone();
+    let main_connect_opts = db_pools.write().connect_options().as_ref().clone();
 
     // Helper to create a pool with schema-specific search_path
     // Reuses connection URLs from main pool (both primary and replica if configured)
@@ -769,29 +805,15 @@ async fn setup_database(
         schema: String,
         opts: sqlx::postgres::PgConnectOptions,
         settings: &config::PoolSettings,
+        max_connections: u32,
     ) -> Result<sqlx::PgPool, sqlx::Error> {
         // Set search_path directly in connection options so PostgreSQL enforces it
         // This is more reliable than after_connect hooks, especially with replicas
         // The options() method formats as: "-c key=value"
-        let search_path_key = "search_path".to_string();
-        let search_path_value = schema.clone();
         info!("Setting search_path={} via connection options for schema pool", schema);
-        let opts_with_schema = opts.options([(search_path_key, search_path_value)]);
+        let opts_with_schema = opts.options([("search_path".to_string(), schema)]);
 
-        sqlx::postgres::PgPoolOptions::new()
-            .max_connections(settings.max_connections)
-            .min_connections(settings.min_connections)
-            .acquire_timeout(std::time::Duration::from_secs(settings.acquire_timeout_secs))
-            .idle_timeout(if settings.idle_timeout_secs > 0 {
-                Some(std::time::Duration::from_secs(settings.idle_timeout_secs))
-            } else {
-                None
-            })
-            .max_lifetime(if settings.max_lifetime_secs > 0 {
-                Some(std::time::Duration::from_secs(settings.max_lifetime_secs))
-            } else {
-                None
-            })
+        replica_governor::pool_options(settings, max_connections)
             .connect_with(opts_with_schema)
             .await
     }
@@ -803,7 +825,13 @@ async fn setup_database(
             name, pool: pool_settings, ..
         } => {
             // Create primary pool using main's connection, with schema-specific search_path
-            let primary = create_schema_pool(name.clone(), main_connect_opts.clone(), pool_settings).await?;
+            let primary = create_schema_pool(
+                name.clone(),
+                main_connect_opts.clone(),
+                pool_settings,
+                replica_governor::effective_max(pool_settings, live),
+            )
+            .await?;
             primary.execute(&*format!("CREATE SCHEMA IF NOT EXISTS {name}")).await?;
 
             // Create replica pool if main has one configured (inherits main's replica connection)
@@ -811,7 +839,13 @@ async fn setup_database(
                 info!("Setting up fusillade read replica (schema mode)");
                 let replica_opts = db_pools.read().connect_options().as_ref().clone();
                 let replica_pool_settings = config.database.fusillade().replica_pool_settings();
-                let replica = create_schema_pool(name.clone(), replica_opts, replica_pool_settings).await?;
+                let replica = create_schema_pool(
+                    name.clone(),
+                    replica_opts,
+                    replica_pool_settings,
+                    replica_governor::effective_max(replica_pool_settings, live),
+                )
+                .await?;
                 DbPools::with_replica(primary, replica)
             } else {
                 DbPools::new(primary)
@@ -825,20 +859,7 @@ async fn setup_database(
         } => {
             info!("Using dedicated database for fusillade");
             let connect_opts = PgConnectOptions::from_str(url)?.log_slow_statements(log::LevelFilter::Warn, slow_threshold);
-            let primary = sqlx::postgres::PgPoolOptions::new()
-                .max_connections(pool_settings.max_connections)
-                .min_connections(pool_settings.min_connections)
-                .acquire_timeout(std::time::Duration::from_secs(pool_settings.acquire_timeout_secs))
-                .idle_timeout(if pool_settings.idle_timeout_secs > 0 {
-                    Some(std::time::Duration::from_secs(pool_settings.idle_timeout_secs))
-                } else {
-                    None
-                })
-                .max_lifetime(if pool_settings.max_lifetime_secs > 0 {
-                    Some(std::time::Duration::from_secs(pool_settings.max_lifetime_secs))
-                } else {
-                    None
-                })
+            let primary = replica_governor::pool_options(pool_settings, replica_governor::effective_max(pool_settings, live))
                 .connect_with(connect_opts)
                 .await?;
 
@@ -846,20 +867,7 @@ async fn setup_database(
                 info!("Setting up fusillade read replica");
                 let replica_pool_settings = config.database.fusillade().replica_pool_settings();
                 let replica_opts = PgConnectOptions::from_str(replica_url)?.log_slow_statements(log::LevelFilter::Warn, slow_threshold);
-                let replica = sqlx::postgres::PgPoolOptions::new()
-                    .max_connections(replica_pool_settings.max_connections)
-                    .min_connections(replica_pool_settings.min_connections)
-                    .acquire_timeout(std::time::Duration::from_secs(replica_pool_settings.acquire_timeout_secs))
-                    .idle_timeout(if replica_pool_settings.idle_timeout_secs > 0 {
-                        Some(std::time::Duration::from_secs(replica_pool_settings.idle_timeout_secs))
-                    } else {
-                        None
-                    })
-                    .max_lifetime(if replica_pool_settings.max_lifetime_secs > 0 {
-                        Some(std::time::Duration::from_secs(replica_pool_settings.max_lifetime_secs))
-                    } else {
-                        None
-                    })
+                let replica = replica_governor::pool_options(replica_pool_settings, replica_governor::effective_max(replica_pool_settings, live))
                     .connect_with(replica_opts)
                     .await?;
                 DbPools::with_replica(primary, replica)
@@ -868,10 +876,26 @@ async fn setup_database(
             }
         }
     };
-    fusillade_arsenal::migrator().run(&*fusillade_pools).await?;
+    if governance_seed.is_some() {
+        governed.push(replica_governor::GovernedPool {
+            name: "fusillade",
+            primary: (
+                config.database.fusillade().pool_settings().clone(),
+                fusillade_pools.write().connect_options().as_ref().clone(),
+            ),
+            replica: fusillade_pools.has_replica().then(|| {
+                (
+                    config.database.fusillade().replica_pool_settings().clone(),
+                    fusillade_pools.read().connect_options().as_ref().clone(),
+                )
+            }),
+            target: fusillade_pools.clone(),
+        });
+    }
+    fusillade_arsenal::migrator().run(&*fusillade_pools.write()).await?;
 
     // Run underway migrations (background task queue)
-    underway::run_migrations(&*db_pools).await?;
+    underway::run_migrations(&*db_pools.write()).await?;
 
     // Setup outlet schema and pool if request logging is enabled
     let outlet_pools = if config.enable_request_logging {
@@ -881,7 +905,13 @@ async fn setup_database(
                 name, pool: pool_settings, ..
             } => {
                 // Create primary pool using main's connection, with schema-specific search_path
-                let primary = create_schema_pool(name.clone(), main_connect_opts.clone(), pool_settings).await?;
+                let primary = create_schema_pool(
+                name.clone(),
+                main_connect_opts.clone(),
+                pool_settings,
+                replica_governor::effective_max(pool_settings, live),
+            )
+            .await?;
                 primary.execute(&*format!("CREATE SCHEMA IF NOT EXISTS {name}")).await?;
 
                 // Create replica pool if main has one configured (inherits main's replica connection)
@@ -889,7 +919,13 @@ async fn setup_database(
                     info!("Setting up outlet read replica (schema mode)");
                     let replica_opts = db_pools.read().connect_options().as_ref().clone();
                     let replica_pool_settings = config.database.outlet().replica_pool_settings();
-                    let replica = create_schema_pool(name.clone(), replica_opts, replica_pool_settings).await?;
+                    let replica = create_schema_pool(
+                    name.clone(),
+                    replica_opts,
+                    replica_pool_settings,
+                    replica_governor::effective_max(replica_pool_settings, live),
+                )
+                .await?;
                     DbPools::with_replica(primary, replica)
                 } else {
                     DbPools::new(primary)
@@ -903,42 +939,16 @@ async fn setup_database(
             } => {
                 info!("Using dedicated database for outlet");
                 let connect_opts = PgConnectOptions::from_str(url)?.log_slow_statements(log::LevelFilter::Warn, slow_threshold);
-                let primary = sqlx::postgres::PgPoolOptions::new()
-                    .max_connections(pool_settings.max_connections)
-                    .min_connections(pool_settings.min_connections)
-                    .acquire_timeout(std::time::Duration::from_secs(pool_settings.acquire_timeout_secs))
-                    .idle_timeout(if pool_settings.idle_timeout_secs > 0 {
-                        Some(std::time::Duration::from_secs(pool_settings.idle_timeout_secs))
-                    } else {
-                        None
-                    })
-                    .max_lifetime(if pool_settings.max_lifetime_secs > 0 {
-                        Some(std::time::Duration::from_secs(pool_settings.max_lifetime_secs))
-                    } else {
-                        None
-                    })
-                    .connect_with(connect_opts)
+                let primary = replica_governor::pool_options(pool_settings, replica_governor::effective_max(pool_settings, live))
+                .connect_with(connect_opts)
                     .await?;
 
                 if let Some(replica_url) = replica_url {
                     info!("Setting up outlet read replica");
                     let replica_pool_settings = config.database.outlet().replica_pool_settings();
                     let replica_opts = PgConnectOptions::from_str(replica_url)?.log_slow_statements(log::LevelFilter::Warn, slow_threshold);
-                    let replica = sqlx::postgres::PgPoolOptions::new()
-                        .max_connections(replica_pool_settings.max_connections)
-                        .min_connections(replica_pool_settings.min_connections)
-                        .acquire_timeout(std::time::Duration::from_secs(replica_pool_settings.acquire_timeout_secs))
-                        .idle_timeout(if replica_pool_settings.idle_timeout_secs > 0 {
-                            Some(std::time::Duration::from_secs(replica_pool_settings.idle_timeout_secs))
-                        } else {
-                            None
-                        })
-                        .max_lifetime(if replica_pool_settings.max_lifetime_secs > 0 {
-                            Some(std::time::Duration::from_secs(replica_pool_settings.max_lifetime_secs))
-                        } else {
-                            None
-                        })
-                        .connect_with(replica_opts)
+                    let replica = replica_governor::pool_options(replica_pool_settings, replica_governor::effective_max(replica_pool_settings, live))
+                    .connect_with(replica_opts)
                         .await?;
                     DbPools::with_replica(primary, replica)
                 } else {
@@ -946,7 +956,23 @@ async fn setup_database(
                 }
             }
         };
-        outlet_postgres::migrator().run(&*pools).await?;
+        outlet_postgres::migrator().run(&*pools.write()).await?;
+        if governance_seed.is_some() {
+            governed.push(replica_governor::GovernedPool {
+                name: "outlet",
+                primary: (
+                    config.database.outlet().pool_settings().clone(),
+                    pools.write().connect_options().as_ref().clone(),
+                ),
+                replica: pools.has_replica().then(|| {
+                    (
+                        config.database.outlet().replica_pool_settings().clone(),
+                        pools.read().connect_options().as_ref().clone(),
+                    )
+                }),
+                target: pools.clone(),
+            });
+        }
 
         Some(pools)
     } else {
@@ -960,7 +986,7 @@ async fn setup_database(
         iterations: config.auth.native.password.argon2_iterations,
         parallelism: config.auth.native.password.argon2_parallelism,
     };
-    create_initial_admin_user(&config.admin_email, config.admin_password.as_deref(), argon2_params, &db_pools)
+    create_initial_admin_user(&config.admin_email, config.admin_password.as_deref(), argon2_params, &db_pools.write())
         .await
         .map_err(|e| anyhow::anyhow!("Failed to create initial admin user: {}", e))?;
 
@@ -969,15 +995,16 @@ async fn setup_database(
     // group gating or pricing) so it exists and has synced into the onwards key
     // cache before the first resume attempt.
     if config.continuation.enabled {
-        continuation::provision_global_key(&db_pools)
+        continuation::provision_global_key(&db_pools.write())
             .await
             .map_err(|e| anyhow::anyhow!("Failed to provision continuation key: {}", e))?;
     }
 
     // Seed database with initial configuration (only runs once)
-    seed_database(&config.model_sources, &db_pools).await?;
+    seed_database(&config.model_sources, &db_pools.write()).await?;
 
-    Ok((embedded_db, db_pools, fusillade_pools, outlet_pools))
+    let governance = governance_seed.map(|seed| replica_governor::PoolGovernance { seed, pools: governed });
+    Ok((embedded_db, db_pools, fusillade_pools, outlet_pools, governance))
 }
 
 /// Build the base CORS layer (methods, headers, max-age, exposed headers) from
@@ -1191,7 +1218,7 @@ pub async fn build_router(
         // Add PostgresHandler for request logging if enabled
         if request_logging_enabled {
             let outlet_pool = state.outlet_db.as_ref().expect("outlet_db checked above");
-            let postgres_handler = PostgresHandler::<DbPools, ParsedAIRequest, AiResponse>::from_pool_provider(outlet_pool.clone())
+            let postgres_handler = PostgresHandler::<sqlx::PgPool, ParsedAIRequest, AiResponse>::from_pool_provider(outlet_pool.write().into_inner())
                 .await
                 .expect("Failed to create PostgresHandler for request logging")
                 .with_request_serializer(parse_ai_request)
@@ -1724,7 +1751,7 @@ pub async fn build_router(
             enabled: cfg.image_normalizer.enabled,
             normalizer,
             realtime_ttl,
-            pool: Some(state.db.write().clone()),
+            pool: Some(sqlx_pool_router::DynPools::new(state.db.clone())),
         };
         onwards_router.layer(middleware::from_fn_with_state(
             image_normalizer_state,
@@ -1734,7 +1761,7 @@ pub async fn build_router(
 
     // Apply error enrichment middleware to onwards router (before outlet logging)
     let onwards_router = onwards_router.layer(middleware::from_fn_with_state(
-        state.db.write().clone(),
+        sqlx_pool_router::DynPools::new(state.db.clone()),
         error_enrichment::error_enrichment_middleware,
     ));
 
@@ -1761,7 +1788,7 @@ pub async fn build_router(
             match crate::continuation::ContinuationState::build(
                 &cfg.continuation,
                 &cfg.cache.tokenizer_url,
-                state.db.write().clone(),
+                sqlx_pool_router::DynPools::new(state.db.clone()),
                 resume_target,
                 body_limit,
             )
@@ -1806,7 +1833,7 @@ pub async fn build_router(
     let onwards_router = {
         let cfg = state.current_config();
         if cfg.cache.enabled {
-            let pool = state.db.write().clone();
+            let pool = sqlx_pool_router::DynPools::new(state.db.clone());
             let classifier = crate::prompt_cache::Classifier::new(
                 crate::prompt_cache::PrincipalResolver::new(pool.clone()),
                 crate::prompt_cache::ModelConfigResolver::new(pool.clone()),
@@ -2210,8 +2237,9 @@ pub struct BackgroundServices {
     /// them up immediately rather than waiting for stale-daemon
     /// detection (~30s).
     onwards_daemon_id: Option<Uuid>,
-    /// Fusillade write pool retained for the SIGTERM drain queries.
-    fusillade_write_pool: Option<sqlx::PgPool>,
+    /// Fusillade pools retained for the SIGTERM drain queries (a live
+    /// provider, so it follows runtime pool swaps).
+    fusillade_write_pool: Option<sqlx_pool_router::DynPools>,
     task_runner: Arc<tasks::TaskRunner>,
     is_leader: bool,
     onwards_targets: onwards::target::Targets,
@@ -2580,14 +2608,17 @@ pub(crate) struct BackgroundServicesInput {
     pub model_capacity_limits: Arc<dashmap::DashMap<String, usize>>,
     /// dwctl primary pool (used for probe scheduler, notification
     /// poller, and the inference middleware setup).
-    pub pool: PgPool,
+    pub db_pools: DbPools,
     /// Fusillade pool wrapper; kept around inside this function only
     /// to clone the write pool for the metrics sampler — fusillade's
     /// daemon already owns its own clone via `request_manager`.
     pub fusillade_pools: DbPools,
     /// Outlet (request-logging) pool. Optional because outlet is
     /// optional.
-    pub outlet_pool: Option<PgPool>,
+    pub outlet_pools: Option<DbPools>,
+    /// Connection-budget governance state from `setup_database`; `None` when
+    /// no pool declares a `total_max_connections` (governor dormant).
+    pub governance: Option<replica_governor::PoolGovernance>,
     pub config: Config,
     pub shared_config: SharedConfig,
     pub shutdown_token: tokio_util::sync::CancellationToken,
@@ -2602,15 +2633,21 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         postgres_daemon,
         step_manager,
         model_capacity_limits,
-        pool,
+        db_pools,
         fusillade_pools,
-        outlet_pool,
+        outlet_pools,
+        governance,
         config,
         shared_config,
         shutdown_token,
         metrics_recorder,
         keystore,
     } = input;
+
+    // Live provider for every long-lived consumer below: a runtime pool swap
+    // (connection-budget re-division across replicas) reaches them on their
+    // next call. Only leader election gets a pinned pool — see there.
+    let dyn_pools = sqlx_pool_router::DynPools::new(db_pools.clone());
 
     // `keystore` comes from the caller (built once and shared). Install the
     // TRANSITIONAL ZDR response transformer on the daemon before it
@@ -2643,7 +2680,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
             .collect();
 
         let (onwards_config_sync, initial_targets, onwards_stream) = sync::onwards_config::OnwardsConfigSync::new_with_daemon_limits(
-            pool.clone(),
+            dyn_pools.clone(),
             Some(model_capacity_limits.clone()),
             config.background_services.batch_daemon.default_model_concurrency,
             escalation_models,
@@ -2699,9 +2736,37 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
     // LISTEN/NOTIFY refresh loop is gated on onwards config sync, with which it
     // shares the `auth_config_changed` channel; with sync disabled the map is
     // still correct at startup, it just does not pick up later policy changes.
-    let zdr_key_cache = crate::sync::zdr_keys::initial_cache(&pool).await?;
+    // Connection-budget governance: heartbeat this pod's membership in its
+    // replica group and re-divide every governed pool as the group changes.
+    // Both tasks are absent when no pool declares a total.
+    if let Some(governance) = governance {
+        let (count_tx, count_rx) = tokio::sync::watch::channel(governance.seed.initial_live);
+        let membership_pools = dyn_pools.clone();
+        let membership_shutdown = shutdown_token.clone();
+        let instance_id = governance.seed.instance_id;
+        let group = governance.seed.group.clone();
+        background_tasks.spawn("replica-membership", async move {
+            replica_governor::run_membership(
+                membership_pools,
+                instance_id,
+                group,
+                count_tx,
+                replica_governor::MembershipConfig::default(),
+                membership_shutdown,
+            )
+            .await;
+            Ok(())
+        });
+        let governor_shutdown = shutdown_token.clone();
+        background_tasks.spawn("connection-governor", async move {
+            replica_governor::run_governor(governance.pools, count_rx, replica_governor::RESIZE_SETTLE, governor_shutdown).await;
+            Ok(())
+        });
+    }
+
+    let zdr_key_cache = crate::sync::zdr_keys::initial_cache(&db_pools.write()).await?;
     if config.background_services.onwards_sync.enabled {
-        let zdr_pool = pool.clone();
+        let zdr_pool = dyn_pools.clone();
         let zdr_cache = zdr_key_cache.clone();
         let zdr_shutdown = shutdown_token.clone();
         let zdr_fallback = config.background_services.onwards_sync.fallback_interval_milliseconds;
@@ -2715,12 +2780,12 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
     // Leader election lock ID: 0x44574354_50524F42 (DWCT_PROB in hex for "dwctl probes")
     const LEADER_LOCK_ID: i64 = 0x4457_4354_5052_4F42_i64;
 
-    let probe_scheduler = probes::ProbeScheduler::new(pool.clone(), config.clone());
+    let probe_scheduler = probes::ProbeScheduler::new(dyn_pools.clone(), config.clone());
 
     // Caller owns `request_manager` / `step_manager` construction —
-    // see the function-level doc. We still need a pool clone here for
-    // the metrics sampler; `fusillade_pools` is otherwise unused.
-    let fusillade_pool_for_metrics = fusillade_pools.write().clone();
+    // see the function-level doc. `fusillade_pools` is only sampled by the
+    // metrics sampler here, through a live provider so pool swaps show up.
+    let fusillade_pools_for_metrics = sqlx_pool_router::DynPools::new(fusillade_pools.clone());
     drop(fusillade_pools);
 
     let is_leader: bool;
@@ -2784,7 +2849,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         {
             let daemon_config = config.clone();
             let daemon_request_manager = request_manager.clone();
-            let daemon_pool = pool.clone();
+            let daemon_pool = dyn_pools.clone();
             let daemon_shutdown = shutdown_token.clone();
             background_tasks.spawn("batch-completion", async move {
                 notifications::run_notification_poller(
@@ -2830,7 +2895,11 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         let is_leader_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         // Spawn leader election background task
-        let leader_election_pool = pool.clone();
+        // Deliberately a pinned pool, NOT the live provider: leader election
+        // holds one session-pinned connection for the advisory lock, and
+        // swapping the pool underneath it would drop the lock.
+        let leader_election_pool = db_pools.write().into_inner();
+        let leader_election_pools_gain = dyn_pools.clone();
         let leader_election_scheduler_gain = probe_scheduler.clone();
         let leader_election_scheduler_lose = probe_scheduler.clone();
         let leader_election_request_manager_gain = request_manager.clone();
@@ -2858,8 +2927,9 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
                 leader_election_flag,
                 LEADER_LOCK_ID,
                 leader_election_shutdown,
-                move |pool, config| {
+                move |_pool, config| {
                     // This closure is run when a replica becomes the leader
+                    let gain_pools = leader_election_pools_gain.clone();
                     let scheduler = leader_election_scheduler_gain.clone();
                     let request_manager = leader_election_request_manager_gain.clone();
                     let postgres_daemon = leader_election_postgres_daemon_gain.clone();
@@ -2923,7 +2993,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
                                     daemon_config.background_services.notifications.clone(),
                                     daemon_config,
                                     notification_request_manager,
-                                    pool,
+                                    gain_pools,
                                     daemon_session_token,
                                 )
                                 .await;
@@ -2986,7 +3056,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         } else {
             None
         })
-        .connect_with(pool.connect_options().as_ref().clone())
+        .connect_with(db_pools.write().connect_options().as_ref().clone())
         .await?;
 
     // Start pool metrics sampler if metrics are enabled
@@ -2994,21 +3064,21 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
         let mut pools = vec![
             db::LabeledPool {
                 name: "main",
-                pool: pool.clone(),
+                pool: dyn_pools.clone(),
             },
             db::LabeledPool {
                 name: "fusillade",
-                pool: fusillade_pool_for_metrics,
+                pool: fusillade_pools_for_metrics,
             },
             db::LabeledPool {
                 name: "main_underway",
-                pool: underway_pool.clone(),
+                pool: sqlx_pool_router::DynPools::new(underway_pool.clone()),
             },
         ];
-        if let Some(outlet) = outlet_pool {
+        if let Some(outlet) = outlet_pools.as_ref() {
             pools.push(db::LabeledPool {
                 name: "outlet",
-                pool: outlet,
+                pool: sqlx_pool_router::DynPools::new(outlet.clone()),
             });
         }
         let metrics_shutdown = shutdown_token.clone();
@@ -3025,7 +3095,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
     // this shares an in-process Notify with it rather than round-tripping through Postgres.
     let usage_refresh_notify = std::sync::Arc::new(tokio::sync::Notify::new());
     if config.enable_analytics && config.background_services.usage_refresh.enabled {
-        let daemon_pool = pool.clone();
+        let daemon_pool = dyn_pools.clone();
         let daemon_config = config.background_services.usage_refresh.clone();
         let daemon_notify = usage_refresh_notify.clone();
         let daemon_shutdown = shutdown_token.clone();
@@ -3037,7 +3107,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
 
     // Start analytics batcher if enabled
     let analytics_sender = if config.enable_analytics {
-        let (batcher, sender) = request_logging::AnalyticsBatcher::new(pool.clone(), config.clone(), metrics_recorder);
+        let (batcher, sender) = request_logging::AnalyticsBatcher::new(dyn_pools.clone(), config.clone(), metrics_recorder);
         let batcher = batcher.with_usage_refresh_notify(usage_refresh_notify.clone());
 
         let batcher_shutdown = shutdown_token.clone();
@@ -3082,7 +3152,7 @@ async fn setup_background_services(input: BackgroundServicesInput) -> anyhow::Re
 
     let task_state = tasks::TaskState {
         request_manager: request_manager.clone(),
-        dwctl_pool: pool.clone(),
+        dwctl_pool: dyn_pools.clone(),
         config: shared_config.clone(),
         encryption_key: encryption_key.clone(),
         ingest_file_job: Arc::new(std::sync::OnceLock::new()),
@@ -3191,7 +3261,7 @@ impl Application {
         debug!("Starting control layer with configuration: {:#?}", config);
 
         // Setup database connections, run migrations, and initialize data
-        let (_embedded_db, db_pools, fusillade_pools, outlet_pools) = setup_database(&config, pool).await?;
+        let (_embedded_db, db_pools, fusillade_pools, outlet_pools, governance) = setup_database(&config, pool).await?;
 
         // Install Prometheus recorder BEFORE background services start
         // This ensures metrics set during background service initialization are captured
@@ -3306,9 +3376,10 @@ impl Application {
             postgres_daemon: postgres_daemon.clone(),
             step_manager: step_manager.clone(),
             model_capacity_limits,
-            pool: (*db_pools).clone(),
+            db_pools: db_pools.clone(),
             fusillade_pools: fusillade_pools.clone(),
-            outlet_pool: outlet_pools.as_ref().map(|p| (**p).clone()),
+            outlet_pools: outlet_pools.clone(),
+            governance,
             config: config.clone(),
             shared_config: shared_config.clone(),
             shutdown_token: shutdown_token.clone(),
@@ -3319,7 +3390,7 @@ impl Application {
 
         // Register onwards as a fusillade daemon so realtime requests get a valid daemon_id.
         let onwards_daemon_id = uuid::Uuid::new_v4();
-        let fusillade_write_pool = bg_services.request_manager.pool().clone();
+        let fusillade_write_pool = sqlx_pool_router::DynPools::new(bg_services.request_manager.pools().clone());
         let daemon_insert_result = sqlx::query(
             "INSERT INTO daemons (id, hostname, pid, version, config_snapshot, status, started_at, last_heartbeat)
              VALUES ($1, $2, $3, $4, $5, 'running', NOW(), NOW())",
@@ -3409,7 +3480,7 @@ impl Application {
                 };
                 format!("http://{addr}/ai")
             },
-            dwctl_pool: (*db_pools).write().clone(),
+            dwctl_pool: sqlx_pool_router::DynPools::new(db_pools.clone()),
             response_store: response_store.clone(),
             image_normalizer: image_normalizer.clone(),
             image_normalizer_enabled: config.image_normalizer.enabled,

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -867,9 +867,10 @@ async fn setup_database(
                 info!("Setting up fusillade read replica");
                 let replica_pool_settings = config.database.fusillade().replica_pool_settings();
                 let replica_opts = PgConnectOptions::from_str(replica_url)?.log_slow_statements(log::LevelFilter::Warn, slow_threshold);
-                let replica = replica_governor::pool_options(replica_pool_settings, replica_governor::effective_max(replica_pool_settings, live))
-                    .connect_with(replica_opts)
-                    .await?;
+                let replica =
+                    replica_governor::pool_options(replica_pool_settings, replica_governor::effective_max(replica_pool_settings, live))
+                        .connect_with(replica_opts)
+                        .await?;
                 DbPools::with_replica(primary, replica)
             } else {
                 DbPools::new(primary)
@@ -906,12 +907,12 @@ async fn setup_database(
             } => {
                 // Create primary pool using main's connection, with schema-specific search_path
                 let primary = create_schema_pool(
-                name.clone(),
-                main_connect_opts.clone(),
-                pool_settings,
-                replica_governor::effective_max(pool_settings, live),
-            )
-            .await?;
+                    name.clone(),
+                    main_connect_opts.clone(),
+                    pool_settings,
+                    replica_governor::effective_max(pool_settings, live),
+                )
+                .await?;
                 primary.execute(&*format!("CREATE SCHEMA IF NOT EXISTS {name}")).await?;
 
                 // Create replica pool if main has one configured (inherits main's replica connection)
@@ -920,12 +921,12 @@ async fn setup_database(
                     let replica_opts = db_pools.read().connect_options().as_ref().clone();
                     let replica_pool_settings = config.database.outlet().replica_pool_settings();
                     let replica = create_schema_pool(
-                    name.clone(),
-                    replica_opts,
-                    replica_pool_settings,
-                    replica_governor::effective_max(replica_pool_settings, live),
-                )
-                .await?;
+                        name.clone(),
+                        replica_opts,
+                        replica_pool_settings,
+                        replica_governor::effective_max(replica_pool_settings, live),
+                    )
+                    .await?;
                     DbPools::with_replica(primary, replica)
                 } else {
                     DbPools::new(primary)
@@ -940,16 +941,17 @@ async fn setup_database(
                 info!("Using dedicated database for outlet");
                 let connect_opts = PgConnectOptions::from_str(url)?.log_slow_statements(log::LevelFilter::Warn, slow_threshold);
                 let primary = replica_governor::pool_options(pool_settings, replica_governor::effective_max(pool_settings, live))
-                .connect_with(connect_opts)
+                    .connect_with(connect_opts)
                     .await?;
 
                 if let Some(replica_url) = replica_url {
                     info!("Setting up outlet read replica");
                     let replica_pool_settings = config.database.outlet().replica_pool_settings();
                     let replica_opts = PgConnectOptions::from_str(replica_url)?.log_slow_statements(log::LevelFilter::Warn, slow_threshold);
-                    let replica = replica_governor::pool_options(replica_pool_settings, replica_governor::effective_max(replica_pool_settings, live))
-                    .connect_with(replica_opts)
-                        .await?;
+                    let replica =
+                        replica_governor::pool_options(replica_pool_settings, replica_governor::effective_max(replica_pool_settings, live))
+                            .connect_with(replica_opts)
+                            .await?;
                     DbPools::with_replica(primary, replica)
                 } else {
                     DbPools::new(primary)
@@ -986,9 +988,14 @@ async fn setup_database(
         iterations: config.auth.native.password.argon2_iterations,
         parallelism: config.auth.native.password.argon2_parallelism,
     };
-    create_initial_admin_user(&config.admin_email, config.admin_password.as_deref(), argon2_params, &db_pools.write())
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create initial admin user: {}", e))?;
+    create_initial_admin_user(
+        &config.admin_email,
+        config.admin_password.as_deref(),
+        argon2_params,
+        &db_pools.write(),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create initial admin user: {}", e))?;
 
     // Provision the global continuation key (hidden, SYSTEM-owned — system
     // ownership is what admits it to every model's onwards keyset regardless of
@@ -1218,11 +1225,12 @@ pub async fn build_router(
         // Add PostgresHandler for request logging if enabled
         if request_logging_enabled {
             let outlet_pool = state.outlet_db.as_ref().expect("outlet_db checked above");
-            let postgres_handler = PostgresHandler::<sqlx::PgPool, ParsedAIRequest, AiResponse>::from_pool_provider(outlet_pool.write().into_inner())
-                .await
-                .expect("Failed to create PostgresHandler for request logging")
-                .with_request_serializer(parse_ai_request)
-                .with_response_serializer(parse_ai_response);
+            let postgres_handler =
+                PostgresHandler::<sqlx::PgPool, ParsedAIRequest, AiResponse>::from_pool_provider(outlet_pool.write().into_inner())
+                    .await
+                    .expect("Failed to create PostgresHandler for request logging")
+                    .with_request_serializer(parse_ai_request)
+                    .with_response_serializer(parse_ai_response);
             // TRANSITIONAL (dwctl ZDR): guard the analytics logger so plaintext
             // ZDR bodies (decrypted for the upstream call, captured on the
             // loopback) never land in http_requests / http_responses. The marker

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -959,21 +959,18 @@ async fn setup_database(
             }
         };
         outlet_postgres::migrator().run(&*pools.write()).await?;
-        if governance_seed.is_some() {
-            governed.push(replica_governor::GovernedPool {
-                name: "outlet",
-                primary: (
-                    config.database.outlet().pool_settings().clone(),
-                    pools.write().connect_options().as_ref().clone(),
-                ),
-                replica: pools.has_replica().then(|| {
-                    (
-                        config.database.outlet().replica_pool_settings().clone(),
-                        pools.read().connect_options().as_ref().clone(),
-                    )
-                }),
-                target: pools.clone(),
-            });
+        // NOT governed: outlet-postgres (0.7) still speaks sqlx-pool-router 0.2
+        // and its PostgresHandler pins the PgPool it is built with, so a swap
+        // would close the pool under request logging. Outlet is a separate
+        // Neon project outside the governed budget, so nothing is lost until
+        // outlet-postgres adopts pool-router 1.0 and this can join `governed`.
+        if config.database.outlet().pool_settings().total_max_connections.is_some()
+            || config.database.outlet().replica_pool_settings().total_max_connections.is_some()
+        {
+            tracing::warn!(
+                "database.outlet.pool.total_max_connections is set but the outlet pool is not governed \
+                 (outlet-postgres pins its pool); the per-pod max_connections applies"
+            );
         }
 
         Some(pools)

--- a/dwctl/src/notifications.rs
+++ b/dwctl/src/notifications.rs
@@ -28,7 +28,6 @@ use chrono::{DateTime, Utc};
 use fusillade_arsenal::PostgresRequestManager;
 use metrics::counter;
 use rust_decimal::prelude::ToPrimitive;
-use sqlx::PgPool;
 use sqlx::postgres::PgListener;
 use sqlx_pool_router::DbPools;
 use tokio_util::sync::CancellationToken;
@@ -144,9 +143,10 @@ pub async fn run_notification_poller(
     config: NotificationsConfig,
     app_config: crate::config::Config,
     request_manager: Arc<PostgresRequestManager<DbPools>>,
-    dwctl_pool: PgPool,
+    dwctl_pool: impl sqlx_pool_router::PoolProvider,
     shutdown: CancellationToken,
 ) {
+    let dwctl_pool = sqlx_pool_router::DynPools::new(dwctl_pool);
     // Webhook dispatcher runs independently of email notifications
     let mut dispatcher = if config.webhooks.enabled {
         Some(WebhookDispatcher::spawn(dwctl_pool.clone(), &config.webhooks, shutdown.clone()))
@@ -174,7 +174,7 @@ pub async fn run_notification_poller(
 
     // Set up PG listener for platform webhook events (user.created, api_key.created)
     let mut listener = if dispatcher.is_some() {
-        match PgListener::connect_with(&dwctl_pool).await {
+        match PgListener::connect_with(&dwctl_pool.write()).await {
             Ok(mut l) => match l.listen(WEBHOOK_EVENT_CHANNEL).await {
                 Ok(()) => {
                     tracing::info!("Listening on PG channel '{WEBHOOK_EVENT_CHANNEL}' for platform webhook events");
@@ -250,7 +250,7 @@ pub async fn run_notification_poller(
         // Reconnect listener if disconnected
         if listener.is_none()
             && dispatcher.is_some()
-            && let Ok(mut l) = PgListener::connect_with(&dwctl_pool).await
+            && let Ok(mut l) = PgListener::connect_with(&dwctl_pool.write()).await
             && l.listen(WEBHOOK_EVENT_CHANNEL).await.is_ok()
         {
             tracing::info!("Reconnected webhook event listener");
@@ -259,7 +259,7 @@ pub async fn run_notification_poller(
 
         tracing::debug!("Notification poller tick");
 
-        let mut conn = match dwctl_pool.acquire().await {
+        let mut conn = match dwctl_pool.write().acquire().await {
             Ok(c) => c,
             Err(e) => {
                 crate::background_error!(NOTIFICATIONS, "db_acquire", Warning, error = %e, "Failed to acquire database connection for notification poller tick");
@@ -1230,9 +1230,8 @@ mod tests {
     use crate::config::{CreditsConfig, DummyConfig};
     use crate::payment_providers;
     use rust_decimal::Decimal;
-    use sqlx::PgPool;
 
-    async fn configure_auto_topup_decline_test_user(pool: &PgPool, user_id: Uuid, customer_id: &str, failure_count: i32) {
+    async fn configure_auto_topup_decline_test_user(pool: &sqlx::PgPool, user_id: Uuid, customer_id: &str, failure_count: i32) {
         sqlx::query!(
             r#"
             UPDATE users
@@ -1267,7 +1266,7 @@ mod tests {
     /// is the dummy provider's "this card always declines" customer, so if the
     /// branch leaked into the card path this would decline instead of crediting.
     #[sqlx::test]
-    async fn test_process_auto_topups_invoices_instead_of_charging(pool: PgPool) {
+    async fn test_process_auto_topups_invoices_instead_of_charging(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
         configure_auto_topup_decline_test_user(&pool, user.id, "cus_test_soft_decline", 0).await;
         sqlx::query!("UPDATE users SET invoicing_enabled = true WHERE id = $1", user.id)
@@ -1303,7 +1302,7 @@ mod tests {
 
     /// The flag defaults false, so every existing account keeps the card path.
     #[sqlx::test]
-    async fn test_process_auto_topups_defaults_to_charging_a_card(pool: PgPool) {
+    async fn test_process_auto_topups_defaults_to_charging_a_card(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
         configure_auto_topup_decline_test_user(&pool, user.id, "cus_test_soft_decline", 0).await;
 
@@ -1325,7 +1324,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_first_soft_decline_pauses_without_charging(pool: PgPool) {
+    async fn test_process_auto_topups_first_soft_decline_pauses_without_charging(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
         configure_auto_topup_decline_test_user(&pool, user.id, "cus_test_soft_decline", 0).await;
 
@@ -1360,7 +1359,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_second_soft_decline_disables_without_charging(pool: PgPool) {
+    async fn test_process_auto_topups_second_soft_decline_disables_without_charging(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
         configure_auto_topup_decline_test_user(&pool, user.id, "cus_test_soft_decline", 1).await;
 
@@ -1380,7 +1379,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_hard_decline_disables_immediately(pool: PgPool) {
+    async fn test_process_auto_topups_hard_decline_disables_immediately(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
         configure_auto_topup_decline_test_user(&pool, user.id, "cus_test_hard_decline", 0).await;
 
@@ -1400,7 +1399,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_provider_error_pauses_without_advancing_decline_state(pool: PgPool) {
+    async fn test_process_auto_topups_provider_error_pauses_without_advancing_decline_state(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
         configure_auto_topup_decline_test_user(&pool, user.id, "cus_test_provider_error", 1).await;
 
@@ -1429,7 +1428,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_payment_method_lookup_error_pauses_without_advancing_decline_state(pool: PgPool) {
+    async fn test_process_auto_topups_payment_method_lookup_error_pauses_without_advancing_decline_state(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
         configure_auto_topup_decline_test_user(&pool, user.id, "cus_test_payment_method_lookup_error", 0).await;
 
@@ -1448,7 +1447,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_without_payment_method_disables_auto_topup(pool: PgPool) {
+    async fn test_process_auto_topups_without_payment_method_disables_auto_topup(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
         configure_auto_topup_decline_test_user(&pool, user.id, "cus_test_no_payment_method", 0).await;
 
@@ -1474,7 +1473,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_success_resets_soft_decline_state(pool: PgPool) {
+    async fn test_process_auto_topups_success_resets_soft_decline_state(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
         configure_auto_topup_decline_test_user(&pool, user.id, "cus_test_success_after_decline", 1).await;
 
@@ -1589,7 +1588,7 @@ mod tests {
         async fn get_payment_session(&self, _: &str) -> crate::payment_providers::Result<crate::payment_providers::PaymentSession> {
             unimplemented!("not called by process_auto_topups")
         }
-        async fn process_payment_session(&self, _: &PgPool, _: &str, _: &CreditsConfig) -> crate::payment_providers::Result<()> {
+        async fn process_payment_session(&self, _: &sqlx::PgPool, _: &str, _: &CreditsConfig) -> crate::payment_providers::Result<()> {
             unimplemented!("not called by process_auto_topups")
         }
         async fn validate_webhook(
@@ -1601,7 +1600,7 @@ mod tests {
         }
         async fn process_webhook_event(
             &self,
-            _: &PgPool,
+            _: &sqlx::PgPool,
             _: &crate::payment_providers::WebhookEvent,
             _: &CreditsConfig,
         ) -> crate::payment_providers::Result<()> {
@@ -1628,7 +1627,7 @@ mod tests {
         }
         async fn process_auto_topup_session(
             &self,
-            _: &PgPool,
+            _: &sqlx::PgPool,
             _: &str,
         ) -> crate::payment_providers::Result<crate::payment_providers::AutoTopupSetupResult> {
             unimplemented!("not called by process_auto_topups")
@@ -1642,7 +1641,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_skips_when_charge_already_in_flight(pool: PgPool) {
+    async fn test_process_auto_topups_skips_when_charge_already_in_flight(pool: sqlx::PgPool) {
         // A concurrent sweep on another replica already owns this charge. We must
         // skip without crediting the user, rather than treating it as a failure.
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
@@ -1675,7 +1674,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_charges_below_threshold(pool: PgPool) {
+    async fn test_process_auto_topups_charges_below_threshold(pool: sqlx::PgPool) {
         // Create a test user with auto top-up configured
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
 
@@ -1713,7 +1712,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_skips_above_threshold(pool: PgPool) {
+    async fn test_process_auto_topups_skips_above_threshold(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
 
         // Set up auto top-up: threshold $5, amount $25
@@ -1763,7 +1762,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_idempotent(pool: PgPool) {
+    async fn test_process_auto_topups_idempotent(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
 
         sqlx::query!(
@@ -1804,7 +1803,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_respects_monthly_limit(pool: PgPool) {
+    async fn test_process_auto_topups_respects_monthly_limit(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
 
         // Set up auto top-up with a $50 monthly limit
@@ -1872,7 +1871,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_blocks_when_limit_exceeded(pool: PgPool) {
+    async fn test_process_auto_topups_blocks_when_limit_exceeded(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
 
         // Set up auto top-up with a $40 monthly limit
@@ -1944,7 +1943,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_process_auto_topups_skips_when_limit_fully_exhausted(pool: PgPool) {
+    async fn test_process_auto_topups_skips_when_limit_fully_exhausted(pool: sqlx::PgPool) {
         let user = crate::test::utils::create_test_user(&pool, Role::StandardUser).await;
 
         // Set up auto top-up with a $25 monthly limit (exactly what we've already spent)

--- a/dwctl/src/probes/scheduler.rs
+++ b/dwctl/src/probes/scheduler.rs
@@ -6,7 +6,6 @@
 
 use crate::metrics::errors::component::PROBE_SCHEDULER;
 use crate::probes::db::ProbeManager;
-use sqlx::PgPool;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -20,16 +19,17 @@ use uuid::Uuid;
 /// It reads probe state from the database and manages background tasks accordingly.
 #[derive(Clone)]
 pub struct ProbeScheduler {
-    pool: PgPool,
+    /// Live provider (not a pinned pool): survives runtime pool swaps.
+    pool: sqlx_pool_router::DynPools,
     config: crate::config::Config,
     schedulers: Arc<RwLock<HashMap<Uuid, JoinHandle<()>>>>,
 }
 
 impl ProbeScheduler {
     /// Create a new ProbeScheduler instance
-    pub fn new(pool: PgPool, config: crate::config::Config) -> Self {
+    pub fn new(pool: impl sqlx_pool_router::PoolProvider, config: crate::config::Config) -> Self {
         Self {
-            pool,
+            pool: sqlx_pool_router::DynPools::new(pool),
             config,
             schedulers: Arc::new(RwLock::new(HashMap::new())),
         }
@@ -45,7 +45,7 @@ impl ProbeScheduler {
             return Ok(());
         }
 
-        let probes = ProbeManager::list_active_probes(&self.pool).await?;
+        let probes = ProbeManager::list_active_probes(&self.pool.write()).await?;
 
         tracing::info!("Initializing schedulers for {} active probes", probes.len());
 
@@ -77,10 +77,10 @@ impl ProbeScheduler {
         // Spawn the scheduler task
         let handle = tokio::spawn(async move {
             // Check when the probe last executed to avoid immediate execution on restart
-            let _should_delay = match ProbeManager::get_recent_results(&pool, probe_id, 1).await {
+            let _should_delay = match ProbeManager::get_recent_results(&pool.write(), probe_id, 1).await {
                 Ok(results) => {
                     if let Some(last_result) = results.first() {
-                        let probe = match ProbeManager::get_probe(&pool, probe_id).await {
+                        let probe = match ProbeManager::get_probe(&pool.write(), probe_id).await {
                             Ok(p) => p,
                             Err(e) => {
                                 crate::background_error!(
@@ -144,7 +144,7 @@ impl ProbeScheduler {
                 }
 
                 // Get the probe to check if it's still active and get the interval
-                let probe = match ProbeManager::get_probe(&pool, probe_id).await {
+                let probe = match ProbeManager::get_probe(&pool.write(), probe_id).await {
                     Ok(p) => p,
                     Err(e) => {
                         crate::background_error!(PROBE_SCHEDULER, "probe_fetch", Warning, "Error fetching probe {}: {}", probe_id, e);
@@ -159,7 +159,7 @@ impl ProbeScheduler {
                 }
 
                 // Execute the probe
-                match ProbeManager::execute_probe(&pool, probe_id, &config).await {
+                match ProbeManager::execute_probe(&pool.write(), probe_id, &config).await {
                     Ok(result) => {
                         if result.success {
                             tracing::debug!(
@@ -240,7 +240,7 @@ impl ProbeScheduler {
     /// - Start schedulers for newly activated probes
     /// - Stop schedulers for deactivated/deleted probes
     pub async fn sync_with_database(&self, shutdown_token: CancellationToken) -> Result<(), anyhow::Error> {
-        let active_probes = ProbeManager::list_active_probes(&self.pool).await?;
+        let active_probes = ProbeManager::list_active_probes(&self.pool.write()).await?;
         let active_probe_ids: std::collections::HashSet<Uuid> = active_probes.iter().map(|p| p.id).collect();
 
         let schedulers = self.schedulers.read().await;
@@ -355,7 +355,7 @@ impl ProbeScheduler {
             }
 
             // Establish a dedicated connection for LISTEN
-            let mut listener = match sqlx::postgres::PgListener::connect_with(&self.pool).await {
+            let mut listener = match sqlx::postgres::PgListener::connect_with(&self.pool.write()).await {
                 Ok(l) => l,
                 Err(e) => {
                     tracing::error!("Failed to create LISTEN connection: {}", e);
@@ -454,9 +454,8 @@ mod tests {
     use super::*;
     use crate::api::models::probes::CreateProbe;
     use crate::probes::db::ProbeManager;
-    use sqlx::PgPool;
 
-    async fn setup_test_deployment(pool: &PgPool) -> Uuid {
+    async fn setup_test_deployment(pool: &sqlx::PgPool) -> Uuid {
         // Generate unique names using UUID
         let unique_id = Uuid::new_v4();
         let endpoint_name = format!("test-endpoint-{}", unique_id);
@@ -492,7 +491,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_scheduler_initialize(pool: PgPool) {
+    async fn test_scheduler_initialize(pool: sqlx::PgPool) {
         // Create separate deployments for each probe
         let deployment_id1 = setup_test_deployment(&pool).await;
         let deployment_id2 = setup_test_deployment(&pool).await;
@@ -537,7 +536,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_sync_starts_new_schedulers(pool: PgPool) {
+    async fn test_sync_starts_new_schedulers(pool: sqlx::PgPool) {
         let deployment_id = setup_test_deployment(&pool).await;
 
         let config = create_test_config();
@@ -571,7 +570,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_sync_stops_deactivated_schedulers(pool: PgPool) {
+    async fn test_sync_stops_deactivated_schedulers(pool: sqlx::PgPool) {
         let deployment_id = setup_test_deployment(&pool).await;
 
         let probe = ProbeManager::create_probe(
@@ -603,7 +602,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_stop_all_schedulers(pool: PgPool) {
+    async fn test_stop_all_schedulers(pool: sqlx::PgPool) {
         // Create separate deployment for each probe
         for i in 0..3 {
             let deployment_id = setup_test_deployment(&pool).await;
@@ -634,7 +633,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn test_scheduler_ignores_inactive_probes(pool: PgPool) {
+    async fn test_scheduler_ignores_inactive_probes(pool: sqlx::PgPool) {
         let deployment_id = setup_test_deployment(&pool).await;
 
         // Create probe and immediately deactivate

--- a/dwctl/src/prompt_cache/model_config.rs
+++ b/dwctl/src/prompt_cache/model_config.rs
@@ -11,7 +11,6 @@
 use std::time::Duration;
 
 use moka::future::Cache;
-use sqlx::PgPool;
 
 use super::index::CacheResult;
 use super::metrics as cache_metrics;
@@ -36,18 +35,22 @@ impl ModelCacheConfig {
 /// Resolves a virtual model (alias) to its [`ModelCacheConfig`], read-through cached.
 #[derive(Clone)]
 pub struct ModelConfigResolver {
-    pool: PgPool,
+    /// Live provider (not a pinned pool): survives runtime pool swaps.
+    pool: sqlx_pool_router::DynPools,
     cache: Cache<String, ModelCacheConfig>,
 }
 
 impl ModelConfigResolver {
-    pub fn new(pool: PgPool) -> Self {
+    pub fn new(pool: impl sqlx_pool_router::PoolProvider) -> Self {
         let cache = Cache::builder()
             .max_capacity(10_000)
             // Short — config is mutable (an operator can expire / insert a tariff version).
             .time_to_live(Duration::from_secs(60))
             .build();
-        Self { pool, cache }
+        Self {
+            pool: sqlx_pool_router::DynPools::new(pool),
+            cache,
+        }
     }
 
     /// Resolve the cache config for `virtual_model` (the `deployed_models.alias`).
@@ -96,7 +99,7 @@ mod tests {
     use crate::test::utils::{create_test_endpoint, create_test_model, create_test_user};
 
     /// Insert a one-row cache tariff (all tiers present) for a model, optionally expired.
-    async fn add_tariff(pool: &PgPool, model_id: uuid::Uuid, min_prefix: i32, expired: bool) {
+    async fn add_tariff(pool: &sqlx::PgPool, model_id: uuid::Uuid, min_prefix: i32, expired: bool) {
         sqlx::query!(
             r#"INSERT INTO model_cache_tariffs
                  (deployed_model_id, write_multiplier_5m, write_multiplier_1h, write_multiplier_24h, min_prefix_tokens, valid_until)
@@ -111,7 +114,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn disabled_without_tariff_and_unknown_model(pool: PgPool) {
+    async fn disabled_without_tariff_and_unknown_model(pool: sqlx::PgPool) {
         let user = create_test_user(&pool, crate::api::models::users::Role::StandardUser).await;
         let endpoint = create_test_endpoint(&pool, "ep", user.id).await;
         let _ = create_test_model(&pool, "m1", "alias-default", endpoint, user.id).await;
@@ -124,7 +127,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn active_tariff_enables_with_its_floor(pool: PgPool) {
+    async fn active_tariff_enables_with_its_floor(pool: sqlx::PgPool) {
         let user = create_test_user(&pool, crate::api::models::users::Role::StandardUser).await;
         let endpoint = create_test_endpoint(&pool, "ep", user.id).await;
         let id = create_test_model(&pool, "m2", "alias-on", endpoint, user.id).await;
@@ -136,7 +139,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn expired_tariff_is_disabled(pool: PgPool) {
+    async fn expired_tariff_is_disabled(pool: sqlx::PgPool) {
         let user = create_test_user(&pool, crate::api::models::users::Role::StandardUser).await;
         let endpoint = create_test_endpoint(&pool, "ep", user.id).await;
         let id = create_test_model(&pool, "m3", "alias-expired", endpoint, user.id).await;

--- a/dwctl/src/prompt_cache/postgres.rs
+++ b/dwctl/src/prompt_cache/postgres.rs
@@ -19,7 +19,6 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rand::RngExt;
-use sqlx::PgPool;
 use tracing::instrument;
 
 use super::index::{CacheEntry, CacheError, CacheIndex, CacheMatch, CacheResult, IndexScope, PrefixHash, TtlTier};
@@ -28,14 +27,18 @@ use super::metrics as cache_metrics;
 /// Postgres-backed prefix index over `prompt_cache_entries`.
 #[derive(Clone)]
 pub struct PostgresIndex {
-    pool: PgPool,
+    /// Live provider (not a pinned pool): survives runtime pool swaps.
+    pool: sqlx_pool_router::DynPools,
     /// Connection-error retries per op (`cache.index_conn_retries`; 0 = never retry).
     conn_retries: u32,
 }
 
 impl PostgresIndex {
-    pub fn new(pool: PgPool, conn_retries: u32) -> Self {
-        Self { pool, conn_retries }
+    pub fn new(pool: impl sqlx_pool_router::PoolProvider, conn_retries: u32) -> Self {
+        Self {
+            pool: sqlx_pool_router::DynPools::new(pool),
+            conn_retries,
+        }
     }
 }
 
@@ -197,7 +200,6 @@ impl CacheIndex for PostgresIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sqlx::PgPool;
 
     fn scope() -> IndexScope {
         IndexScope {
@@ -218,7 +220,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn write_then_lookup_returns_match(pool: PgPool) {
+    async fn write_then_lookup_returns_match(pool: sqlx::PgPool) {
         let idx = PostgresIndex::new(pool, 1);
         let s = scope();
         idx.write(&entry(&s, b"hash-a", 1024, TtlTier::OneHour)).await.unwrap();
@@ -231,7 +233,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn lookup_excludes_expired_and_other_scopes(pool: PgPool) {
+    async fn lookup_excludes_expired_and_other_scopes(pool: sqlx::PgPool) {
         let idx = PostgresIndex::new(pool, 1);
         let s = scope();
 
@@ -251,7 +253,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn refresh_slides_expiry(pool: PgPool) {
+    async fn refresh_slides_expiry(pool: sqlx::PgPool) {
         let idx = PostgresIndex::new(pool, 1);
         let s = scope();
         let mut e = entry(&s, b"refreshable", 7, TtlTier::FiveMinutes);
@@ -268,7 +270,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn write_upserts_on_conflict(pool: PgPool) {
+    async fn write_upserts_on_conflict(pool: sqlx::PgPool) {
         let idx = PostgresIndex::new(pool, 1);
         let s = scope();
         idx.write(&entry(&s, b"dup", 100, TtlTier::FiveMinutes)).await.unwrap();

--- a/dwctl/src/prompt_cache/principal.rs
+++ b/dwctl/src/prompt_cache/principal.rs
@@ -16,7 +16,6 @@
 use std::time::Duration;
 
 use moka::future::Cache;
-use sqlx::PgPool;
 
 use crate::db::handlers::api_keys::ApiKeys;
 use crate::types::UserId;
@@ -28,25 +27,29 @@ use super::metrics as cache_metrics;
 /// over a DB read-through.
 #[derive(Clone)]
 pub struct PrincipalResolver {
-    pool: PgPool,
+    /// Live provider (not a pinned pool): survives runtime pool swaps.
+    pool: sqlx_pool_router::DynPools,
     l1: Cache<String, Option<UserId>>,
 }
 
 impl PrincipalResolver {
-    pub fn new(pool: PgPool) -> Self {
+    pub fn new(pool: impl sqlx_pool_router::PoolProvider) -> Self {
         // 100k entries ≈ a few MB (String key + Option<Uuid>) — comfortably covers the
         // active-key working set of a busy tenant; cold keys evict + take one DB miss on
         // next use (cheap, indexed point lookup). Bump via `with_capacity` if churn warrants.
         Self::with_capacity(pool, 100_000)
     }
 
-    pub fn with_capacity(pool: PgPool, max_entries: u64) -> Self {
+    pub fn with_capacity(pool: impl sqlx_pool_router::PoolProvider, max_entries: u64) -> Self {
         let l1 = Cache::builder()
             .max_capacity(max_entries)
             // Hygiene only — the mapping is immutable, so correctness doesn't need it.
             .time_to_live(Duration::from_secs(3600))
             .build();
-        Self { pool, l1 }
+        Self {
+            pool: sqlx_pool_router::DynPools::new(pool),
+            l1,
+        }
     }
 
     /// Resolve a validated bearer token to its billing principal. `None` => the token
@@ -66,7 +69,7 @@ impl PrincipalResolver {
             cache_metrics::record_principal_resolve(if cached.is_some() { "hit" } else { "unknown_key" });
             return Ok(cached);
         }
-        let mut conn = self.pool.acquire().await?;
+        let mut conn = self.pool.write().acquire().await?;
         let user_id = ApiKeys::new(&mut conn).get_user_id_by_secret(token).await?;
         cache_metrics::record_principal_resolve(if user_id.is_some() { "miss" } else { "unknown_key" });
         self.l1.insert(token.to_string(), user_id).await;
@@ -81,7 +84,7 @@ mod tests {
     use crate::test::utils::{create_test_api_key_for_user, create_test_user};
 
     #[sqlx::test]
-    async fn resolves_validated_key_to_user(pool: PgPool) {
+    async fn resolves_validated_key_to_user(pool: sqlx::PgPool) {
         let user = create_test_user(&pool, Role::StandardUser).await;
         let key = create_test_api_key_for_user(&pool, user.id).await;
 
@@ -92,7 +95,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn unknown_token_resolves_none(pool: PgPool) {
+    async fn unknown_token_resolves_none(pool: sqlx::PgPool) {
         let resolver = PrincipalResolver::new(pool);
         assert_eq!(resolver.resolve("not-a-real-secret").await.unwrap(), None);
     }

--- a/dwctl/src/replica_governor.rs
+++ b/dwctl/src/replica_governor.rs
@@ -200,7 +200,9 @@ impl GovernedPool {
     }
 
     fn current_replica_max(&self) -> Option<u32> {
-        self.target.has_replica().then(|| self.target.read().options().get_max_connections())
+        self.target
+            .has_replica()
+            .then(|| self.target.read().options().get_max_connections())
     }
 }
 
@@ -305,7 +307,11 @@ mod tests {
     fn effective_max_prefers_total_over_per_pod() {
         assert_eq!(effective_max(&settings(Some(800), 400), 2), 400);
         assert_eq!(effective_max(&settings(Some(800), 400), 4), 200);
-        assert_eq!(effective_max(&settings(None, 400), 4), 400, "no total: per-pod value, replica count irrelevant");
+        assert_eq!(
+            effective_max(&settings(None, 400), 4),
+            400,
+            "no total: per-pod value, replica count irrelevant"
+        );
     }
 
     #[test]
@@ -336,7 +342,11 @@ mod tests {
         assert_eq!(register_and_count(&pool, a, "api", liveness).await.unwrap(), 1);
         // Deregistration removes the row.
         deregister(&pool, a).await.unwrap();
-        assert_eq!(register_and_count(&pool, c, "api", liveness).await.unwrap(), 1, "only c remains in api");
+        assert_eq!(
+            register_and_count(&pool, c, "api", liveness).await.unwrap(),
+            1,
+            "only c remains in api"
+        );
     }
 
     #[sqlx::test]
@@ -349,12 +359,33 @@ mod tests {
         let shutdown_b = CancellationToken::new();
         let (tx_a, mut rx_a) = watch::channel(1u32);
         let (tx_b, mut rx_b) = watch::channel(1u32);
-        let handle_a = tokio::spawn(run_membership(pool.clone(), Uuid::new_v4(), "api".into(), tx_a, cfg.clone(), shutdown_a.clone()));
-        let _handle_b = tokio::spawn(run_membership(pool.clone(), Uuid::new_v4(), "api".into(), tx_b, cfg.clone(), shutdown_b.clone()));
+        let handle_a = tokio::spawn(run_membership(
+            pool.clone(),
+            Uuid::new_v4(),
+            "api".into(),
+            tx_a,
+            cfg.clone(),
+            shutdown_a.clone(),
+        ));
+        let _handle_b = tokio::spawn(run_membership(
+            pool.clone(),
+            Uuid::new_v4(),
+            "api".into(),
+            tx_b,
+            cfg.clone(),
+            shutdown_b.clone(),
+        ));
         // A member of another group must not be counted.
         let (tx_c, _rx_c) = watch::channel(1u32);
         let shutdown_c = CancellationToken::new();
-        let _handle_c = tokio::spawn(run_membership(pool.clone(), Uuid::new_v4(), "batch".into(), tx_c, cfg.clone(), shutdown_c.clone()));
+        let _handle_c = tokio::spawn(run_membership(
+            pool.clone(),
+            Uuid::new_v4(),
+            "batch".into(),
+            tx_c,
+            cfg.clone(),
+            shutdown_c.clone(),
+        ));
 
         tokio::time::timeout(Duration::from_secs(5), async {
             while !(*rx_a.borrow() == 2 && *rx_b.borrow() == 2) {

--- a/dwctl/src/replica_governor.rs
+++ b/dwctl/src/replica_governor.rs
@@ -1,0 +1,431 @@
+//! Replica-group membership over Postgres, and the connection-budget governor
+//! that divides `total_max_connections` across the live members.
+//!
+//! # Why
+//!
+//! With a fixed `max_connections` per pod, the replica count was effectively a
+//! config constant: the database's connection limit, not CPU or memory, capped
+//! how far a Deployment could be scaled. `PoolSettings::total_max_connections`
+//! states the budget for a whole replica group instead. Every pod discovers how
+//! many peers are alive through the `replica_registry` table and sizes its
+//! pools at `total / live_replicas`, re-dividing at runtime as replicas come
+//! and go — so an autoscaler can move the replica count freely and the
+//! aggregate never exceeds the budget.
+//!
+//! # How
+//!
+//! Postgres is the consensus substrate, exactly like the advisory-lock leader
+//! election: a registry row is alive iff its heartbeat falls inside
+//! [`LIVENESS_WINDOW`], so all members of a group converge on the same count
+//! within one [`HEARTBEAT_INTERVAL`]. sqlx pools cannot be resized in place,
+//! so applying a new share means build-new / [`DbPools::replace`] / drain-old;
+//! every component holds a live provider (`DbPools` / `DynPools`) rather than a
+//! pinned `PgPool`, so the swap reaches them on their next query.
+//!
+//! Fully dormant unless some pool declares a total
+//! (`DatabaseConfig::connection_budget_enabled`): no registry rows, no
+//! heartbeats, pools sized from `max_connections` as before.
+
+use std::time::Duration;
+
+use sqlx::PgPool;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+use sqlx_pool_router::{DbPools, PoolProvider};
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::config::PoolSettings;
+
+/// How often a member refreshes its registry row and re-counts the group.
+pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+/// A member whose heartbeat is older than this is dead (3 missed beats).
+pub const LIVENESS_WINDOW: Duration = Duration::from_secs(30);
+/// How long a new count must hold before pools are rebuilt. A rolling update
+/// surges a pod up and back down within about a minute; re-dividing on every
+/// blip would churn pools for nothing.
+pub const RESIZE_SETTLE: Duration = Duration::from_secs(20);
+/// Rows silent for this long are swept (crashed pods never deregister).
+const REGISTRY_GC_AFTER: Duration = Duration::from_secs(600);
+
+/// Equal division of `total` across `live_replicas`, floor 1.
+pub fn share(total: u32, live_replicas: u32) -> u32 {
+    (total / live_replicas.max(1)).max(1)
+}
+
+/// The pool size this pod should run: its share of the total when one is
+/// declared, otherwise the plain per-pod `max_connections`.
+pub fn effective_max(settings: &PoolSettings, live_replicas: u32) -> u32 {
+    match settings.total_max_connections {
+        Some(total) => share(total, live_replicas),
+        None => settings.max_connections,
+    }
+}
+
+/// `PgPoolOptions` for `settings` at an explicit `max_connections` (the one
+/// place the timeout/lifetime knobs are translated). `min_connections` is
+/// clamped to the max so a small share cannot ask for more warm connections
+/// than it may hold.
+pub fn pool_options(settings: &PoolSettings, max_connections: u32) -> PgPoolOptions {
+    PgPoolOptions::new()
+        .max_connections(max_connections)
+        .min_connections(settings.min_connections.min(max_connections))
+        .acquire_timeout(Duration::from_secs(settings.acquire_timeout_secs))
+        .idle_timeout((settings.idle_timeout_secs > 0).then(|| Duration::from_secs(settings.idle_timeout_secs)))
+        .max_lifetime((settings.max_lifetime_secs > 0).then(|| Duration::from_secs(settings.max_lifetime_secs)))
+}
+
+/// Upsert this instance's registry row and return the number of live members
+/// of `group`, including itself (never below 1).
+pub async fn register_and_count(pool: &PgPool, instance_id: Uuid, group: &str, liveness: Duration) -> Result<u32, sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO replica_registry (instance_id, replica_group)
+         VALUES ($1, $2)
+         ON CONFLICT (instance_id) DO UPDATE SET last_heartbeat = now()",
+    )
+    .bind(instance_id)
+    .bind(group)
+    .execute(pool)
+    .await?;
+    let live: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM replica_registry
+         WHERE replica_group = $1
+           AND last_heartbeat > now() - make_interval(secs => $2)",
+    )
+    .bind(group)
+    .bind(liveness.as_secs_f64())
+    .fetch_one(pool)
+    .await?;
+    Ok(u32::try_from(live).unwrap_or(u32::MAX).max(1))
+}
+
+/// Remove this instance's registry row (graceful shutdown), so peers re-divide
+/// on their next heartbeat instead of waiting out the liveness window.
+pub async fn deregister(pool: &PgPool, instance_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM replica_registry WHERE instance_id = $1")
+        .bind(instance_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Timing knobs for [`run_membership`]; production uses the defaults, tests
+/// shrink them so convergence is observable in milliseconds.
+#[derive(Debug, Clone)]
+pub struct MembershipConfig {
+    pub heartbeat_interval: Duration,
+    pub liveness_window: Duration,
+}
+
+impl Default for MembershipConfig {
+    fn default() -> Self {
+        Self {
+            heartbeat_interval: HEARTBEAT_INTERVAL,
+            liveness_window: LIVENESS_WINDOW,
+        }
+    }
+}
+
+/// Heartbeat loop: keeps this instance's row fresh, publishes the live member
+/// count of `group` on `count_tx` whenever it changes, and deregisters on
+/// shutdown. Runs until `shutdown` fires.
+pub async fn run_membership(
+    pools: impl PoolProvider,
+    instance_id: Uuid,
+    group: String,
+    count_tx: watch::Sender<u32>,
+    cfg: MembershipConfig,
+    shutdown: CancellationToken,
+) {
+    let mut interval = tokio::time::interval(cfg.heartbeat_interval);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                if let Err(e) = deregister(&pools.write(), instance_id).await {
+                    warn!(error = %e, "replica_registry deregistration failed; peers will time the row out");
+                }
+                break;
+            }
+            _ = interval.tick() => {}
+        }
+        let pool = pools.write();
+        match register_and_count(&pool, instance_id, &group, cfg.liveness_window).await {
+            Ok(n) => {
+                metrics::gauge!("dwctl_replica_group_size", "group" => group.clone()).set(n as f64);
+                count_tx.send_if_modified(|current| {
+                    if *current != n {
+                        debug!(group, from = *current, to = n, "replica group size changed");
+                        *current = n;
+                        true
+                    } else {
+                        false
+                    }
+                });
+            }
+            // Keep the last known count on error: shrinking pools because the
+            // database blipped would amplify the blip.
+            Err(e) => warn!(error = %e, "replica_registry heartbeat failed; keeping last known count"),
+        }
+        if let Err(e) = sqlx::query("DELETE FROM replica_registry WHERE last_heartbeat < now() - make_interval(secs => $1)")
+            .bind(REGISTRY_GC_AFTER.as_secs_f64())
+            .execute(&pool)
+            .await
+        {
+            debug!(error = %e, "replica_registry sweep failed");
+        }
+    }
+}
+
+/// Identity this pod joined the group with at boot, and the count it saw.
+#[derive(Debug, Clone)]
+pub struct GovernanceSeed {
+    pub instance_id: Uuid,
+    pub group: String,
+    pub initial_live: u32,
+}
+
+/// One `DbPools` the governor resizes, with everything needed to rebuild it.
+pub struct GovernedPool {
+    pub name: &'static str,
+    pub primary: (PoolSettings, PgConnectOptions),
+    pub replica: Option<(PoolSettings, PgConnectOptions)>,
+    pub target: DbPools,
+}
+
+impl GovernedPool {
+    fn current_primary_max(&self) -> u32 {
+        self.target.write().options().get_max_connections()
+    }
+
+    fn current_replica_max(&self) -> Option<u32> {
+        self.target.has_replica().then(|| self.target.read().options().get_max_connections())
+    }
+}
+
+/// Everything `setup_database` hands to the background services to keep the
+/// budget honoured after boot.
+pub struct PoolGovernance {
+    pub seed: GovernanceSeed,
+    pub pools: Vec<GovernedPool>,
+}
+
+fn record_share(name: &'static str, max: u32) {
+    metrics::gauge!("dwctl_db_pool_share", "pool" => name).set(max as f64);
+}
+
+/// Rebuild `gp` at the share for `live` replicas if that differs from what it
+/// runs now. The old pools are drained in the background: `close()` shuts idle
+/// connections immediately and checked-out ones as they are returned, so
+/// in-flight work completes untouched.
+fn apply_share(gp: &GovernedPool, live: u32) {
+    let new_primary_max = effective_max(&gp.primary.0, live);
+    let new_replica_max = gp.replica.as_ref().map(|(settings, _)| effective_max(settings, live));
+    let current_primary = gp.current_primary_max();
+    if new_primary_max == current_primary && new_replica_max == gp.current_replica_max() {
+        return;
+    }
+    let new_primary = pool_options(&gp.primary.0, new_primary_max).connect_lazy_with(gp.primary.1.clone());
+    let new_replica = gp
+        .replica
+        .as_ref()
+        .zip(new_replica_max)
+        .map(|((settings, opts), max)| pool_options(settings, max).connect_lazy_with(opts.clone()));
+    let (old_primary, old_replica) = gp.target.replace(new_primary, new_replica);
+    record_share(gp.name, new_primary_max);
+    info!(
+        pool = gp.name,
+        from = current_primary,
+        to = new_primary_max,
+        replicas = live,
+        "re-divided connection budget"
+    );
+    tokio::spawn(async move {
+        old_primary.close().await;
+        if let Some(replica) = old_replica {
+            replica.close().await;
+        }
+    });
+}
+
+/// Resize loop: whenever the live count published by [`run_membership`]
+/// changes and then holds for `settle`, rebuild every governed pool at its new
+/// share. Runs until `shutdown` fires or the count sender is dropped.
+pub async fn run_governor(pools: Vec<GovernedPool>, mut count_rx: watch::Receiver<u32>, settle: Duration, shutdown: CancellationToken) {
+    for gp in &pools {
+        record_share(gp.name, gp.current_primary_max());
+    }
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            changed = count_rx.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+            }
+        }
+        let live = *count_rx.borrow_and_update();
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            _ = tokio::time::sleep(settle) => {}
+        }
+        if *count_rx.borrow() != live {
+            // Moved again during the settle window; `changed()` fires next loop.
+            continue;
+        }
+        for gp in &pools {
+            apply_share(gp, live);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings(total: Option<u32>, max: u32) -> PoolSettings {
+        PoolSettings {
+            max_connections: max,
+            total_max_connections: total,
+            min_connections: 0,
+            ..PoolSettings::default()
+        }
+    }
+
+    #[test]
+    fn share_divides_equally_with_floor_one() {
+        assert_eq!(share(800, 2), 400);
+        assert_eq!(share(1000, 3), 333);
+        assert_eq!(share(10, 0), 10, "zero live replicas is treated as one");
+        assert_eq!(share(1, 4), 1, "never below one connection");
+    }
+
+    #[test]
+    fn effective_max_prefers_total_over_per_pod() {
+        assert_eq!(effective_max(&settings(Some(800), 400), 2), 400);
+        assert_eq!(effective_max(&settings(Some(800), 400), 4), 200);
+        assert_eq!(effective_max(&settings(None, 400), 4), 400, "no total: per-pod value, replica count irrelevant");
+    }
+
+    #[test]
+    fn pool_options_clamps_min_to_max() {
+        let mut s = settings(Some(100), 100);
+        s.min_connections = 50;
+        let opts = pool_options(&s, 10);
+        assert_eq!(opts.get_max_connections(), 10);
+        assert_eq!(opts.get_min_connections(), 10);
+    }
+
+    #[sqlx::test]
+    async fn register_and_count_sees_only_live_members_of_the_group(pool: PgPool) {
+        let liveness = Duration::from_secs(30);
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        assert_eq!(register_and_count(&pool, a, "api", liveness).await.unwrap(), 1);
+        assert_eq!(register_and_count(&pool, b, "api", liveness).await.unwrap(), 2);
+        // Other groups do not count.
+        let c = Uuid::new_v4();
+        assert_eq!(register_and_count(&pool, c, "fusillade-batch", liveness).await.unwrap(), 1);
+        // A stale heartbeat drops out of the count.
+        sqlx::query("UPDATE replica_registry SET last_heartbeat = now() - interval '1 hour' WHERE instance_id = $1")
+            .bind(b)
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert_eq!(register_and_count(&pool, a, "api", liveness).await.unwrap(), 1);
+        // Deregistration removes the row.
+        deregister(&pool, a).await.unwrap();
+        assert_eq!(register_and_count(&pool, c, "api", liveness).await.unwrap(), 1, "only c remains in api");
+    }
+
+    #[sqlx::test]
+    async fn two_members_converge_on_count_two_and_shrink_on_deregister(pool: PgPool) {
+        let cfg = MembershipConfig {
+            heartbeat_interval: Duration::from_millis(50),
+            liveness_window: Duration::from_secs(5),
+        };
+        let shutdown_a = CancellationToken::new();
+        let shutdown_b = CancellationToken::new();
+        let (tx_a, mut rx_a) = watch::channel(1u32);
+        let (tx_b, mut rx_b) = watch::channel(1u32);
+        let handle_a = tokio::spawn(run_membership(pool.clone(), Uuid::new_v4(), "api".into(), tx_a, cfg.clone(), shutdown_a.clone()));
+        let _handle_b = tokio::spawn(run_membership(pool.clone(), Uuid::new_v4(), "api".into(), tx_b, cfg.clone(), shutdown_b.clone()));
+        // A member of another group must not be counted.
+        let (tx_c, _rx_c) = watch::channel(1u32);
+        let shutdown_c = CancellationToken::new();
+        let _handle_c = tokio::spawn(run_membership(pool.clone(), Uuid::new_v4(), "batch".into(), tx_c, cfg.clone(), shutdown_c.clone()));
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !(*rx_a.borrow() == 2 && *rx_b.borrow() == 2) {
+                tokio::select! {
+                    r = rx_a.changed() => r.unwrap(),
+                    r = rx_b.changed() => r.unwrap(),
+                }
+            }
+        })
+        .await
+        .expect("both api members should observe count=2");
+
+        // Graceful shutdown of A deregisters it, so B sees 1 well before the
+        // liveness window would have expired.
+        shutdown_a.cancel();
+        handle_a.await.unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while *rx_b.borrow() != 1 {
+                rx_b.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("remaining member should observe count=1 after deregistration");
+        shutdown_b.cancel();
+        shutdown_c.cancel();
+    }
+
+    #[sqlx::test]
+    async fn governor_rebuilds_pools_at_the_new_share(pool: PgPool) {
+        let opts = pool.connect_options().as_ref().clone();
+        let s = settings(Some(10), 10);
+        let target = DbPools::new(pool_options(&s, 10).connect_lazy_with(opts.clone()));
+        let held = target.clone();
+        let governed = vec![GovernedPool {
+            name: "test",
+            primary: (s.clone(), opts),
+            replica: None,
+            target: target.clone(),
+        }];
+        let (count_tx, count_rx) = watch::channel(1u32);
+        let shutdown = CancellationToken::new();
+        let handle = tokio::spawn(run_governor(governed, count_rx, Duration::from_millis(20), shutdown.clone()));
+
+        let max_of = |p: &DbPools| p.write().options().get_max_connections();
+        async fn wait_for(p: &DbPools, want: u32) {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while p.write().options().get_max_connections() != want {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .unwrap_or_else(|_| panic!("pool never reached max {want}"));
+        }
+
+        count_tx.send(2).unwrap();
+        wait_for(&held, 5).await;
+        assert_eq!(max_of(&held), 5, "clone held elsewhere sees the swap");
+        // The swapped-in pool is usable.
+        let one: (i32,) = sqlx::query_as("SELECT 1").fetch_one(held.write()).await.unwrap();
+        assert_eq!(one.0, 1);
+
+        // A blip that reverts inside the settle window changes nothing.
+        count_tx.send(4).unwrap();
+        count_tx.send(2).unwrap();
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert_eq!(max_of(&held), 5);
+
+        count_tx.send(1).unwrap();
+        wait_for(&held, 10).await;
+
+        shutdown.cancel();
+        handle.await.unwrap();
+    }
+}

--- a/dwctl/src/replica_governor.rs
+++ b/dwctl/src/replica_governor.rs
@@ -50,8 +50,20 @@ pub const RESIZE_SETTLE: Duration = Duration::from_secs(20);
 const REGISTRY_GC_AFTER: Duration = Duration::from_secs(600);
 
 /// Equal division of `total` across `live_replicas`, floor 1.
+///
+/// The floor keeps a pod runnable, but it is the one place the budget can be
+/// exceeded: `live_replicas` pods with `total < live_replicas` hold
+/// `live_replicas` connections. [`share_is_floored`] flags that case so the
+/// governor can log and export it; the autoscaler's `maxReplicas` must stay
+/// at or below every governed pool's total.
 pub fn share(total: u32, live_replicas: u32) -> u32 {
     (total / live_replicas.max(1)).max(1)
+}
+
+/// True when [`share`] had to fall back to its floor, i.e. the group has more
+/// live replicas than `total` connections and the aggregate is over budget.
+pub fn share_is_floored(total: u32, live_replicas: u32) -> bool {
+    live_replicas.max(1) > total
 }
 
 /// The pool size this pod should run: its share of the total when one is
@@ -217,6 +229,28 @@ fn record_share(name: &'static str, max: u32) {
     metrics::gauge!("dwctl_db_pool_share", "pool" => name).set(max as f64);
 }
 
+/// Export (and log) whether `gp`'s share is pinned at the floor for `live`
+/// replicas: the only condition under which the group exceeds its budget.
+fn record_floor(gp: &GovernedPool, live: u32) {
+    let mut floored = false;
+    if let Some(total) = gp.primary.0.total_max_connections {
+        floored |= share_is_floored(total, live);
+    }
+    if let Some((settings, _)) = &gp.replica
+        && let Some(total) = settings.total_max_connections
+    {
+        floored |= share_is_floored(total, live);
+    }
+    metrics::gauge!("dwctl_db_pool_share_floored", "pool" => gp.name).set(if floored { 1.0 } else { 0.0 });
+    if floored {
+        warn!(
+            pool = gp.name,
+            replicas = live,
+            "more live replicas than total_max_connections: every pod holds 1 connection and the group is OVER BUDGET; lower the autoscaler's maxReplicas or raise the total"
+        );
+    }
+}
+
 /// Rebuild `gp` at the share for `live` replicas if that differs from what it
 /// runs now. The old pools are drained in the background: `close()` shuts idle
 /// connections immediately and checked-out ones as they are returned, so
@@ -236,6 +270,7 @@ fn apply_share(gp: &GovernedPool, live: u32) {
         .map(|((settings, opts), max)| pool_options(settings, max).connect_lazy_with(opts.clone()));
     let (old_primary, old_replica) = gp.target.replace(new_primary, new_replica);
     record_share(gp.name, new_primary_max);
+    record_floor(gp, live);
     info!(
         pool = gp.name,
         from = current_primary,
@@ -257,6 +292,7 @@ fn apply_share(gp: &GovernedPool, live: u32) {
 pub async fn run_governor(pools: Vec<GovernedPool>, mut count_rx: watch::Receiver<u32>, settle: Duration, shutdown: CancellationToken) {
     for gp in &pools {
         record_share(gp.name, gp.current_primary_max());
+        record_floor(gp, *count_rx.borrow());
     }
     loop {
         tokio::select! {
@@ -301,6 +337,14 @@ mod tests {
         assert_eq!(share(1000, 3), 333);
         assert_eq!(share(10, 0), 10, "zero live replicas is treated as one");
         assert_eq!(share(1, 4), 1, "never below one connection");
+    }
+
+    #[test]
+    fn share_is_floored_only_when_replicas_exceed_total() {
+        assert!(!share_is_floored(800, 4));
+        assert!(!share_is_floored(4, 4), "exactly one connection each is still within budget");
+        assert!(share_is_floored(3, 4));
+        assert!(!share_is_floored(1, 0), "zero live replicas counts as one");
     }
 
     #[test]

--- a/dwctl/src/request_logging/batcher.rs
+++ b/dwctl/src/request_logging/batcher.rs
@@ -46,7 +46,6 @@ use chrono::{DateTime, Utc};
 use metrics::{counter, histogram};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
-use sqlx::PgPool;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::{Notify, mpsc};
@@ -218,7 +217,8 @@ pub struct AnalyticsBatcher<M = crate::metrics::GenAiMetrics>
 where
     M: MetricsRecorder + Clone + Send + Sync + 'static,
 {
-    pool: PgPool,
+    /// Live provider (not a pinned pool): survives runtime pool swaps.
+    pool: sqlx_pool_router::DynPools,
     metrics_recorder: Option<M>,
     receiver: mpsc::Receiver<RawAnalyticsRecord>,
     batch_size: usize,
@@ -246,7 +246,8 @@ where
     ///
     /// A tuple of (batcher, sender) where the sender is used by AnalyticsHandler
     /// to submit records.
-    pub fn new(pool: PgPool, config: Config, metrics_recorder: Option<M>) -> (Self, AnalyticsSender) {
+    pub fn new(pool: impl sqlx_pool_router::PoolProvider, config: Config, metrics_recorder: Option<M>) -> (Self, AnalyticsSender) {
+        let pool = sqlx_pool_router::DynPools::new(pool);
         let (sender, receiver) = mpsc::channel(CHANNEL_BUFFER_SIZE);
 
         let batch_size = config.analytics.batch_size;
@@ -747,7 +748,7 @@ where
     #[tracing::instrument(skip_all)]
     async fn batch_lookup_cache_tariffs(&self, aliases: &[&str]) -> Result<HashMap<String, Vec<CacheTariffRow>>, sqlx::Error> {
         let aliases_vec: Vec<String> = aliases.iter().map(|s| s.to_string()).collect();
-        let map = crate::pricing::lookup_cache_tariffs(&self.pool, &aliases_vec).await?;
+        let map = crate::pricing::lookup_cache_tariffs(&self.pool.write(), &aliases_vec).await?;
         trace!(count = map.len(), "Batch lookup cache tariffs completed");
         Ok(map)
     }
@@ -755,7 +756,7 @@ where
     /// Write enriched records to the database in a single transaction.
     #[tracing::instrument(skip_all)]
     async fn write_batch_transactional(&self, records: &[EnrichedRecord]) -> Result<(), sqlx::Error> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.pool.write().begin().await?;
 
         // Phase 1: Batch INSERT http_analytics
         let (analytics_ids, newly_inserted) = self.batch_insert_analytics(&mut tx, records).await?;
@@ -1883,10 +1884,9 @@ mod integration_tests {
     use crate::db::models::credits::CreditTransactionType;
     use crate::test::utils::create_test_user;
     use rust_decimal::prelude::FromStr;
-    use sqlx::PgPool;
 
     /// Helper: Create a test model with endpoint
-    async fn create_test_model(pool: &PgPool, model_name: &str) -> crate::types::DeploymentId {
+    async fn create_test_model(pool: &sqlx::PgPool, model_name: &str) -> crate::types::DeploymentId {
         use crate::db::handlers::{Deployments, InferenceEndpoints};
         use crate::db::models::{deployments::DeploymentCreateDBRequest, inference_endpoints::InferenceEndpointCreateDBRequest};
         use std::str::FromStr as _;
@@ -1959,7 +1959,7 @@ mod integration_tests {
     /// Helper: Setup a tariff for a model
     /// Note: Batch tariffs require a completion_window per database constraint
     async fn setup_tariff(
-        pool: &PgPool,
+        pool: &sqlx::PgPool,
         deployed_model_id: crate::types::DeploymentId,
         input_price: Decimal,
         output_price: Decimal,
@@ -1993,7 +1993,7 @@ mod integration_tests {
     }
 
     /// Helper: Create a user with initial balance
-    async fn setup_user_with_balance(pool: &PgPool, balance: Decimal) -> Uuid {
+    async fn setup_user_with_balance(pool: &sqlx::PgPool, balance: Decimal) -> Uuid {
         use crate::db::handlers::credits::Credits;
         use crate::db::models::credits::{CreditTransactionCreateDBRequest, CreditTransactionType};
 
@@ -2020,7 +2020,7 @@ mod integration_tests {
     }
 
     /// Helper: Create an API key for a user
-    async fn create_api_key_for_user(pool: &PgPool, user_id: Uuid, purpose: ApiKeyPurpose) -> String {
+    async fn create_api_key_for_user(pool: &sqlx::PgPool, user_id: Uuid, purpose: ApiKeyPurpose) -> String {
         use crate::db::handlers::api_keys::ApiKeys;
         use crate::db::models::api_keys::ApiKeyCreateDBRequest;
 
@@ -2085,7 +2085,7 @@ mod integration_tests {
     }
 
     /// Run the batcher with given records and wait for completion
-    async fn run_batcher_with_records(pool: &PgPool, records: Vec<RawAnalyticsRecord>) {
+    async fn run_batcher_with_records(pool: &sqlx::PgPool, records: Vec<RawAnalyticsRecord>) {
         let config = crate::test::utils::create_test_config();
         let (batcher, sender) = AnalyticsBatcher::<crate::metrics::GenAiMetrics>::new(pool.clone(), config, None);
 
@@ -2104,7 +2104,7 @@ mod integration_tests {
 
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_credit_deduction_successful(pool: PgPool) {
+    async fn test_batcher_credit_deduction_successful(pool: sqlx::PgPool) {
         // Setup: Create model with tariff
         let model_id = create_test_model(&pool, "gpt-4-test").await;
         let input_price = Decimal::from_str("0.00001").unwrap();
@@ -2144,7 +2144,7 @@ mod integration_tests {
 
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_cache_discount_applied(pool: PgPool) {
+    async fn test_batcher_cache_discount_applied(pool: sqlx::PgPool) {
         // Model with a base tariff + a cache tariff (presence = enabled): 1h write ×2.0,
         // read ×0.1. The other tiers are set but unused by this request.
         let model_id = create_test_model(&pool, "cache-bill-test").await;
@@ -2206,7 +2206,7 @@ mod integration_tests {
 
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_different_tariffs_for_batch_and_realtime(pool: PgPool) {
+    async fn test_batcher_different_tariffs_for_batch_and_realtime(pool: sqlx::PgPool) {
         // Setup: Create model with different tariffs for batch and realtime
         let model_id = create_test_model(&pool, "gpt-4-turbo-test").await;
 
@@ -2277,7 +2277,7 @@ mod integration_tests {
 
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_folds_batch_analytics_into_aggregates(pool: PgPool) {
+    async fn test_batcher_folds_batch_analytics_into_aggregates(pool: sqlx::PgPool) {
         // Three requests of one batch fold their tokens / latency / list-cost into
         // batch_aggregates (COR-524), so get_batch_analytics can read the row instead of
         // scanning http_analytics. The third is on an UNPRICED model (free): it is not billed
@@ -2360,7 +2360,7 @@ mod integration_tests {
 
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_denormalizes_fusillade_request_id_onto_credits(pool: PgPool) {
+    async fn test_batcher_denormalizes_fusillade_request_id_onto_credits(pool: sqlx::PgPool) {
         // A batched request's credit row carries its fusillade_request_id (migration 120), so the
         // responses view can read per-request cost off the ledger durably instead of joining
         // http_analytics (COR-524 follow-up / Usage E).
@@ -2399,7 +2399,7 @@ mod integration_tests {
 
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_fallback_to_realtime_when_batch_tariff_missing(pool: PgPool) {
+    async fn test_batcher_fallback_to_realtime_when_batch_tariff_missing(pool: sqlx::PgPool) {
         // Setup: Create model with ONLY realtime tariff
         let model_id = create_test_model(&pool, "gpt-4-fallback-test").await;
         let realtime_input = Decimal::from_str("0.00015").unwrap();
@@ -2433,7 +2433,7 @@ mod integration_tests {
 
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_skip_deduction_when_no_pricing(pool: PgPool) {
+    async fn test_batcher_skip_deduction_when_no_pricing(pool: sqlx::PgPool) {
         // Setup: Create model WITHOUT any tariff
         let _model_id = create_test_model(&pool, "gpt-4-no-tariff").await;
 
@@ -2476,7 +2476,7 @@ mod integration_tests {
     /// reads.
     #[sqlx::test]
     #[test_log::test]
-    async fn batcher_persists_the_user_agent_to_http_analytics(pool: PgPool) {
+    async fn batcher_persists_the_user_agent_to_http_analytics(pool: sqlx::PgPool) {
         create_test_model(&pool, "ua-persist-test").await;
 
         let mut record = create_raw_record("ua-persist-test", None, 10, 5);
@@ -2500,7 +2500,7 @@ mod integration_tests {
     /// any duration computed from it then reads as decades of queue delay.
     #[sqlx::test]
     #[test_log::test]
-    async fn batcher_persists_the_submitted_at_to_http_analytics(pool: PgPool) {
+    async fn batcher_persists_the_submitted_at_to_http_analytics(pool: sqlx::PgPool) {
         create_test_model(&pool, "submitted-at-test").await;
 
         let submitted = Utc::now() - chrono::Duration::minutes(90);
@@ -2526,7 +2526,7 @@ mod integration_tests {
     /// "no submitted_at" is how a consumer tells deferred work from immediate.
     #[sqlx::test]
     #[test_log::test]
-    async fn realtime_rows_have_no_submitted_at(pool: PgPool) {
+    async fn realtime_rows_have_no_submitted_at(pool: sqlx::PgPool) {
         create_test_model(&pool, "realtime-no-submit").await;
 
         let record = create_raw_record("realtime-no-submit", None, 10, 5);
@@ -2543,7 +2543,7 @@ mod integration_tests {
 
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_skip_deduction_for_unauthenticated_requests(pool: PgPool) {
+    async fn test_batcher_skip_deduction_for_unauthenticated_requests(pool: sqlx::PgPool) {
         // Setup: Create model with tariff
         let model_id = create_test_model(&pool, "gpt-4-unauth-test").await;
         setup_tariff(
@@ -2579,7 +2579,7 @@ mod integration_tests {
     /// Test that the batcher sends pg_notify when a user's balance is depleted (crosses zero downward)
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_balance_depleted_notification(pool: PgPool) {
+    async fn test_batcher_balance_depleted_notification(pool: sqlx::PgPool) {
         use sqlx::postgres::PgListener;
         use std::time::Duration;
         use tokio::time::timeout;
@@ -2661,7 +2661,7 @@ mod integration_tests {
     /// (edge-triggered), and further over-cap flushes fold silently.
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_folds_cap_scope_and_notifies_on_crossing(pool: PgPool) {
+    async fn test_batcher_folds_cap_scope_and_notifies_on_crossing(pool: sqlx::PgPool) {
         use crate::db::handlers::api_keys::ApiKeys;
         use sqlx::postgres::PgListener;
         use std::time::Duration;
@@ -2753,7 +2753,7 @@ mod integration_tests {
     /// crossing NOTIFY when the fresh window is under the cap.
     #[sqlx::test]
     #[test_log::test]
-    async fn test_batcher_cap_window_rollover(pool: PgPool) {
+    async fn test_batcher_cap_window_rollover(pool: sqlx::PgPool) {
         use sqlx::postgres::PgListener;
         use std::time::Duration;
         use tokio::time::timeout;
@@ -2827,7 +2827,7 @@ mod integration_tests {
 
     #[sqlx::test]
     #[test_log::test]
-    async fn test_flush_emits_single_notification_for_multiple_depletions(pool: PgPool) {
+    async fn test_flush_emits_single_notification_for_multiple_depletions(pool: sqlx::PgPool) {
         use sqlx::postgres::PgListener;
         use std::time::Duration;
         use tokio::time::timeout;

--- a/dwctl/src/sync/onwards_config/mod.rs
+++ b/dwctl/src/sync/onwards_config/mod.rs
@@ -395,18 +395,19 @@ impl OnwardsConfigSync {
     /// watch channel is closed (all receivers dropped); Err only for fatal
     /// DB errors (closed pool / connection).
     async fn full_reload(&mut self, source: &'static str) -> Result<bool, anyhow::Error> {
-        let new_targets = match load_targets_from_db(&self.db.write(), &self.escalation_models, self.strict_mode, &self.rate_limit_tiers).await {
-            Ok(targets) => targets,
-            Err(e) => {
-                crate::background_error!(ONWARDS_SYNC, "load_targets", Error, "Failed to load targets from database: {}", e);
-                if e.to_string().contains("closed pool") || e.to_string().contains("connection closed") {
-                    error!("Database pool closed, exiting sync task");
-                    return Err(e);
+        let new_targets =
+            match load_targets_from_db(&self.db.write(), &self.escalation_models, self.strict_mode, &self.rate_limit_tiers).await {
+                Ok(targets) => targets,
+                Err(e) => {
+                    crate::background_error!(ONWARDS_SYNC, "load_targets", Error, "Failed to load targets from database: {}", e);
+                    if e.to_string().contains("closed pool") || e.to_string().contains("connection closed") {
+                        error!("Database pool closed, exiting sync task");
+                        return Err(e);
+                    }
+                    // Continue listening for other types of errors
+                    return Ok(true);
                 }
-                // Continue listening for other types of errors
-                return Ok(true);
-            }
-        };
+            };
         debug!("Loaded {} targets from database", new_targets.targets.len());
 
         // Update daemon capacity limits if configured

--- a/dwctl/src/sync/onwards_config/mod.rs
+++ b/dwctl/src/sync/onwards_config/mod.rs
@@ -118,7 +118,7 @@ struct OnwardsApiKey {
 
 /// Manages the integration between onwards-pilot and the onwards proxy
 pub struct OnwardsConfigSync {
-    db: PgPool,
+    db: sqlx_pool_router::DynPools,
     sender: watch::Sender<Targets>,
     /// Shared map of model batch capacity limits for the daemon
     daemon_capacity_limits: Option<Arc<dashmap::DashMap<String, usize>>>,
@@ -170,24 +170,26 @@ impl OnwardsConfigSync {
     /// `rate_limit_tiers` - Default rate limits applied per-key based on the owning user's `verified` flag.
     #[instrument(skip(db, daemon_capacity_limits, escalation_models, rate_limit_tiers))]
     pub async fn new_with_daemon_limits(
-        db: PgPool,
+        db: impl sqlx_pool_router::PoolProvider,
         daemon_capacity_limits: Option<Arc<dashmap::DashMap<String, usize>>>,
         default_batch_capacity: usize,
         escalation_models: Vec<String>,
         strict_mode: bool,
         rate_limit_tiers: RateLimitTiersConfig,
     ) -> Result<(Self, Targets, WatchTargetsStream), anyhow::Error> {
+        // Live provider (not a pinned pool): survives runtime pool swaps.
+        let db = sqlx_pool_router::DynPools::new(db);
         // Load initial configuration (including composite models)
-        let initial_targets = load_targets_from_db(&db, &escalation_models, strict_mode, &rate_limit_tiers).await?;
+        let initial_targets = load_targets_from_db(&db.write(), &escalation_models, strict_mode, &rate_limit_tiers).await?;
 
         // If daemon limits are provided, populate them
         if let Some(ref limits) = daemon_capacity_limits {
-            update_daemon_capacity_limits(&db, limits, default_batch_capacity).await?;
+            update_daemon_capacity_limits(&db.write(), limits, default_batch_capacity).await?;
         }
 
         // Populate cache info metrics on startup
         let mut cache_info_state = crate::metrics::CacheInfoState::new();
-        if let Err(e) = crate::metrics::update_cache_info_metrics(&db, &initial_targets, &mut cache_info_state).await {
+        if let Err(e) = crate::metrics::update_cache_info_metrics(&db.write(), &initial_targets, &mut cache_info_state).await {
             crate::background_error!(
                 ONWARDS_SYNC,
                 "cache_info_metrics",
@@ -242,7 +244,7 @@ impl OnwardsConfigSync {
             if let Some(tx) = &config.status_tx {
                 tx.send(SyncStatus::Connecting).await?;
             }
-            let mut listener = PgListener::connect_with(&self.db).await?;
+            let mut listener = PgListener::connect_with(&self.db.write()).await?;
             // Listen to auth config changes
             listener.listen(ONWARDS_CONFIG_CHANGED_CHANNEL).await?;
 
@@ -393,7 +395,7 @@ impl OnwardsConfigSync {
     /// watch channel is closed (all receivers dropped); Err only for fatal
     /// DB errors (closed pool / connection).
     async fn full_reload(&mut self, source: &'static str) -> Result<bool, anyhow::Error> {
-        let new_targets = match load_targets_from_db(&self.db, &self.escalation_models, self.strict_mode, &self.rate_limit_tiers).await {
+        let new_targets = match load_targets_from_db(&self.db.write(), &self.escalation_models, self.strict_mode, &self.rate_limit_tiers).await {
             Ok(targets) => targets,
             Err(e) => {
                 crate::background_error!(ONWARDS_SYNC, "load_targets", Error, "Failed to load targets from database: {}", e);
@@ -409,7 +411,7 @@ impl OnwardsConfigSync {
 
         // Update daemon capacity limits if configured
         if let Some(ref limits) = self.daemon_capacity_limits
-            && let Err(e) = update_daemon_capacity_limits(&self.db, limits, self.default_batch_capacity).await
+            && let Err(e) = update_daemon_capacity_limits(&self.db.write(), limits, self.default_batch_capacity).await
         {
             crate::background_error!(
                 ONWARDS_SYNC,
@@ -421,7 +423,7 @@ impl OnwardsConfigSync {
         }
 
         // Update cache info metrics
-        if let Err(e) = crate::metrics::update_cache_info_metrics(&self.db, &new_targets, &mut self.cache_info_state).await {
+        if let Err(e) = crate::metrics::update_cache_info_metrics(&self.db.write(), &new_targets, &mut self.cache_info_state).await {
             crate::background_error!(
                 ONWARDS_SYNC,
                 "cache_info_metrics",

--- a/dwctl/src/sync/usage_refresh.rs
+++ b/dwctl/src/sync/usage_refresh.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use sqlx::PgPool;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, instrument};
@@ -30,7 +29,13 @@ use crate::metrics::errors::component::USAGE_REFRESH;
 /// refresh, then waits `min_interval` before it can run again (bounding the refresh rate
 /// and coalescing bursts of nudges).
 #[instrument(skip_all)]
-pub async fn run_usage_refresh_daemon(pool: PgPool, config: UsageRefreshConfig, notify: Arc<Notify>, shutdown: CancellationToken) {
+pub async fn run_usage_refresh_daemon(
+    pools: impl sqlx_pool_router::PoolProvider,
+    config: UsageRefreshConfig,
+    notify: Arc<Notify>,
+    shutdown: CancellationToken,
+) {
+    let pools = sqlx_pool_router::DynPools::new(pools);
     let min_interval = Duration::from_millis(config.min_interval_milliseconds);
 
     // Fallback tick is optional (0 disables it). Skip missed ticks so a stall doesn't
@@ -58,7 +63,7 @@ pub async fn run_usage_refresh_daemon(pool: PgPool, config: UsageRefreshConfig, 
             _ = async { match fallback.as_mut() { Some(t) => { t.tick().await; }, None => std::future::pending().await } } => {}
         }
 
-        if let Err(e) = refresh_user_model_usage_daily(&pool).await {
+        if let Err(e) = refresh_user_model_usage_daily(&pools.write()).await {
             crate::background_error!(USAGE_REFRESH, "refresh", Error, error = %e, "Failed to refresh user_model_usage_daily");
         }
 

--- a/dwctl/src/sync/zdr_keys.rs
+++ b/dwctl/src/sync/zdr_keys.rs
@@ -98,12 +98,18 @@ pub async fn initial_cache(pool: &PgPool) -> Result<ZdrKeyCache, sqlx::Error> {
 /// Background task: keep `cache` fresh. Listens on `auth_config_changed` and
 /// reloads (debounced), with a periodic fallback reload to recover from any
 /// missed notification. Returns when `shutdown` fires.
-pub async fn run(pool: PgPool, cache: ZdrKeyCache, fallback_interval_ms: u64, shutdown: CancellationToken) -> Result<(), anyhow::Error> {
+pub async fn run(
+    pools: impl sqlx_pool_router::PoolProvider,
+    cache: ZdrKeyCache,
+    fallback_interval_ms: u64,
+    shutdown: CancellationToken,
+) -> Result<(), anyhow::Error> {
+    let pools = sqlx_pool_router::DynPools::new(pools);
     const MIN_RELOAD_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
     let fallback = (fallback_interval_ms > 0).then(|| std::time::Duration::from_millis(fallback_interval_ms));
 
     'outer: loop {
-        let mut listener = PgListener::connect_with(&pool).await?;
+        let mut listener = PgListener::connect_with(&pools.write()).await?;
         listener.listen(ONWARDS_CONFIG_CHANGED_CHANNEL).await?;
         info!("Started ZDR key sync listener");
 
@@ -127,7 +133,7 @@ pub async fn run(pool: PgPool, cache: ZdrKeyCache, fallback_interval_ms: u64, sh
                     Ok(Some(_)) => {
                         if last_reload.elapsed() < MIN_RELOAD_INTERVAL { continue; }
                         last_reload = std::time::Instant::now();
-                        reload(&pool, &cache).await;
+                        reload(&pools.write(), &cache).await;
                     }
                     Ok(None) => {
                         debug!("ZDR key sync: connection lost, reconnecting");
@@ -141,7 +147,7 @@ pub async fn run(pool: PgPool, cache: ZdrKeyCache, fallback_interval_ms: u64, sh
                 _ = tick => {
                     if last_reload.elapsed() < MIN_RELOAD_INTERVAL { continue; }
                     last_reload = std::time::Instant::now();
-                    reload(&pool, &cache).await;
+                    reload(&pools.write(), &cache).await;
                 }
             }
         }

--- a/dwctl/src/tasks.rs
+++ b/dwctl/src/tasks.rs
@@ -37,7 +37,7 @@ type WeakJobRef<I, P> = Arc<OnceLock<Weak<Job<I, TaskState<P>>>>>;
 pub struct TaskState<P: PoolProvider + Clone = sqlx_pool_router::DbPools> {
     pub request_manager: Arc<PostgresRequestManager<P>>,
     /// dwctl database pool — for querying connections, sync_operations, sync_entries.
-    pub dwctl_pool: PgPool,
+    pub dwctl_pool: sqlx_pool_router::DynPools,
     /// Shared config for capacity checks and other runtime configuration.
     pub config: crate::SharedConfig,
     /// Encryption key for decrypting connection credentials inside jobs.

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -1247,8 +1247,8 @@ async fn test_request_logging_enabled(pool: PgPool) {
 
     // Get outlet_db from app_state to query logs
     let outlet_pool = app.app_state.outlet_db.clone().expect("outlet_db should exist");
-    let repository: outlet_postgres::RequestRepository<DbPools, AiRequest, AiResponse> =
-        outlet_postgres::RequestRepository::new(outlet_pool);
+    let repository: outlet_postgres::RequestRepository<sqlx::PgPool, AiRequest, AiResponse> =
+        outlet_postgres::RequestRepository::new(outlet_pool.write().into_inner());
 
     let (server, _drop_guard) = app.into_test_server();
 
@@ -1302,7 +1302,7 @@ async fn test_outlet_suppresses_zdr_bodies(pool: PgPool) {
 
     // Real analytics handler wrapped in the scrubber, mirroring lib.rs wiring.
     let handler =
-        outlet_postgres::PostgresHandler::<DbPools, serde_json::Value, serde_json::Value>::from_pool_provider(DbPools::new(pool.clone()))
+        outlet_postgres::PostgresHandler::<sqlx::PgPool, serde_json::Value, serde_json::Value>::from_pool_provider(pool.clone())
             .await
             .expect("build PostgresHandler");
     let handler = crate::inference::engine::outlet_handler::ZdrBodyScrubber::new(handler);
@@ -1382,7 +1382,7 @@ async fn test_request_logging_disabled(pool: PgPool) {
     underway::run_migrations(&pool).await.expect("Failed to run underway migrations");
     let task_state = TaskState {
         request_manager: request_manager.clone(),
-        dwctl_pool: pool.clone(),
+        dwctl_pool: sqlx_pool_router::DynPools::new(pool.clone()),
         config: shared_config.clone(),
         encryption_key: None,
         ingest_file_job: std::sync::Arc::new(std::sync::OnceLock::new()),
@@ -1488,6 +1488,7 @@ async fn test_dedicated_databases_for_components(pool: PgPool) {
             replica_pool: None,
         },
         underway_pool: crate::config::default_underway_pool(),
+        replica_group: crate::config::default_replica_group(),
     };
 
     // Create application - this will run migrations on the dedicated databases
@@ -1542,8 +1543,8 @@ async fn test_dedicated_databases_for_components(pool: PgPool) {
     );
 
     // Make a request and verify it gets logged to the dedicated outlet database
-    let repository: outlet_postgres::RequestRepository<DbPools, AiRequest, AiResponse> =
-        outlet_postgres::RequestRepository::new(outlet_pool);
+    let repository: outlet_postgres::RequestRepository<sqlx::PgPool, AiRequest, AiResponse> =
+        outlet_postgres::RequestRepository::new(outlet_pool.write().into_inner());
 
     let (server, bg_services) = app.into_test_server();
 
@@ -2045,7 +2046,7 @@ async fn test_build_router_with_metrics_disabled(pool: PgPool) {
     underway::run_migrations(&pool).await.expect("Failed to run underway migrations");
     let task_state = crate::tasks::TaskState {
         request_manager: request_manager.clone(),
-        dwctl_pool: pool.clone(),
+        dwctl_pool: sqlx_pool_router::DynPools::new(pool.clone()),
         config: shared_config.clone(),
         encryption_key: None,
         ingest_file_job: std::sync::Arc::new(std::sync::OnceLock::new()),
@@ -2107,7 +2108,7 @@ async fn test_build_router_with_metrics_enabled(pool: PgPool) {
     underway::run_migrations(&pool).await.expect("Failed to run underway migrations");
     let task_state = TaskState {
         request_manager: request_manager.clone(),
-        dwctl_pool: pool.clone(),
+        dwctl_pool: sqlx_pool_router::DynPools::new(pool.clone()),
         config: shared_config.clone(),
         encryption_key: None,
         ingest_file_job: std::sync::Arc::new(std::sync::OnceLock::new()),

--- a/dwctl/src/test/mod.rs
+++ b/dwctl/src/test/mod.rs
@@ -1301,10 +1301,9 @@ async fn test_outlet_suppresses_zdr_bodies(pool: PgPool) {
     }
 
     // Real analytics handler wrapped in the scrubber, mirroring lib.rs wiring.
-    let handler =
-        outlet_postgres::PostgresHandler::<sqlx::PgPool, serde_json::Value, serde_json::Value>::from_pool_provider(pool.clone())
-            .await
-            .expect("build PostgresHandler");
+    let handler = outlet_postgres::PostgresHandler::<sqlx::PgPool, serde_json::Value, serde_json::Value>::from_pool_provider(pool.clone())
+        .await
+        .expect("build PostgresHandler");
     let handler = crate::inference::engine::outlet_handler::ZdrBodyScrubber::new(handler);
 
     fn request(correlation_id: u64, zdr: bool) -> RequestData {

--- a/dwctl/src/test/utils.rs
+++ b/dwctl/src/test/utils.rs
@@ -43,7 +43,7 @@ pub async fn create_test_app_state_with_config(pool: PgPool, config: crate::conf
     underway::run_migrations(&pool).await.expect("Failed to run underway migrations");
     let task_state = crate::tasks::TaskState {
         request_manager: request_manager.clone(),
-        dwctl_pool: pool.clone(),
+        dwctl_pool: sqlx_pool_router::DynPools::new(pool.clone()),
         config: shared_config.clone(),
         encryption_key: None,
         ingest_file_job: std::sync::Arc::new(std::sync::OnceLock::new()),
@@ -139,7 +139,7 @@ pub async fn create_test_app_state_with_database_pools(
     underway::run_migrations(&pool).await.expect("Failed to run underway migrations");
     let task_state = crate::tasks::TaskState {
         request_manager: request_manager.clone(),
-        dwctl_pool: pool.clone(),
+        dwctl_pool: sqlx_pool_router::DynPools::new(pool.clone()),
         config: shared_config.clone(),
         encryption_key: None,
         ingest_file_job: std::sync::Arc::new(std::sync::OnceLock::new()),
@@ -250,6 +250,7 @@ pub fn create_test_config() -> crate::config::Config {
                 min_connections: 0,
                 ..Default::default()
             },
+            replica_group: crate::config::default_replica_group(),
         },
         slow_statement_threshold_ms: 1000,
         host: "127.0.0.1".to_string(),

--- a/dwctl/src/webhooks/dispatcher.rs
+++ b/dwctl/src/webhooks/dispatcher.rs
@@ -35,7 +35,6 @@ use std::time::Duration;
 
 use chrono::Utc;
 use metrics::counter;
-use sqlx::PgPool;
 use tokio::sync::{Semaphore, mpsc};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -76,7 +75,8 @@ struct WebhookSendResult {
 // --- Dispatcher ---
 
 pub struct WebhookDispatcher {
-    pool: PgPool,
+    /// Live provider (not a pinned pool): survives runtime pool swaps.
+    pool: sqlx_pool_router::DynPools,
     send_tx: mpsc::Sender<WebhookSendRequest>,
     result_rx: mpsc::Receiver<WebhookSendResult>,
     retry_schedule: Vec<i64>,
@@ -86,7 +86,8 @@ pub struct WebhookDispatcher {
 
 impl WebhookDispatcher {
     /// Create a new dispatcher and spawn the background sender task.
-    pub fn spawn(pool: PgPool, config: &WebhookConfig, shutdown: CancellationToken) -> Self {
+    pub fn spawn(pool: impl sqlx_pool_router::PoolProvider, config: &WebhookConfig, shutdown: CancellationToken) -> Self {
+        let pool = sqlx_pool_router::DynPools::new(pool);
         let (send_tx, send_rx) = mpsc::channel::<WebhookSendRequest>(config.channel_capacity);
         let (result_tx, result_rx) = mpsc::channel(config.channel_capacity);
 
@@ -116,7 +117,7 @@ impl WebhookDispatcher {
 
     /// Claim deliveries that are due, sign them, and push to the sender channel.
     async fn claim_and_send(&self) {
-        let mut conn = match self.pool.acquire().await {
+        let mut conn = match self.pool.write().acquire().await {
             Ok(c) => c,
             Err(e) => {
                 crate::background_error!(WEBHOOK_DISPATCH, "db_acquire", Warning, error = %e, "Failed to acquire connection for retry claims");
@@ -220,7 +221,7 @@ impl WebhookDispatcher {
 
     /// Drain completed send results and update DB status.
     async fn drain_results(&mut self) {
-        let mut conn = match self.pool.acquire().await {
+        let mut conn = match self.pool.write().acquire().await {
             Ok(c) => c,
             Err(e) => {
                 crate::background_error!(WEBHOOK_DISPATCH, "db_acquire", Warning, error = %e, "Failed to acquire connection for result drain");

--- a/fusillade-arsenal/Cargo.toml
+++ b/fusillade-arsenal/Cargo.toml
@@ -37,7 +37,7 @@ humantime = "2"
 metrics = "0.24"
 rand = "0.10"
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono", "json", "tls-rustls"] }
-sqlx-pool-router = "0.2.0"
+sqlx-pool-router = "0.3.0"
 
 [dev-dependencies]
 test-log = "0.2.18"

--- a/fusillade-arsenal/Cargo.toml
+++ b/fusillade-arsenal/Cargo.toml
@@ -37,7 +37,7 @@ humantime = "2"
 metrics = "0.24"
 rand = "0.10"
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono", "json", "tls-rustls"] }
-sqlx-pool-router = "0.3.0"
+sqlx-pool-router = "1.0"
 
 [dev-dependencies]
 test-log = "0.2.18"

--- a/fusillade-arsenal/src/lib.rs
+++ b/fusillade-arsenal/src/lib.rs
@@ -17,7 +17,7 @@ pub use fusillade_core::manager::{
 };
 pub use fusillade_core::request::AnyRequest;
 pub use fusillade_core::response_step;
-pub use postgres::{BatchInsertStrategy, PoolProvider, PostgresRequestManager, TestDbPools};
+pub use postgres::{BatchInsertStrategy, DynPools, PoolHandle, PoolProvider, PostgresRequestManager, TestDbPools};
 pub use postgres_response_step::PostgresResponseStepManager;
 pub use transform::ResponseTransformer;
 

--- a/fusillade-arsenal/src/lib.rs
+++ b/fusillade-arsenal/src/lib.rs
@@ -17,7 +17,9 @@ pub use fusillade_core::manager::{
 };
 pub use fusillade_core::request::AnyRequest;
 pub use fusillade_core::response_step;
-pub use postgres::{BatchInsertStrategy, DynPools, PoolHandle, PoolProvider, PostgresRequestManager, TestDbPools};
+pub use postgres::{
+    BatchInsertStrategy, DynPools, PoolHandle, PoolProvider, PostgresRequestManager, TestDbPools,
+};
 pub use postgres_response_step::PostgresResponseStepManager;
 pub use transform::ResponseTransformer;
 

--- a/fusillade-arsenal/src/postgres.rs
+++ b/fusillade-arsenal/src/postgres.rs
@@ -1168,13 +1168,17 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
 
             if is_complete {
                 // Spawn background finalization - don't block listing
-                let pool = self.pools.write().into_inner();
+                let pools = self.pools.clone();
                 let retry_config = self.db_retry_config.clone();
 
                 tokio::spawn(async move {
-                    if let Err(e) =
-                        Self::finalize_file_size(&pool, &retry_config, file_id, estimated_size)
-                            .await
+                    if let Err(e) = Self::finalize_file_size(
+                        &pools.write(),
+                        &retry_config,
+                        file_id,
+                        estimated_size,
+                    )
+                    .await
                     {
                         tracing::warn!("Failed to finalize file size for {}: {}", file_id, e);
                     }
@@ -3936,7 +3940,9 @@ impl<P: PoolProvider> Storage for PostgresRequestManager<P> {
         offset: usize,
         search: Option<String>,
     ) -> Pin<Box<dyn Stream<Item = Result<FileContentItem>> + Send>> {
-        let pool = self.pools.read().into_inner();
+        // A live provider, not a pool snapshot: this task can outlive a
+        // connection-budget re-division and must follow the swap.
+        let pools = self.pools.clone();
         let retry_config = self.db_retry_config.clone();
         let (tx, rx) = mpsc::channel(self.download_buffer_size);
         let offset = offset as i64;
@@ -3951,7 +3957,7 @@ impl<P: PoolProvider> Storage for PostgresRequestManager<P> {
                 "#,
                 *file_id as Uuid,
             )
-            .fetch_one(crate::db::RetryingPgPool::new(&pool, &retry_config))
+            .fetch_one(crate::db::RetryingPgPool::new(&pools.read(), &retry_config))
             .await;
 
             let purpose = match file_result {
@@ -3970,16 +3976,24 @@ impl<P: PoolProvider> Storage for PostgresRequestManager<P> {
             // Route to appropriate streaming logic based on purpose
             match purpose.as_deref() {
                 Some("batch_output") => {
-                    Self::stream_batch_output(pool, retry_config, file_id, offset, search, tx)
+                    Self::stream_batch_output(pools, retry_config, file_id, offset, search, tx)
                         .await;
                 }
                 Some("batch_error") => {
-                    Self::stream_batch_error(pool, retry_config, file_id, offset, search, tx).await;
+                    Self::stream_batch_error(pools, retry_config, file_id, offset, search, tx)
+                        .await;
                 }
                 _ => {
                     // Regular file or purpose='batch': stream request templates
-                    Self::stream_request_templates(pool, retry_config, file_id, offset, search, tx)
-                        .await;
+                    Self::stream_request_templates(
+                        pools,
+                        retry_config,
+                        file_id,
+                        offset,
+                        search,
+                        tx,
+                    )
+                    .await;
                 }
             }
         });
@@ -6095,13 +6109,14 @@ impl<P: PoolProvider> Storage for PostgresRequestManager<P> {
         search: Option<String>,
         status: Option<String>,
     ) -> Pin<Box<dyn Stream<Item = Result<crate::batch::BatchResultItem>> + Send>> {
-        let pool = self.pools.read().into_inner();
+        // Live provider (see get_file_content_stream).
+        let pools = self.pools.clone();
         let retry_config = self.db_retry_config.clone();
         let (tx, rx) = mpsc::channel(self.download_buffer_size);
         let offset = offset as i64;
 
         tokio::spawn(async move {
-            Self::stream_batch_results(pool, retry_config, batch_id, offset, search, status, tx)
+            Self::stream_batch_results(pools, retry_config, batch_id, offset, search, status, tx)
                 .await;
         });
 
@@ -7193,7 +7208,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
 
     /// Stream request templates from a regular file
     async fn stream_request_templates(
-        pool: sqlx::PgPool,
+        pools: P,
         retry_config: crate::DbRetryConfig,
         file_id: FileId,
         offset: i64,
@@ -7230,7 +7245,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
                 BATCH_SIZE,
                 search_pattern.as_deref(),
             )
-            .fetch_all(crate::db::RetryingPgPool::new(&pool, &retry_config))
+            .fetch_all(crate::db::RetryingPgPool::new(&pools.read(), &retry_config))
             .await;
 
             match template_batch {
@@ -7282,7 +7297,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
 
     /// Stream batch output (completed requests) for a virtual output file
     async fn stream_batch_output(
-        pool: sqlx::PgPool,
+        pools: P,
         retry_config: crate::DbRetryConfig,
         file_id: FileId,
         offset: i64,
@@ -7311,7 +7326,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
             "#,
             *file_id as Uuid,
         )
-        .fetch_one(crate::db::RetryingPgPool::new(&pool, &retry_config))
+        .fetch_one(crate::db::RetryingPgPool::new(&pools.read(), &retry_config))
         .await;
 
         let (batch_id, bucket) = match batch_result {
@@ -7378,7 +7393,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
                 search_pattern.as_deref(),
                 bucket,
             )
-            .fetch_all(crate::db::RetryingPgPool::new(&pool, &retry_config))
+            .fetch_all(crate::db::RetryingPgPool::new(&pools.read(), &retry_config))
             .await;
 
             match request_batch {
@@ -7446,7 +7461,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
 
     /// Stream batch errors (failed requests) for a virtual error file
     async fn stream_batch_error(
-        pool: sqlx::PgPool,
+        pools: P,
         retry_config: crate::DbRetryConfig,
         file_id: FileId,
         offset: i64,
@@ -7470,7 +7485,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
             "#,
             *file_id as Uuid,
         )
-        .fetch_one(crate::db::RetryingPgPool::new(&pool, &retry_config))
+        .fetch_one(crate::db::RetryingPgPool::new(&pools.read(), &retry_config))
         .await;
 
         let (batch_id, bucket, _expires_at) = match batch_result {
@@ -7547,7 +7562,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
 
             let request_batch = query_builder
                 .build()
-                .fetch_all(crate::db::RetryingPgPool::new(&pool, &retry_config))
+                .fetch_all(crate::db::RetryingPgPool::new(&pools.read(), &retry_config))
                 .await;
 
             match request_batch {
@@ -7602,7 +7617,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
     /// Stream batch results with merged input/output data for the Results view.
     /// This joins requests with their templates to provide input body alongside response/error.
     async fn stream_batch_results(
-        pool: sqlx::PgPool,
+        pools: P,
         retry_config: crate::DbRetryConfig,
         batch_id: BatchId,
         offset: i64,
@@ -7619,7 +7634,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
             r#"SELECT file_id, expires_at, archive_bucket FROM batches WHERE id = $1 AND deleted_at IS NULL"#,
             *batch_id as Uuid,
         )
-        .fetch_optional(crate::db::RetryingPgPool::new(&pool, &retry_config))
+        .fetch_optional(crate::db::RetryingPgPool::new(&pools.read(), &retry_config))
         .await
         {
             Ok(Some(row)) => {
@@ -7741,7 +7756,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
             // For each template, we find the matching request for this batch.
             let request_batch = query_builder
                 .build()
-                .fetch_all(crate::db::RetryingPgPool::new(&pool, &retry_config))
+                .fetch_all(crate::db::RetryingPgPool::new(&pools.read(), &retry_config))
                 .await;
 
             match request_batch {

--- a/fusillade-arsenal/src/postgres.rs
+++ b/fusillade-arsenal/src/postgres.rs
@@ -5,7 +5,7 @@
 
 use crate::request::AnyRequest;
 use futures::StreamExt;
-pub use sqlx_pool_router::{PoolProvider, TestDbPools};
+pub use sqlx_pool_router::{DynPools, PoolHandle, PoolProvider, TestDbPools};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -415,23 +415,23 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
     }
 
     fn read_executor(&self) -> crate::db::RetryingPgPool {
-        crate::db::RetryingPgPool::new(self.pools.read(), &self.db_retry_config)
+        crate::db::RetryingPgPool::new(&self.pools.read(), &self.db_retry_config)
     }
 
     fn write_executor(&self) -> crate::db::RetryingPgPool {
-        crate::db::RetryingPgPool::new(self.pools.write(), &self.db_retry_config)
+        crate::db::RetryingPgPool::new(&self.pools.write(), &self.db_retry_config)
     }
 
     async fn begin_read(
         &self,
     ) -> std::result::Result<sqlx::Transaction<'static, sqlx::Postgres>, sqlx::Error> {
-        crate::db::begin_transaction(self.pools.read(), &self.db_retry_config).await
+        crate::db::begin_transaction(&self.pools.read(), &self.db_retry_config).await
     }
 
     async fn begin_write(
         &self,
     ) -> std::result::Result<sqlx::Transaction<'static, sqlx::Postgres>, sqlx::Error> {
-        crate::db::begin_transaction(self.pools.write(), &self.db_retry_config).await
+        crate::db::begin_transaction(&self.pools.write(), &self.db_retry_config).await
     }
 
     async fn insert_batch_record(&self, input: NewBatchRecord) -> Result<Batch> {
@@ -794,8 +794,17 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
     /// For backward compatibility, this returns the write pool (primary).
     /// Use the pool provider's `.read()` and `.write()` methods directly
     /// for explicit read/write routing.
-    pub fn pool(&self) -> &PgPool {
+    ///
+    /// Returns an owned handle to the pool that is active *now*; do not
+    /// cache it (the provider may replace its pools at runtime).
+    pub fn pool(&self) -> sqlx_pool_router::PoolHandle {
         self.pools.write()
+    }
+
+    /// The pool provider itself, for components that must stay live across
+    /// runtime pool swaps (hold this, not a `PoolHandle`).
+    pub fn pools(&self) -> &P {
+        &self.pools
     }
 
     /// Create a listener for real-time request updates.
@@ -803,7 +812,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
     /// This returns a PgListener that can be used to receive notifications
     /// when requests are updated. Uses the write pool (primary) for consistency.
     pub async fn create_listener(&self) -> Result<PgListener> {
-        crate::db::connect_listener(self.pools.write(), &self.db_retry_config)
+        crate::db::connect_listener(&self.pools.write(), &self.db_retry_config)
             .await
             .map_err(|e| FusilladeError::Other(anyhow!("Failed to create listener: {}", e)))
     }
@@ -1159,7 +1168,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
 
             if is_complete {
                 // Spawn background finalization - don't block listing
-                let pool = self.pools.write().clone();
+                let pool = self.pools.write().into_inner();
                 let retry_config = self.db_retry_config.clone();
 
                 tokio::spawn(async move {
@@ -1226,7 +1235,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
 
         // Batch is complete - try to finalize this file
         let finalized = Self::finalize_file_size(
-            self.pools.write(),
+            &self.pools.write(),
             &self.db_retry_config,
             file.id,
             estimated_size,
@@ -3927,7 +3936,7 @@ impl<P: PoolProvider> Storage for PostgresRequestManager<P> {
         offset: usize,
         search: Option<String>,
     ) -> Pin<Box<dyn Stream<Item = Result<FileContentItem>> + Send>> {
-        let pool = self.pools.read().clone();
+        let pool = self.pools.read().into_inner();
         let retry_config = self.db_retry_config.clone();
         let (tx, rx) = mpsc::channel(self.download_buffer_size);
         let offset = offset as i64;
@@ -6086,7 +6095,7 @@ impl<P: PoolProvider> Storage for PostgresRequestManager<P> {
         search: Option<String>,
         status: Option<String>,
     ) -> Pin<Box<dyn Stream<Item = Result<crate::batch::BatchResultItem>> + Send>> {
-        let pool = self.pools.read().clone();
+        let pool = self.pools.read().into_inner();
         let retry_config = self.db_retry_config.clone();
         let (tx, rx) = mpsc::channel(self.download_buffer_size);
         let offset = offset as i64;

--- a/fusillade-arsenal/src/response_step.rs
+++ b/fusillade-arsenal/src/response_step.rs
@@ -56,7 +56,7 @@ impl<P: PoolProvider> PostgresResponseStepManager<P> {
     }
 
     fn write_executor(&self) -> crate::db::RetryingPgPool {
-        crate::db::RetryingPgPool::new(self.pools.write(), &self.db_retry_config)
+        crate::db::RetryingPgPool::new(&self.pools.write(), &self.db_retry_config)
     }
 }
 

--- a/fusillade-arsenal/tests/db_retry.rs
+++ b/fusillade-arsenal/tests/db_retry.rs
@@ -20,12 +20,12 @@ use uuid::Uuid;
 struct LazyPools(PgPool);
 
 impl PoolProvider for LazyPools {
-    fn read(&self) -> &PgPool {
-        &self.0
+    fn read(&self) -> sqlx_pool_router::PoolHandle {
+        self.0.clone().into()
     }
 
-    fn write(&self) -> &PgPool {
-        &self.0
+    fn write(&self) -> sqlx_pool_router::PoolHandle {
+        self.0.clone().into()
     }
 }
 


### PR DESCRIPTION
## Why

Pool sizes were per-pod constants, so the Neon connection limit — not CPU or memory — capped how far a control-layer Deployment could scale, and the replica count was effectively a config constant (the production values carry a hand-maintained `2×500 + 2×1200 = 3400/4000` budget). This is the control-layer half of putting HPAs on every control-layer workload.

## What

- **`PoolSettings::total_max_connections`** (optional): the budget for a whole replica group. **`database.replica_group`** (default `"default"`; the chart injects `DWCTL_DATABASE__REPLICA_GROUP` per Deployment).
- **`replica_registry` table + `dwctl/src/replica_governor.rs`**: each pod registers at boot *before sizing pools* (so it starts at its fair share), heartbeats every 10 s, counts live members (30 s liveness window), and when the count changes and holds for 20 s rebuilds every governed pool (`main` and `fusillade`, primaries and replicas) at `total / live`. Graceful shutdown deregisters; long-silent rows are swept. Metrics: `dwctl_replica_group_size{group}`, `dwctl_db_pool_share{pool}`, `dwctl_db_pool_share_floored{pool}` (1 + a warn when a group has more replicas than a pool's total, the only way the budget can be exceeded); `dwctl_db_pool_connections_max` now follows swaps.
- **Live providers everywhere.** sqlx pools cannot be resized, so a re-division is build-new / `DbPools::replace` / drain-old (sqlx-pool-router 1.0). Every long-lived holder — image-normaliser and error-enrichment middleware state, continuation, prompt-cache resolvers/index, probe scheduler, analytics batcher, ZDR key sync, usage refresh, webhook dispatcher, notification poller, task state, onwards-config sync, metrics sampler, the SIGTERM drain pool — now holds a `DbPools`/`DynPools` instead of a pinned `PgPool`. Leader election keeps a pinned pool on purpose (session-pinned advisory-lock connection).
- **Dormant by default**: with no total configured there are no registry writes, no heartbeats, and pools are sized from `max_connections` exactly as before (the migration still runs).

## Deliberately not governed

- **`outlet`**: outlet-postgres 0.7 pins sqlx-pool-router 0.2 and its `PostgresHandler` keeps the pool it is built with, so a swap would close it under request logging (caught in review). Outlet is a separate Neon project outside the budget; dwctl warns if a total is set on it. Follow-up: bump outlet-postgres to pool-router 1.0, then add it to `governed`.
- **`underway`**: per-pod by design (long-lived `PgListener` connections).

Follow-up (non-blocking): the fire-and-forget `image_access` bookkeeping in the image normaliser / file upload path spawns with a `PgPool` snapshot; passing `DynPools` there would make it swap-proof too. Best-effort write, rare window.

## Tests

`cargo test -p dwctl` against local Postgres: **2225 passed, 0 failed** (new: `replica_governor::*` — membership convergence and deregistration, registry liveness/GC, governor pool swap visible to held clones with settle hysteresis, floor detection, `share`/`effective_max`/min-clamp). fusillade crates green. Clippy introduces no new warnings.

Rollout order and rollback floors: internal repo `docs/src/architecture/control-layer-autoscaling.md` (doublewordai/internal#1825).

🤖 Generated with [Claude Code](https://claude.com/claude-code)