### PR TITLE
fix: search customer-visible model fields

### DIFF
--- a/dashboard/src/api/control-layer/mocks/handlers.ts
+++ b/dashboard/src/api/control-layer/mocks/handlers.ts
@@ -1334,13 +1334,18 @@ export const handlers = [
       models = models.filter((m) => !!m.is_composite === wantComposite);
     }
 
-    // Apply search filter (case-insensitive substring match on alias or model_name)
+    // Apply search filter using the same customer-visible fields as the API
     if (search) {
       const searchLower = search.toLowerCase();
       models = models.filter(
         (m) =>
           m.alias.toLowerCase().includes(searchLower) ||
-          m.model_name.toLowerCase().includes(searchLower),
+          m.model_name.toLowerCase().includes(searchLower) ||
+          (m.display_name?.toLowerCase().includes(searchLower) ?? false) ||
+          (endpointsData
+            .find((endpoint) => endpoint.id === m.hosted_on)
+            ?.name.toLowerCase()
+            .includes(searchLower) ?? false),
       );
     }
 

--- a/dashboard/src/api/control-layer/types.ts
+++ b/dashboard/src/api/control-layer/types.ts
@@ -547,7 +547,7 @@ export interface ModelsQuery {
   group?: string; // Filter by group IDs (comma-separated UUIDs)
   include?: ModelsInclude;
   accessible?: boolean; // Filter to only models the current user can access
-  search?: string; // Search query to filter models by alias or model_name
+  search?: string; // Case-insensitive search across model names and endpoint names
   is_composite?: boolean; // Filter by composite/virtual model status (true = virtual, false = hosted)
   provider?: string; // Filter by provider name (case-insensitive exact match)
   model_type?: ModelType; // Filter by model type (CHAT, EMBEDDINGS, RERANKER)

--- a/dwctl/src/api/handlers/deployments.rs
+++ b/dwctl/src/api/handlers/deployments.rs
@@ -214,7 +214,7 @@ fn db_component_to_response(c: DeploymentComponentDBResponse) -> ModelComponentR
         ("inactive" = Option<bool>, Query, description = "Show inactive models when true (admin only)"),
         ("limit" = Option<i64>, Query, description = "Maximum number of items to return (default: 10, max: 100)"),
         ("skip" = Option<i64>, Query, description = "Number of items to skip (default: 0)"),
-        ("search" = Option<String>, Query, description = "Search query to filter models by alias, model_name, or endpoint name (case-insensitive substring match)"),
+        ("search" = Option<String>, Query, description = "Search query to filter models by alias, model name, display name, or endpoint name (case-insensitive substring match)"),
         ("is_composite" = Option<bool>, Query, description = "Filter by composite/virtual model status (true = virtual models only, false = hosted models only)"),
     ),
     responses(

--- a/dwctl/src/db/handlers/deployments.rs
+++ b/dwctl/src/db/handlers/deployments.rs
@@ -40,7 +40,7 @@ pub struct DeploymentFilter {
     pub accessible_to: Option<UserId>, // None = show all deployments, Some(user_id) = show only deployments accessible to that user
     pub group_ids: Option<Vec<crate::types::GroupId>>, // None = show all, Some(group_ids) = show only models in any of these groups
     pub aliases: Option<Vec<String>>,
-    pub search: Option<String>,                // Case-insensitive substring search on alias and model_name
+    pub search: Option<String>,                // Case-insensitive substring search
     pub is_composite: Option<bool>,            // None = show all, Some(true) = composite only, Some(false) = non-composite only
     pub provider: Option<String>,              // Filter by metadata provider (case-insensitive exact match)
     pub model_type: Option<ModelType>,         // Filter by model type column
@@ -809,6 +809,8 @@ impl<'c> Deployments<'c> {
             query.push(" AND (LOWER(dm.alias) LIKE ");
             query.push_bind(search_pattern.clone());
             query.push(" OR LOWER(dm.model_name) LIKE ");
+            query.push_bind(search_pattern.clone());
+            query.push(" OR LOWER(dm.display_name) LIKE ");
             query.push_bind(search_pattern.clone());
             query.push(" OR LOWER(ie.name) LIKE ");
             query.push_bind(search_pattern);
@@ -1715,6 +1717,49 @@ mod tests {
             roles: vec![Role::StandardUser],
         });
         user_repo.create(&user_create).await.unwrap().into()
+    }
+
+    #[sqlx::test]
+    #[test_log::test]
+    async fn searches_customer_visible_model_fields(pool: PgPool) {
+        let base_url = url::Url::parse("http://localhost:8080").unwrap();
+        crate::seed_database(
+            &[crate::config::ModelSource {
+                name: "test".to_string(),
+                url: base_url,
+                api_key: None,
+                sync_interval: std::time::Duration::from_secs(3600),
+                default_models: None,
+            }],
+            &pool,
+        )
+        .await
+        .unwrap();
+
+        let user = create_test_user(&pool).await;
+        let endpoint_id = get_test_endpoint_id(&pool).await;
+        let mut conn = pool.acquire().await.unwrap();
+        let mut repo = Deployments::new(&mut conn);
+        let created = repo
+            .create(
+                &DeploymentCreateDBRequest::builder()
+                    .created_by(user.id)
+                    .model_name("vendor/model-27b".to_string())
+                    .alias("vendor/model-27b".to_string())
+                    .display_name("Qwen3.8 27B".to_string())
+                    .description("Optimized for multilingual retrieval".to_string())
+                    .hosted_on(endpoint_id)
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        let results = repo
+            .list(&DeploymentFilter::new(0, 10).with_search("qwen3.8 27b".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, created.id);
     }
 
     fn reasoning_translation_overrides() -> ReasoningTranslationOverrides {


### PR DESCRIPTION
The models page can initially match display names or descriptions, but the delayed server search only considered internal identifiers and endpoint names. This caused valid results to disappear once the API response arrived.

Include display names and descriptions in the server-side filter so both search paths return consistent results.