### PR TITLE
feat(auth): make the active-organization cookie name configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -156,6 +156,20 @@ auth:
       cookie_name: "dwctl_session"
       cookie_secure: true
       cookie_same_site: "strict"
+      # Cookie carrying the caller's active organization.
+      #
+      # Give this a distinct value per environment whenever several
+      # deployments share a parent domain and cookie_domain is set. A cookie
+      # scoped to `.example.com` is offered to every host beneath it, so a
+      # staging or second-region deployment receives the neighbouring
+      # deployment's copy alongside its own — under the same name, in the same
+      # Cookie header. Same-name cookies are ordered by path length then
+      # creation time (RFC 6265 §5.4); domain specificity is not a tiebreaker,
+      # so the winner is whichever the user acquired first. Narrowing
+      # cookie_domain cannot prevent this: a parent-domain cookie always
+      # reaches its subdomains. Only a distinct name gives each deployment its
+      # own slot.
+      org_cookie_name: "dw_active_org"
     password_reset_token_duration: "30m"
 
   # Proxy header authentication

--- a/dwctl/src/api/handlers/auth.rs
+++ b/dwctl/src/api/handlers/auth.rs
@@ -374,8 +374,8 @@ pub async fn logout<P: PoolProvider>(State(state): State<AppState<P>>) -> Result
 
     // Also clear the active organization cookie
     let org_cookie = format!(
-        "dw_active_org=; Path=/; HttpOnly{}{}; SameSite={}; Max-Age=0",
-        secure, domain, session_config.cookie_same_site
+        "{}=; Path=/; HttpOnly{}{}; SameSite={}; Max-Age=0",
+        session_config.org_cookie_name, secure, domain, session_config.cookie_same_site
     );
 
     let auth_response = AuthSuccessResponse {

--- a/dwctl/src/api/handlers/organizations.rs
+++ b/dwctl/src/api/handlers/organizations.rs
@@ -2010,7 +2010,8 @@ pub async fn create_user_join_request<P: PoolProvider>(
 
 /// Validate and confirm an active organization context.
 ///
-/// Sets a `dw_active_org` cookie so the browser sends it automatically with all
+/// Sets the org cookie (`auth.native.session.org_cookie_name`, default
+/// `dw_active_org`) so the browser sends it automatically with all
 /// subsequent requests.  CLI tools can still use the `X-Organization-Id` header.
 #[utoipa::path(
     post,
@@ -2049,7 +2050,7 @@ pub async fn set_active_organization<P: PoolProvider>(
         }
     }
 
-    // Build the dw_active_org cookie using the same security settings as the session cookie
+    // Build the org cookie using the same security settings as the session cookie
     let config = state.current_config();
     let session_config = &config.auth.native.session;
     let secure = if session_config.cookie_secure { "; Secure" } else { "" };
@@ -2058,10 +2059,12 @@ pub async fn set_active_organization<P: PoolProvider>(
         .as_ref()
         .map(|d| format!("; Domain={d}"))
         .unwrap_or_default();
+    let org_cookie_name = &session_config.org_cookie_name;
     let cookie = if let Some(org_id) = data.organization_id {
         // Set cookie with long max-age (30 days) — cleared explicitly when switching back
         format!(
-            "dw_active_org={}; Path=/; HttpOnly{}{}; SameSite={}; Max-Age={}",
+            "{}={}; Path=/; HttpOnly{}{}; SameSite={}; Max-Age={}",
+            org_cookie_name,
             org_id,
             secure,
             domain,
@@ -2071,8 +2074,8 @@ pub async fn set_active_organization<P: PoolProvider>(
     } else {
         // Clear cookie
         format!(
-            "dw_active_org=; Path=/; HttpOnly{}{}; SameSite={}; Max-Age=0",
-            secure, domain, session_config.cookie_same_site
+            "{}=; Path=/; HttpOnly{}{}; SameSite={}; Max-Age=0",
+            org_cookie_name, secure, domain, session_config.cookie_same_site
         )
     };
 

--- a/dwctl/src/api/models/auth.rs
+++ b/dwctl/src/api/models/auth.rs
@@ -99,7 +99,7 @@ impl IntoResponse for LoginResponse {
 pub struct LogoutResponse {
     pub auth_response: AuthSuccessResponse,
     pub cookie: String,
-    /// Additional cookies to clear (e.g. dw_active_org)
+    /// Additional cookies to clear (e.g. the org cookie)
     pub extra_cookies: Vec<String>,
 }
 

--- a/dwctl/src/auth/current_user.rs
+++ b/dwctl/src/auth/current_user.rs
@@ -514,8 +514,9 @@ impl FromRequestParts<AppState> for HasApiKey {
 pub const ORGANIZATION_HEADER: &str = "x-organization-id";
 
 /// Populate organization context on an authenticated user.
-/// Reads the `X-Organization-Id` header and queries the user's org memberships.
-async fn populate_org_context(user: &mut CurrentUser, parts: &Parts, db: &PgPool) {
+/// Reads the org cookie (`org_cookie_name`, falling back to the
+/// `X-Organization-Id` header) and queries the user's org memberships.
+async fn populate_org_context(user: &mut CurrentUser, parts: &Parts, db: &PgPool, org_cookie_name: &str) {
     // Query all organizations the user belongs to
     let mut conn = match db.acquire().await {
         Ok(conn) => conn,
@@ -576,9 +577,15 @@ async fn populate_org_context(user: &mut CurrentUser, parts: &Parts, db: &PgPool
         }
     }
 
-    // Read active organization from dw_active_org cookie, falling back to X-Organization-Id header.
+    // Read active organization from the org cookie, falling back to X-Organization-Id header.
     // The cookie is set by POST /session/organization and sent automatically by the browser.
     // The header is used by CLI tools and API clients without access to an API key (likely none).
+    //
+    // The name is configurable (`auth.native.session.org_cookie_name`) because
+    // this takes the FIRST match in the header: environments sharing a parent
+    // domain otherwise deliver two same-named cookies here and the winner is
+    // decided by acquisition order, not by which host the request reached.
+    let org_cookie_prefix = format!("{org_cookie_name}=");
     let org_id_str = parts
         .headers
         .get_all("cookie")
@@ -587,7 +594,7 @@ async fn populate_org_context(user: &mut CurrentUser, parts: &Parts, db: &PgPool
         .flat_map(|s| s.split(';'))
         .find_map(|cookie| {
             let cookie = cookie.trim();
-            cookie.strip_prefix("dw_active_org=").filter(|v| !v.is_empty())
+            cookie.strip_prefix(&org_cookie_prefix).filter(|v| !v.is_empty())
         })
         .map(String::from)
         .or_else(|| {
@@ -649,12 +656,16 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
         let mut auth_errors = Vec::new();
         let mut any_auth_attempted = false;
 
+        // Read once up front: every auth path below needs the org cookie name.
+        let config = state.current_config();
+        let org_cookie_name = config.auth.native.session.org_cookie_name.clone();
+
         // Try API key authentication first (most specific)
         match try_api_key_auth(parts, state.db.read()).await {
             Some(Ok((mut user, last_login))) => {
                 debug!("Authentication successful via API key");
                 trace!("Authenticated user: {}", user.id);
-                populate_org_context(&mut user, parts, state.db.read()).await;
+                populate_org_context(&mut user, parts, state.db.read(), &org_cookie_name).await;
                 maybe_update_last_login(user.id, last_login, state.db.write());
                 return Ok(user);
             }
@@ -669,13 +680,12 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
         }
 
         // Native authentication (JWT sessions)
-        let config = state.current_config();
         if config.auth.native.enabled {
             match try_jwt_session_auth(parts, &config, state.db.read()).await {
                 Some(Ok((mut user, last_login))) => {
                     debug!("Authentication successful via JWT session");
                     trace!("Authenticated user: {}", user.id);
-                    populate_org_context(&mut user, parts, state.db.read()).await;
+                    populate_org_context(&mut user, parts, state.db.read(), &org_cookie_name).await;
                     maybe_update_last_login(user.id, last_login, state.db.write());
                     return Ok(user);
                 }
@@ -696,7 +706,7 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
                 Some(Ok((mut user, last_login))) => {
                     debug!("Authentication successful via proxy header");
                     trace!("Authenticated user: {}", user.id);
-                    populate_org_context(&mut user, parts, state.db.read()).await;
+                    populate_org_context(&mut user, parts, state.db.read(), &org_cookie_name).await;
                     maybe_update_last_login(user.id, last_login, state.db.write());
                     return Ok(user);
                 }

--- a/dwctl/src/auth/current_user.rs
+++ b/dwctl/src/auth/current_user.rs
@@ -585,7 +585,6 @@ async fn populate_org_context(user: &mut CurrentUser, parts: &Parts, db: &PgPool
     // this takes the FIRST match in the header: environments sharing a parent
     // domain otherwise deliver two same-named cookies here and the winner is
     // decided by acquisition order, not by which host the request reached.
-    let org_cookie_prefix = format!("{org_cookie_name}=");
     let org_id_str = parts
         .headers
         .get_all("cookie")
@@ -593,8 +592,14 @@ async fn populate_org_context(user: &mut CurrentUser, parts: &Parts, db: &PgPool
         .filter_map(|v| v.to_str().ok())
         .flat_map(|s| s.split(';'))
         .find_map(|cookie| {
-            let cookie = cookie.trim();
-            cookie.strip_prefix(&org_cookie_prefix).filter(|v| !v.is_empty())
+            // Split the name and the `=` rather than formatting a joined prefix:
+            // this runs on every authenticated request, and the joined form would
+            // allocate a String per request to compare against.
+            cookie
+                .trim()
+                .strip_prefix(org_cookie_name)
+                .and_then(|rest| rest.strip_prefix('='))
+                .filter(|v| !v.is_empty())
         })
         .map(String::from)
         .or_else(|| {
@@ -657,15 +662,17 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
         let mut any_auth_attempted = false;
 
         // Read once up front: every auth path below needs the org cookie name.
+        // Borrowed from the config snapshot rather than cloned — this is the
+        // per-request authentication path.
         let config = state.current_config();
-        let org_cookie_name = config.auth.native.session.org_cookie_name.clone();
+        let org_cookie_name = config.auth.native.session.org_cookie_name.as_str();
 
         // Try API key authentication first (most specific)
         match try_api_key_auth(parts, state.db.read()).await {
             Some(Ok((mut user, last_login))) => {
                 debug!("Authentication successful via API key");
                 trace!("Authenticated user: {}", user.id);
-                populate_org_context(&mut user, parts, state.db.read(), &org_cookie_name).await;
+                populate_org_context(&mut user, parts, state.db.read(), org_cookie_name).await;
                 maybe_update_last_login(user.id, last_login, state.db.write());
                 return Ok(user);
             }
@@ -685,7 +692,7 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
                 Some(Ok((mut user, last_login))) => {
                     debug!("Authentication successful via JWT session");
                     trace!("Authenticated user: {}", user.id);
-                    populate_org_context(&mut user, parts, state.db.read(), &org_cookie_name).await;
+                    populate_org_context(&mut user, parts, state.db.read(), org_cookie_name).await;
                     maybe_update_last_login(user.id, last_login, state.db.write());
                     return Ok(user);
                 }
@@ -706,7 +713,7 @@ impl<P: sqlx_pool_router::PoolProvider + Clone + Send + Sync> FromRequestParts<c
                 Some(Ok((mut user, last_login))) => {
                     debug!("Authentication successful via proxy header");
                     trace!("Authenticated user: {}", user.id);
-                    populate_org_context(&mut user, parts, state.db.read(), &org_cookie_name).await;
+                    populate_org_context(&mut user, parts, state.db.read(), org_cookie_name).await;
                     maybe_update_last_login(user.id, last_login, state.db.write());
                     return Ok(user);
                 }

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -805,6 +805,19 @@ pub struct SessionConfig {
     pub cookie_same_site: String,
     /// Optional Domain attribute for cookies (e.g. ".doubleword.ai" for cross-subdomain)
     pub cookie_domain: Option<String>,
+    /// Cookie name carrying the caller's active organization.
+    ///
+    /// Deployments that share a parent domain must give this a distinct value
+    /// per environment. A cookie set with `Domain=.example.com` is offered by
+    /// the browser to *every* host under that parent, so a staging or
+    /// second-region host sitting beside production receives production's copy
+    /// as well as its own. Both arrive under the same name in one `Cookie`
+    /// header, and same-name cookies are ordered by path length then creation
+    /// time (RFC 6265 §5.4) — domain specificity is not a tiebreaker — so which
+    /// one wins is decided by whichever the user happened to acquire first.
+    /// `cookie_domain` cannot prevent this from either side; only a distinct
+    /// name gives each environment its own slot.
+    pub org_cookie_name: String,
 }
 
 /// Password validation rules.
@@ -2911,6 +2924,7 @@ impl Default for SessionConfig {
             cookie_secure: true,
             cookie_same_site: "strict".to_string(),
             cookie_domain: None,
+            org_cookie_name: "dw_active_org".to_string(),
         }
     }
 }
@@ -3325,6 +3339,23 @@ impl Config {
                     operation: format!("Config validation: cookie_domain '{domain}' produces an invalid HTTP header value."),
                 });
             }
+        }
+
+        // Validate org_cookie_name — it is interpolated straight into a Set-Cookie
+        // header and matched as a `<name>=` prefix when reading, so it must be a
+        // bare RFC 6265 token.
+        let org_cookie_name = &self.auth.native.session.org_cookie_name;
+        let invalid_name = org_cookie_name.is_empty()
+            || org_cookie_name
+                .chars()
+                .any(|c| !c.is_ascii() || c.is_ascii_control() || c.is_whitespace() || "()<>@,;:\\\"/[]?={}".contains(c));
+        if invalid_name {
+            return Err(Error::Internal {
+                operation: format!(
+                    "Config validation: Invalid org_cookie_name '{org_cookie_name}'. \
+                     Must be a non-empty RFC 6265 cookie name (no whitespace, control characters, or separators)."
+                ),
+            });
         }
 
         // Validate CORS configuration
@@ -4655,6 +4686,60 @@ auth:
 
             Ok(())
         });
+    }
+
+    #[test]
+    fn test_org_cookie_name_defaults_and_env_override() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "test.yaml",
+                r#"
+secret_key: "test-secret-key"
+auth:
+  native:
+    session:
+      cookie_domain: ".doubleword.ai"
+"#,
+            )?;
+
+            let args = Args {
+                config: "test.yaml".into(),
+                validate: false,
+            };
+
+            // Unset, the name is the historical hard-coded one, so production
+            // keeps working without pinning it.
+            let config = Config::load(&args)?;
+            assert_eq!(config.auth.native.session.org_cookie_name, "dw_active_org");
+
+            // Environments sharing the parent domain override it so prod's
+            // cookie cannot occupy their slot.
+            jail.set_env("DWCTL_AUTH__NATIVE__SESSION__ORG_COOKIE_NAME", "dw_active_org_staging");
+            let config = Config::load(&args)?;
+            assert_eq!(config.auth.native.session.org_cookie_name, "dw_active_org_staging");
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_invalid_org_cookie_name_rejected() {
+        // The names we actually deploy raise no org_cookie_name complaint.
+        for good in ["dw_active_org", "dw_active_org_staging", "dw_active_org_us", "dw_active_org_cl-1234"] {
+            let mut config = Config::default();
+            config.auth.native.session.org_cookie_name = good.to_string();
+            let complaint = config.validate().err().map(|e| e.to_string()).unwrap_or_default();
+            assert!(!complaint.contains("org_cookie_name"), "expected {good:?} to be accepted, got: {complaint}");
+        }
+
+        // Empty, whitespace and RFC 6265 separators would all produce a
+        // malformed Set-Cookie header or a prefix that never matches on read.
+        for bad in ["", "dw active org", "dw_active_org;", "dw=active", "dw_active_org\n", "dw_active_org\u{e9}"] {
+            let mut config = Config::default();
+            config.auth.native.session.org_cookie_name = bad.to_string();
+            let error = config.validate().unwrap_err().to_string();
+            assert!(error.contains("org_cookie_name"), "expected {bad:?} to be rejected, got: {error}");
+        }
     }
 
     #[test]

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -4725,16 +4725,31 @@ auth:
     #[test]
     fn test_invalid_org_cookie_name_rejected() {
         // The names we actually deploy raise no org_cookie_name complaint.
-        for good in ["dw_active_org", "dw_active_org_staging", "dw_active_org_us", "dw_active_org_cl-1234"] {
+        for good in [
+            "dw_active_org",
+            "dw_active_org_staging",
+            "dw_active_org_us",
+            "dw_active_org_cl-1234",
+        ] {
             let mut config = Config::default();
             config.auth.native.session.org_cookie_name = good.to_string();
             let complaint = config.validate().err().map(|e| e.to_string()).unwrap_or_default();
-            assert!(!complaint.contains("org_cookie_name"), "expected {good:?} to be accepted, got: {complaint}");
+            assert!(
+                !complaint.contains("org_cookie_name"),
+                "expected {good:?} to be accepted, got: {complaint}"
+            );
         }
 
         // Empty, whitespace and RFC 6265 separators would all produce a
         // malformed Set-Cookie header or a prefix that never matches on read.
-        for bad in ["", "dw active org", "dw_active_org;", "dw=active", "dw_active_org\n", "dw_active_org\u{e9}"] {
+        for bad in [
+            "",
+            "dw active org",
+            "dw_active_org;",
+            "dw=active",
+            "dw_active_org\n",
+            "dw_active_org\u{e9}",
+        ] {
             let mut config = Config::default();
             config.auth.native.session.org_cookie_name = bad.to_string();
             let error = config.validate().unwrap_err().to_string();

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -4724,6 +4724,17 @@ auth:
 
     #[test]
     fn test_invalid_org_cookie_name_rejected() {
+        // `validate` returns on its FIRST complaint, and a bare `Config::default()`
+        // trips the missing-secret_key check well before it reaches the cookie
+        // name. Give it enough to get that far, or every case below passes for
+        // the wrong reason.
+        fn config_with_org_cookie_name(name: &str) -> Config {
+            let mut config = Config::default();
+            config.secret_key = Some("test-secret-key".to_string());
+            config.auth.native.session.org_cookie_name = name.to_string();
+            config
+        }
+
         // The names we actually deploy raise no org_cookie_name complaint.
         for good in [
             "dw_active_org",
@@ -4731,9 +4742,11 @@ auth:
             "dw_active_org_us",
             "dw_active_org_cl-1234",
         ] {
-            let mut config = Config::default();
-            config.auth.native.session.org_cookie_name = good.to_string();
-            let complaint = config.validate().err().map(|e| e.to_string()).unwrap_or_default();
+            let complaint = config_with_org_cookie_name(good)
+                .validate()
+                .err()
+                .map(|e| e.to_string())
+                .unwrap_or_default();
             assert!(
                 !complaint.contains("org_cookie_name"),
                 "expected {good:?} to be accepted, got: {complaint}"
@@ -4750,9 +4763,7 @@ auth:
             "dw_active_org\n",
             "dw_active_org\u{e9}",
         ] {
-            let mut config = Config::default();
-            config.auth.native.session.org_cookie_name = bad.to_string();
-            let error = config.validate().unwrap_err().to_string();
+            let error = config_with_org_cookie_name(bad).validate().unwrap_err().to_string();
             assert!(error.contains("org_cookie_name"), "expected {bad:?} to be rejected, got: {error}");
         }
     }


### PR DESCRIPTION
## Why

The org cookie's name was hard-coded as `dw_active_org` in three places: the read in `populate_org_context` (`dwctl/src/auth/current_user.rs`), the write in `set_active_organization` (`organizations.rs`), and the clear on logout (`auth.rs`). That is a problem for any deployment running several environments under one parent domain.

`cookie_domain` is commonly set to something like `.example.com` so that an app host and an API host can share org context. **A cookie scoped to a parent domain is offered by the browser to every host beneath it, and that is not configurable from the receiving side** — so a staging or second-region deployment sitting alongside production receives production's cookie as well as its own. Both arrive under the same name in one `Cookie` header, and the read here takes the first match:

    let org_id_str = parts.headers.get_all("cookie")
        ...
        .find_map(|cookie| cookie.strip_prefix("dw_active_org=")...)

Same-name cookies are ordered by path length and then **creation time** (RFC 6265 §5.4) — domain specificity is not a tiebreaker. So the winner is decided by which environment the user happened to sign in to first, not by which host the request actually reached. Worse, clearing the cookie on the narrower host cannot dislodge the parent-domain one, because `Set-Cookie` with `Max-Age=0` only clears the cookie matching the domain it is sent with.

Narrowing `cookie_domain` does not help: a parent-domain cookie always reaches its subdomains, so there is no domain arrangement that isolates environments sharing a parent. Only a distinct name gives each deployment its own slot.

## What

`auth.native.session.org_cookie_name`, defaulting to `dw_active_org`.

- Threaded through the read path as a new `populate_org_context` argument. The config read moves to the top of `from_request_parts` so the API-key branch (which runs before the previous `state.current_config()` call) can see it.
- Used by both write paths.
- Validated as a bare RFC 6265 token — the value is interpolated straight into a `Set-Cookie` header and matched as a `<name>=` prefix on read, so an empty string, whitespace, or a separator character would produce either a malformed header or a prefix that never matches.

Existing deployments are unaffected and need not set anything; the default is the name that was previously hard-coded.

## Tests

Two added in `config.rs`:

- `test_org_cookie_name_defaults_and_env_override` — the default is the historical name, and `DWCTL_AUTH__NATIVE__SESSION__ORG_COOKIE_NAME` overrides it.
- `test_invalid_org_cookie_name_rejected` — accepts the names we deploy (including a hyphenated per-preview one), rejects empty, whitespace, `;`, `=`, a newline, and a non-ASCII character.

Existing handler tests build request cookies with the literal `dw_active_org` against a default config, so they continue to exercise the default path unchanged.

## Deployment note

dwctl uses `deny_unknown_fields`, so this field crash-loops any image predating it. Deployments pinning `org_cookie_name` must be on a release carrying it. Anything that leaves it unset is decoupled from this release entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)