### PR TITLE
fix(billing): report first-purchase state so the promo can gate on the ledger

### DIFF
--- a/.sqlx/query-22e002458f9ab1f268df1843b36f6c738935eb7af392a214722eea94c1f3ba9c.json
+++ b/.sqlx/query-22e002458f9ab1f268df1843b36f6c738935eb7af392a214722eea94c1f3ba9c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT EXISTS (\n                SELECT 1 FROM credits_transactions\n                WHERE user_id = $1 AND transaction_type = 'purchase'\n            ) AS \"purchased!\"\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "purchased!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "22e002458f9ab1f268df1843b36f6c738935eb7af392a214722eea94c1f3ba9c"
+}

--- a/.sqlx/query-5b6961cfc0c2851e60130a38d7adbb75c06fbb04fa33104828dbe1bce97767fa.json
+++ b/.sqlx/query-5b6961cfc0c2851e60130a38d7adbb75c06fbb04fa33104828dbe1bce97767fa.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT DISTINCT user_id AS \"user_id!\"\n            FROM credits_transactions\n            WHERE user_id = ANY($1::uuid[]) AND transaction_type = 'purchase'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_id!",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5b6961cfc0c2851e60130a38d7adbb75c06fbb04fa33104828dbe1bce97767fa"
+}

--- a/dwctl/src/api/handlers/config.rs
+++ b/dwctl/src/api/handlers/config.rs
@@ -4,6 +4,8 @@ use axum::{Json, extract::State, response::IntoResponse};
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use rust_decimal::prelude::ToPrimitive;
+
 use crate::{AppState, api::models::users::CurrentUser};
 
 /// Batch processing configuration
@@ -44,6 +46,14 @@ pub struct ConfigResponse {
     pub organization: Option<String>,
     /// Whether payment processing is enabled
     pub payment_enabled: bool,
+    /// First-payment match promotion ceiling, in dollars: a billing target's
+    /// first ever purchase is matched with bonus credits up to this amount.
+    /// `0` means the promotion is switched off on this instance.
+    ///
+    /// Exposed so clients can both gate the promotional UI on the promotion
+    /// actually being live and render the real figure, rather than hard-coding
+    /// an amount that drifts from `credits.first_payment_match_up_to`.
+    pub first_payment_match_up_to: f64,
     /// URL to JSONL documentation for batch file format, if available
     pub docs_jsonl_url: Option<String>,
     /// URL to the documentation site
@@ -101,6 +111,10 @@ pub async fn get_config(State(state): State<AppState>, _user: CurrentUser) -> im
         organization: metadata.organization.clone(),
         // Compute payment_enabled based on whether payment_processor is configured
         payment_enabled: config.payment.is_some(),
+        // Lossy on paper, exact in practice: the ceiling is a whole-dollar
+        // marketing figure, and this value is only ever displayed or compared
+        // against zero - the money itself is matched in Decimal server-side.
+        first_payment_match_up_to: config.credits.first_payment_match_up_to.to_f64().unwrap_or(0.0),
         docs_url: metadata.docs_url.clone(),
         docs_jsonl_url: metadata.docs_jsonl_url.clone(),
         batches: batches_config,
@@ -117,7 +131,7 @@ pub async fn get_config(State(state): State<AppState>, _user: CurrentUser) -> im
 mod tests {
     use crate::Application;
     use crate::api::models::users::Role;
-    use crate::test::utils::{add_auth_headers, create_test_app, create_test_user};
+    use crate::test::utils::{add_auth_headers, create_test_app, create_test_app_with_config, create_test_config, create_test_user};
     use axum::http::StatusCode;
     use serde_json::Value;
     use sqlx::PgPool;
@@ -183,6 +197,50 @@ onwards:
         // Check that metadata fields are present
         assert!(json.get("region").is_some());
         assert!(json.get("organization").is_some());
+    }
+
+    /// The promotion ceiling has to reach the client, because the client is what
+    /// decides whether to advertise the promotion at all. Defaulting it off and
+    /// leaving the dashboard to assume a figure is how you end up promising a
+    /// match that `grant_first_payment_match` then declines to pay.
+    #[sqlx::test]
+    async fn test_get_config_exposes_the_first_payment_match_ceiling(pool: PgPool) {
+        let mut config = create_test_config();
+        config.credits.first_payment_match_up_to = rust_decimal::Decimal::new(50, 0);
+        let (app, _bg_services) = create_test_app_with_config(pool.clone(), config, false).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+
+        let headers = add_auth_headers(&user);
+        let response = app
+            .get("/admin/api/v1/config")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await;
+
+        response.assert_status(StatusCode::OK);
+        let json: Value = response.json();
+
+        assert_eq!(json.get("first_payment_match_up_to").and_then(|v| v.as_f64()), Some(50.0));
+    }
+
+    /// Off is the default, and it must be legible as off rather than absent -
+    /// a missing field reads as "old server" to a client, not "promo disabled".
+    #[sqlx::test]
+    async fn test_get_config_reports_a_disabled_promotion_as_zero(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+
+        let headers = add_auth_headers(&user);
+        let response = app
+            .get("/admin/api/v1/config")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await;
+
+        response.assert_status(StatusCode::OK);
+        let json: Value = response.json();
+
+        assert_eq!(json.get("first_payment_match_up_to").and_then(|v| v.as_f64()), Some(0.0));
     }
 
     #[sqlx::test]

--- a/dwctl/src/api/handlers/config.rs
+++ b/dwctl/src/api/handlers/config.rs
@@ -106,15 +106,28 @@ pub async fn get_config(State(state): State<AppState>, _user: CurrentUser) -> im
         None
     };
 
+    // Lossy on paper, exact in practice: the ceiling is a whole-dollar marketing
+    // figure, and this value is only ever displayed or compared against zero -
+    // the money itself is matched in Decimal server-side.
+    //
+    // Falling back to 0 turns the promotion off client-side, which is the safe
+    // direction, but 0 is also a legitimate configured value - so a caller
+    // can't tell a disabled promo from a broken conversion. Log it, or an
+    // unrepresentable ceiling silently reads as "no promotion" forever.
+    let match_ceiling = config.credits.first_payment_match_up_to.to_f64().unwrap_or_else(|| {
+        tracing::warn!(
+            configured = %config.credits.first_payment_match_up_to,
+            "credits.first_payment_match_up_to is not representable as f64; reporting the promotion as disabled"
+        );
+        0.0
+    });
+
     let response = ConfigResponse {
         region: metadata.region.clone(),
         organization: metadata.organization.clone(),
         // Compute payment_enabled based on whether payment_processor is configured
         payment_enabled: config.payment.is_some(),
-        // Lossy on paper, exact in practice: the ceiling is a whole-dollar
-        // marketing figure, and this value is only ever displayed or compared
-        // against zero - the money itself is matched in Decimal server-side.
-        first_payment_match_up_to: config.credits.first_payment_match_up_to.to_f64().unwrap_or(0.0),
+        first_payment_match_up_to: match_ceiling,
         docs_url: metadata.docs_url.clone(),
         docs_jsonl_url: metadata.docs_jsonl_url.clone(),
         batches: batches_config,

--- a/dwctl/src/api/handlers/users.rs
+++ b/dwctl/src/api/handlers/users.rs
@@ -264,6 +264,11 @@ pub async fn get_user<P: PoolProvider>(
             0.0
         });
         response = response.with_credit_balance(balance);
+        // Ships with the balance rather than behind its own `include`: every
+        // caller that cares (the first-payment-match banner) is already asking
+        // for billing, and the partial purchases index makes it a lookup.
+        let has_purchased = credits_repo.has_purchased(target_user_id).await?;
+        response = response.with_has_purchased(has_purchased);
     }
 
     // Include organizations if requested
@@ -632,7 +637,10 @@ mod tests {
     use crate::api::models::pagination::MAX_LIMIT;
     use crate::api::models::users::Role;
     use crate::db::handlers::{Credits, Groups, Repository};
-    use crate::db::models::{credits::CreditTransactionCreateDBRequest, groups::GroupCreateDBRequest};
+    use crate::db::models::{
+        credits::{CreditTransactionCreateDBRequest, CreditTransactionType},
+        groups::GroupCreateDBRequest,
+    };
     use crate::test::utils::*;
     use rust_decimal::Decimal;
     use serde_json::json;
@@ -1903,6 +1911,73 @@ mod tests {
         let balance: UserResponse = response.json();
         assert_eq!(balance.id, user.id);
         assert_eq!(balance.credit_balance, Some(150.0));
+    }
+
+    /// `has_purchased` is the ledger answer to "has this billing target already
+    /// had its first top-up?", which is what the first-payment-match promotion
+    /// is actually keyed on. It must not be confused with
+    /// `has_payment_provider_id`: an account that verified a card, or merely
+    /// tried to switch on auto top-up, has a provider record and no purchase,
+    /// and is still owed the match.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_billing_include_reports_first_purchase_state(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+
+        // An admin grant (signup credits) gives them a balance but no purchase.
+        create_initial_credit_transaction(&pool, user.id, "1.0").await;
+
+        let headers = add_auth_headers(&user);
+        let before: UserResponse = app
+            .get("/admin/api/v1/users/current?include=billing")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await
+            .json();
+        assert_eq!(before.credit_balance, Some(1.0));
+        assert_eq!(before.has_purchased, Some(false));
+
+        let mut conn = pool.acquire().await.unwrap();
+        Credits::new(&mut conn)
+            .create_transaction(&CreditTransactionCreateDBRequest {
+                user_id: user.id,
+                transaction_type: CreditTransactionType::Purchase,
+                amount: Decimal::from_str("30.0").unwrap(),
+                source_id: "sess-1".to_string(),
+                description: None,
+                fusillade_batch_id: None,
+                api_key_id: None,
+            })
+            .await
+            .expect("insert purchase");
+        drop(conn);
+
+        let after: UserResponse = app
+            .get("/admin/api/v1/users/current?include=billing")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await
+            .json();
+        assert_eq!(after.has_purchased, Some(true));
+    }
+
+    /// Absent without `include=billing`, so a caller can tell "not asked for"
+    /// apart from "asked for, and the answer is no".
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_first_purchase_state_is_omitted_without_the_billing_include(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let user = create_test_user(&pool, Role::StandardUser).await;
+
+        let response = app
+            .get("/admin/api/v1/users/current")
+            .add_header(&add_auth_headers(&user)[0].0, &add_auth_headers(&user)[0].1)
+            .add_header(&add_auth_headers(&user)[1].0, &add_auth_headers(&user)[1].1)
+            .await;
+
+        response.assert_status_ok();
+        assert_eq!(response.json::<UserResponse>().has_purchased, None);
     }
 
     // Test: GET /users/current/balance works for standard user with billing info

--- a/dwctl/src/api/handlers/users.rs
+++ b/dwctl/src/api/handlers/users.rs
@@ -96,12 +96,19 @@ pub async fn list_users<P: PoolProvider>(
     // Check if user has permission to view billing data (Credits ReadAll)
     let can_view_billing = permissions::has_permission(&current_user, Resource::Credits, Operation::ReadAll);
 
-    // If includes billing AND user has permission, create balances_map
-    let balances_map = if includes.contains(&"billing") && can_view_billing {
+    // If includes billing AND user has permission, create balances_map.
+    //
+    // Both billing facts are fetched together so `include=billing` means the
+    // same thing here as it does on the single-user GET - a caller shouldn't
+    // have to know which endpoint it asked to know which fields it gets. Both
+    // are bulk queries over the page's ids, not per-row lookups.
+    let (balances_map, purchased_ids) = if includes.contains(&"billing") && can_view_billing {
         let mut credits_repo = Credits::new(&mut conn);
-        Some(credits_repo.get_users_balances_bulk(&user_ids).await?)
+        let balances = credits_repo.get_users_balances_bulk(&user_ids).await?;
+        let purchased = credits_repo.has_purchased_bulk(&user_ids).await?;
+        (Some(balances), Some(purchased))
     } else {
-        None
+        (None, None)
     };
 
     // If includes groups, make groups_map and user_groups_map
@@ -145,6 +152,10 @@ pub async fn list_users<P: PoolProvider>(
         if let Some(balances_map) = &balances_map {
             let balance = balances_map.get(&response_user.id).and_then(|b| b.to_f64()).unwrap_or(0.0);
             response_user = response_user.with_credit_balance(balance);
+        }
+        if let Some(purchased_ids) = &purchased_ids {
+            let has_purchased = purchased_ids.contains(&response_user.id);
+            response_user = response_user.with_has_purchased(has_purchased);
         }
 
         response_users.push(response_user);
@@ -643,7 +654,7 @@ mod tests {
     };
     use crate::test::utils::*;
     use rust_decimal::Decimal;
-    use serde_json::json;
+    use serde_json::{Value, json};
     use sqlx::PgPool;
     use std::collections::HashSet;
     use std::str::FromStr;
@@ -1960,6 +1971,52 @@ mod tests {
             .await
             .json();
         assert_eq!(after.has_purchased, Some(true));
+    }
+
+    /// `include=billing` has to mean the same thing on the list endpoint as it
+    /// does on the single-user one, or callers can't rely on it at all.
+    #[sqlx::test]
+    #[test_log::test]
+    async fn test_list_users_billing_include_reports_first_purchase_state(pool: PgPool) {
+        let (app, _bg_services) = create_test_app(pool.clone(), false).await;
+        let admin = create_test_user(&pool, Role::PlatformManager).await;
+        let buyer = create_test_user(&pool, Role::StandardUser).await;
+        let non_buyer = create_test_user(&pool, Role::StandardUser).await;
+
+        let mut conn = pool.acquire().await.unwrap();
+        Credits::new(&mut conn)
+            .create_transaction(&CreditTransactionCreateDBRequest {
+                user_id: buyer.id,
+                transaction_type: CreditTransactionType::Purchase,
+                amount: Decimal::from_str("30.0").unwrap(),
+                source_id: "sess-1".to_string(),
+                description: None,
+                fusillade_batch_id: None,
+                api_key_id: None,
+            })
+            .await
+            .expect("insert purchase");
+        drop(conn);
+
+        let headers = add_auth_headers(&admin);
+        let response = app
+            .get("/admin/api/v1/users?include=billing&limit=100")
+            .add_header(&headers[0].0, &headers[0].1)
+            .add_header(&headers[1].0, &headers[1].1)
+            .await;
+
+        response.assert_status_ok();
+        let body: Value = response.json();
+        let rows = body["data"].as_array().expect("data array");
+
+        let purchased_for = |id: UserId| -> Option<bool> {
+            rows.iter()
+                .find(|r| r["id"].as_str() == Some(&id.to_string()))
+                .and_then(|r| r["has_purchased"].as_bool())
+        };
+
+        assert_eq!(purchased_for(buyer.id), Some(true));
+        assert_eq!(purchased_for(non_buyer.id), Some(false));
     }
 
     /// Absent without `include=billing`, so a caller can tell "not asked for"

--- a/dwctl/src/api/models/users.rs
+++ b/dwctl/src/api/models/users.rs
@@ -125,6 +125,17 @@ pub struct UserResponse {
     /// User's credit balance (only included if `include=billing` is specified)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credit_balance: Option<f64>,
+    /// Whether this billing target has ever completed a purchase (only included
+    /// if `include=billing` is specified).
+    ///
+    /// This is the ledger truth behind the first-payment-match promotion: the
+    /// match is granted exactly when no earlier `purchase` exists for the
+    /// target. Clients gating on "has this account already had its first
+    /// top-up?" must read this rather than `has_payment_provider_id`, which is
+    /// true for accounts that only verified a card or merely attempted to turn
+    /// on auto top-up.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_purchased: Option<bool>,
     /// Indicates whether this user has an associated payment provider customer record.
     ///
     /// Note: This field replaces the previous `payment_provider_id` response field to avoid
@@ -260,6 +271,7 @@ impl From<UserDBResponse> for UserResponse {
             last_login: db.last_login,
             groups: None,         // By default, relationships are not included
             credit_balance: None, // By default, credit balances are not included
+            has_purchased: None,  // Ditto: only populated for include=billing
             has_payment_provider_id: db.payment_provider_id.as_ref().is_some_and(|s| !s.is_empty()),
             batch_notifications_enabled: db.batch_notifications_enabled,
             low_balance_threshold: db.low_balance_threshold,
@@ -288,6 +300,12 @@ impl UserResponse {
     /// Create a response with credit balance included
     pub fn with_credit_balance(mut self, balance: f64) -> Self {
         self.credit_balance = Some(balance);
+        self
+    }
+
+    /// Create a response with the first-purchase flag included
+    pub fn with_has_purchased(mut self, has_purchased: bool) -> Self {
+        self.has_purchased = Some(has_purchased);
         self
     }
 

--- a/dwctl/src/db/handlers/credits.rs
+++ b/dwctl/src/db/handlers/credits.rs
@@ -203,6 +203,40 @@ impl<'c> Credits<'c> {
         })
     }
 
+    /// Has this billing target ever completed a purchase?
+    ///
+    /// The read-side counterpart of [`Self::grant_first_payment_match`]: that
+    /// method decides eligibility from the absence of a prior `purchase` row,
+    /// and this answers the same question for callers that need to know
+    /// *before* any money moves - notably the dashboard's first-deposit-match
+    /// banner, which must not advertise a promotion the ledger will refuse.
+    ///
+    /// Deliberately not `has_payment_provider_id`: a payment-provider customer
+    /// record is created by setup-mode card verification and by
+    /// `POST /auto-topup/enable` (even on the `needs_billing_portal` bail-out),
+    /// so it goes true for accounts that have never bought anything and would
+    /// hide the promotion from people still entitled to it.
+    ///
+    /// Served by the partial `idx_credits_transactions_user_purchases` index
+    /// (migration 100), so it stays a direct lookup no matter how many `usage`
+    /// rows the target has accumulated.
+    #[instrument(skip(self), fields(user_id = %abbrev_uuid(&user_id)), err)]
+    pub async fn has_purchased(&mut self, user_id: UserId) -> Result<bool> {
+        let purchased = sqlx::query_scalar!(
+            r#"
+            SELECT EXISTS (
+                SELECT 1 FROM credits_transactions
+                WHERE user_id = $1 AND transaction_type = 'purchase'
+            ) AS "purchased!"
+            "#,
+            user_id
+        )
+        .fetch_one(&mut *self.db)
+        .await?;
+
+        Ok(purchased)
+    }
+
     /// Grant a first-payment match bonus to `payee` if eligible.
     ///
     /// The promotion matches a user's first ever payment with bonus credits, up
@@ -2202,6 +2236,65 @@ mod tests {
         .fetch_optional(pool)
         .await
         .expect("query bonus")
+    }
+
+    #[sqlx::test]
+    async fn test_has_purchased_is_false_before_any_purchase(pool: PgPool) {
+        let user = create_test_user(&pool).await;
+        let mut conn = pool.acquire().await.unwrap();
+        let mut credits = Credits::new(&mut conn);
+
+        assert!(!credits.has_purchased(user).await.unwrap());
+
+        insert_purchase(&mut credits, user, "30.0", "sess-1").await;
+
+        assert!(credits.has_purchased(user).await.unwrap());
+    }
+
+    #[sqlx::test]
+    async fn test_has_purchased_ignores_grants_and_usage(pool: PgPool) {
+        // The regression this guards: signup credits and a verified card both
+        // give an account a balance and a payment-provider record without a
+        // purchase, and the first-payment match is still owed to them.
+        let user = create_test_user(&pool).await;
+        let mut conn = pool.acquire().await.unwrap();
+        let mut credits = Credits::new(&mut conn);
+
+        for (transaction_type, source_id) in [
+            (CreditTransactionType::AdminGrant, "signup-credits"),
+            (CreditTransactionType::Usage, "some-request"),
+            (CreditTransactionType::AdminRemoval, "clawback"),
+        ] {
+            credits
+                .create_transaction(&CreditTransactionCreateDBRequest {
+                    user_id: user,
+                    transaction_type,
+                    amount: Decimal::from_str("1.0").unwrap(),
+                    source_id: source_id.to_string(),
+                    description: None,
+                    fusillade_batch_id: None,
+                    api_key_id: None,
+                })
+                .await
+                .unwrap();
+        }
+
+        assert!(!credits.has_purchased(user).await.unwrap());
+    }
+
+    #[sqlx::test]
+    async fn test_has_purchased_is_scoped_to_the_billing_target(pool: PgPool) {
+        // An org admin paying for their org must not lose their own personal
+        // eligibility, and vice versa - the two are separate billing targets.
+        let payer = create_test_user(&pool).await;
+        let other = create_test_user(&pool).await;
+        let mut conn = pool.acquire().await.unwrap();
+        let mut credits = Credits::new(&mut conn);
+
+        insert_purchase(&mut credits, payer, "30.0", "sess-1").await;
+
+        assert!(credits.has_purchased(payer).await.unwrap());
+        assert!(!credits.has_purchased(other).await.unwrap());
     }
 
     #[sqlx::test]

--- a/dwctl/src/db/handlers/credits.rs
+++ b/dwctl/src/db/handlers/credits.rs
@@ -13,7 +13,7 @@ use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, PgConnection};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tracing::{instrument, trace};
 use uuid::Uuid;
 
@@ -235,6 +235,34 @@ impl<'c> Credits<'c> {
         .await?;
 
         Ok(purchased)
+    }
+
+    /// Which of `user_ids` have ever completed a purchase?
+    ///
+    /// Bulk form of [`Self::has_purchased`], for the list endpoints - one
+    /// query for the page rather than one per row. Returns only the ids that
+    /// have purchased; absent means no purchase, so callers test membership.
+    ///
+    /// `DISTINCT` rather than a count: we only need the boolean, and stopping
+    /// at existence keeps this on the partial purchases index.
+    #[instrument(skip(self, user_ids), fields(count = user_ids.len()), err)]
+    pub async fn has_purchased_bulk(&mut self, user_ids: &[UserId]) -> Result<HashSet<UserId>> {
+        if user_ids.is_empty() {
+            return Ok(HashSet::new());
+        }
+
+        let rows = sqlx::query_scalar!(
+            r#"
+            SELECT DISTINCT user_id AS "user_id!"
+            FROM credits_transactions
+            WHERE user_id = ANY($1::uuid[]) AND transaction_type = 'purchase'
+            "#,
+            user_ids
+        )
+        .fetch_all(&mut *self.db)
+        .await?;
+
+        Ok(rows.into_iter().collect())
     }
 
     /// Grant a first-payment match bonus to `payee` if eligible.

--- a/dwctl/src/test/utils.rs
+++ b/dwctl/src/test/utils.rs
@@ -515,6 +515,7 @@ pub async fn get_system_user(pool: &mut PgConnection) -> UserResponse {
         external_user_id: None,
         groups: None, // Groups not included in test users by default
         credit_balance: None,
+        has_purchased: None,
         has_payment_provider_id: false,
         batch_notifications_enabled: false,
         low_balance_threshold: None,
@@ -706,6 +707,7 @@ pub async fn create_test_org(pool: &PgPool, created_by: UserId) -> UserResponse 
         external_user_id: None,
         groups: None,
         credit_balance: None,
+        has_purchased: None,
         has_payment_provider_id: false,
         batch_notifications_enabled: false,
         low_balance_threshold: None,


### PR DESCRIPTION
## Why

The first-payment match is granted iff the billing target has no earlier `purchase` row — see `grant_first_payment_match` and the `credits.first_payment_match_up_to` doc comment. Nothing exposed that fact to clients, so the dashboard's promo banner gated on `has_payment_provider_id` instead.

Those are different questions. dwctl creates a payment-provider customer record in three places that move no money:

- `POST /payments/setup` — setup-mode card verification (onboarding's "add a payment method")
- `POST /auto-topup/enable` — creates the customer *before* checking for a card, and persists it even on the `needs_billing_portal` bail-out
- the completed-checkout path, which writes the id to `creditor_id` while the purchase row and the match go to `creditee_id`

So the flag goes true for accounts that have never bought anything and are still owed the match. The promotion was being hidden from exactly the people it was aimed at. `verified` has the same problem and is not a substitute.

## What

- `Credits::has_purchased()` — the read-side counterpart of `grant_first_payment_match`, running the same predicate. Served by the existing partial `idx_credits_transactions_user_purchases` index (migration 100), so it stays a direct lookup regardless of how many `usage` rows the target has. No new migration.
- `has_purchased` on `UserResponse`, populated under `include=billing` alongside `credit_balance`. Optional and omitted otherwise, so a caller can tell "not asked for" from "asked for, and the answer is no".
- `first_payment_match_up_to` on `/config`. It defaults to 0 (promotion off), and a client with no way to read it can only hard-code an amount and hope — which is how you end up advertising a match the ledger then declines to pay.

## Testing

7 new tests. The ones that matter: `has_purchased` ignores admin grants, usage and removals (signup credits and a verified card both give an account a balance with no purchase); it is scoped per billing target, so an org admin paying for their org keeps their own personal eligibility; and `/config` reports a disabled promotion as an explicit `0` rather than omitting the field.

Clippy and `cargo fmt` are clean locally. I ran the new tests plus the credits repo suite; the broader handler-module sweep is left to CI.

## Rollout

The dashboard side is doublewordai/app-doubleword-private#214. This one has to land and deploy first — until it does, the field is absent, which the client treats as unknown and hides the banner. Safe, but the promo is dark in that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)