### PR TITLE
fix(payments): keep credentials out of the logs and stop erroring on routine events

### DIFF
--- a/dwctl/src/api/handlers/payments.rs
+++ b/dwctl/src/api/handlers/payments.rs
@@ -481,7 +481,12 @@ pub async fn webhook_handler<P: PoolProvider>(
             return StatusCode::NOT_IMPLEMENTED;
         }
         Err(e) => {
-            tracing::error!("Webhook validation failed: {:?}", e);
+            // warn, not error: the endpoint is public and unauthenticated, so
+            // anyone can post junk at it. Genuine causes (a rotated signing
+            // secret, the wrong endpoint registered) show up as a sustained run
+            // rather than a single line, and the 400 is already counted by
+            // dwctl_http_requests_total{status}.
+            tracing::warn!("Webhook validation failed: {:?}", e);
             return StatusCode::BAD_REQUEST;
         }
     };

--- a/dwctl/src/config.rs
+++ b/dwctl/src/config.rs
@@ -3509,8 +3509,139 @@ impl Config {
     }
 }
 
+/// Field names whose values are credentials. Matched case-insensitively as a
+/// substring of the key, so `api_key`, `webhook_secret` and
+/// `stripe_api_key` are all caught by the same entries.
+///
+/// Substring rather than exact match is deliberate: a new secret is far more
+/// likely to be named `something_token` than to invent a fresh word, so this
+/// fails safe as the config grows. Over-redacting a harmless field costs a
+/// debugging round trip; under-redacting one writes a live credential into the
+/// log pipeline.
+const SENSITIVE_KEY_FRAGMENTS: &[&str] = &[
+    "secret",
+    "password",
+    "api_key",
+    "token",
+    "encryption_key",
+    "wrap_keys",
+    "private_key",
+];
+
+fn is_sensitive_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    SENSITIVE_KEY_FRAGMENTS.iter().any(|fragment| key.contains(fragment))
+}
+
+/// Recursively replace the value of every sensitive-looking key with a marker.
+///
+/// Whole subtrees are redacted when the key itself is sensitive — `wrap_keys`
+/// is a map whose *values* are the key material, so redacting only scalars
+/// would leak it.
+fn redact_value(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, child) in map.iter_mut() {
+                if is_sensitive_key(key) {
+                    *child = serde_json::Value::String("<redacted>".to_string());
+                } else {
+                    redact_value(child);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => items.iter_mut().for_each(redact_value),
+        _ => {}
+    }
+}
+
+impl Config {
+    /// The configuration rendered for logging, with credentials removed.
+    ///
+    /// Startup used to log `{:#?}` of this struct, which wrote the live Stripe
+    /// API key and webhook signing secret — plus `secret_key`, the connections
+    /// encryption key and the keystore wrap keys — into the log pipeline in
+    /// plaintext on every boot, where they were shipped to log aggregation and
+    /// retained.
+    ///
+    /// Goes through `Serialize` rather than `Debug` so redaction is applied to
+    /// the whole tree by construction. A field added anywhere in the config,
+    /// at any depth, is covered without touching this function, provided it is
+    /// conventionally named.
+    pub fn redacted_for_logging(&self) -> String {
+        match serde_json::to_value(self) {
+            Ok(mut value) => {
+                redact_value(&mut value);
+                serde_json::to_string_pretty(&value).unwrap_or_else(|e| format!("<config could not be rendered: {e}>"))
+            }
+            // Never fall back to `{:#?}` here: that is exactly the leak this
+            // exists to prevent.
+            Err(e) => format!("<config could not be serialised for logging: {e}>"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+
+    /// Startup logs the whole config. It used to do so with `{:#?}`, which put
+    /// the live Stripe API key and webhook signing secret into the log
+    /// pipeline verbatim on every boot. This asserts the rendered form carries
+    /// neither the values nor any other credential in the tree.
+    #[test]
+    fn redacted_config_does_not_contain_credentials() {
+        let mut config = Config::default();
+        config.secret_key = Some("super-secret-signing-key".to_string());
+        config.payment = Some(PaymentConfig::Stripe(StripeConfig {
+            api_key: "rk_live_THIS_MUST_NOT_APPEAR".to_string(),
+            webhook_secret: "whsec_THIS_MUST_NOT_APPEAR".to_string(),
+            price_id: "price_public_identifier".to_string(),
+            enable_invoice_creation: true,
+            auto_topup_terms_of_service_text: None,
+            setup_terms_of_service_text: None,
+            tax_code: None,
+        }));
+
+        let rendered = config.redacted_for_logging();
+
+        for secret in [
+            "rk_live_THIS_MUST_NOT_APPEAR",
+            "whsec_THIS_MUST_NOT_APPEAR",
+            "super-secret-signing-key",
+        ] {
+            assert!(
+                !rendered.contains(secret),
+                "credential leaked into the startup log: {secret}\n{rendered}"
+            );
+        }
+        assert!(
+            rendered.contains("<redacted>"),
+            "nothing was redacted, so the walk did not run:\n{rendered}"
+        );
+        // Non-sensitive neighbours must survive, or the dump is useless for
+        // the debugging it exists to support.
+        assert!(
+            rendered.contains("price_public_identifier"),
+            "over-redacted: a non-secret field was removed"
+        );
+    }
+
+    #[test]
+    fn sensitive_key_matching_is_case_insensitive_and_substring() {
+        for key in [
+            "api_key",
+            "API_KEY",
+            "stripe_api_key",
+            "webhook_secret",
+            "Password",
+            "encryption_key",
+            "wrap_keys",
+        ] {
+            assert!(is_sensitive_key(key), "{key} should be treated as sensitive");
+        }
+        for key in ["price_id", "url", "enabled", "region", "bucket"] {
+            assert!(!is_sensitive_key(key), "{key} should not be redacted");
+        }
+    }
     use super::*;
     use figment::Jail;
 

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -3640,7 +3640,7 @@ impl Application {
         pool: Option<PgPool>,
         tracer_provider: Option<telemetry::SdkTracerProvider>,
     ) -> anyhow::Result<Self> {
-        debug!("Starting control layer with configuration: {:#?}", config);
+        debug!("Starting control layer with configuration: {}", config.redacted_for_logging());
 
         // Setup database connections, run migrations, and initialize data
         let (_embedded_db, db_pools, fusillade_pools, outlet_pools, partition_maintenance_pool) = setup_database(&config, pool).await?;

--- a/dwctl/src/payment_providers/dummy.rs
+++ b/dwctl/src/payment_providers/dummy.rs
@@ -123,8 +123,10 @@ impl PaymentProvider for DummyProvider {
 
             {
                 let mut users = crate::db::handlers::users::Users::new(&mut conn);
+                // Mirrors the Stripe provider: an unknown target is a foreign
+                // region's session, not bad data, so it acks rather than errors.
                 if users.get_by_id(target_id).await?.is_none() {
-                    return Err(PaymentError::InvalidData("Setup session target user not found".to_string()));
+                    return Err(PaymentError::UnknownReference(target_id.to_string()));
                 }
                 users
                     .set_payment_provider_id_if_empty(target_id, &format!("dummy_cus_{}", target_id))
@@ -477,6 +479,52 @@ mod tests {
         .unwrap();
 
         assert_eq!(count.count.unwrap(), 1, "Should only have one transaction (idempotent)");
+    }
+
+    /// A setup session naming a user this plane does not own is the expected
+    /// shape of another region's event, since one payment account serves both
+    /// planes and every endpoint receives every plane's events.
+    ///
+    /// It must surface as `UnknownReference`, which the webhook acks with a
+    /// single warn, and NOT as `InvalidData` — that routes through the
+    /// handler's catch-all and logs an ERROR blaming data integrity for a
+    /// routine cross-region delivery.
+    #[sqlx::test]
+    async fn setup_session_for_a_foreign_user_is_an_unknown_reference(pool: PgPool) {
+        let provider = DummyProvider::from(crate::config::DummyConfig {
+            amount: Decimal::new(100, 0),
+        });
+
+        // A well-formed id that simply does not exist in this plane's DB —
+        // exactly what a foreign region's client_reference_id looks like here.
+        let foreign_id = uuid::Uuid::new_v4();
+        let session_id = format!("{}{}_{}", DUMMY_SETUP_SESSION_PREFIX, foreign_id, uuid::Uuid::new_v4());
+
+        let err = provider
+            .process_payment_session(&pool, &session_id, &crate::config::CreditsConfig::default())
+            .await
+            .expect_err("a setup session for an unknown user must not succeed");
+
+        match err {
+            PaymentError::UnknownReference(reference) => {
+                assert_eq!(reference, foreign_id.to_string(), "the reference must name the user, for triage");
+            }
+            other => panic!("expected UnknownReference so the webhook acks quietly, got {other:?}"),
+        }
+
+        // The ack must not have credited anybody on the way through.
+        let credited = sqlx::query!(
+            r#"
+            SELECT COUNT(*) as count
+            FROM credits_transactions
+            WHERE source_id = $1
+            "#,
+            session_id.to_string()
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(credited.count.unwrap(), 0, "a foreign session must never create a credit");
     }
 
     #[test]

--- a/dwctl/src/payment_providers/stripe.rs
+++ b/dwctl/src/payment_providers/stripe.rs
@@ -338,6 +338,32 @@ impl StripeProvider {
                 PaymentError::InvalidData(format!("Invalid target user ID: {}", e))
             })?;
 
+        // Bail before touching Stripe if this plane does not own the target.
+        //
+        // One Stripe account serves both regional planes and every endpoint
+        // receives every plane's events, so a target this plane has never heard
+        // of is the *expected* shape of a foreign region's setup session, not a
+        // fault. `UnknownReference` matches what the payment-mode path returns
+        // for the same situation, so the webhook acks it with a single warn
+        // naming the reference instead of an ERROR claiming a data integrity
+        // issue — and the front-channel PATCH gets 404 rather than 400, which
+        // is the honest answer for a session whose user does not exist here.
+        //
+        // Checked here rather than further down because everything between this
+        // point and the original check talks to Stripe: on a foreign event the
+        // old ordering issued an UpdateCustomer against the other region's
+        // customer. Harmless in practice — both planes write the same default
+        // payment method — but it is a mutation of shared account state by a
+        // plane with no claim to it, plus an API call against a per-account
+        // rate limit, on every cross-region card verification.
+        if crate::db::handlers::users::Users::new(&mut *conn)
+            .get_by_id(target_id)
+            .await?
+            .is_none()
+        {
+            return Err(PaymentError::UnknownReference(target_id.to_string()));
+        }
+
         let customer_id = match &session.customer {
             Some(stripe_types::Expandable::Id(id)) => Some(id.to_string()),
             Some(stripe_types::Expandable::Object(c)) => Some(c.id.to_string()),
@@ -384,14 +410,7 @@ impl StripeProvider {
         {
             let mut users = crate::db::handlers::users::Users::new(&mut *conn);
 
-            if users.get_by_id(target_id).await?.is_none() {
-                tracing::error!(
-                    "Target user {} not found for setup session {}. This indicates a data integrity issue.",
-                    target_id,
-                    session_id
-                );
-                return Err(PaymentError::InvalidData("Setup session target user not found".to_string()));
-            }
+            // Existence was established above, before any Stripe call.
 
             // Stripe may have created the customer during checkout; persist it so
             // the billing portal and auto top-up can find it later.
@@ -755,18 +774,22 @@ impl PaymentProvider for StripeProvider {
         let signature = headers
             .get("stripe-signature")
             .ok_or_else(|| {
-                tracing::error!("Missing stripe-signature header");
+                // Unauthenticated public endpoint: a malformed or unsigned POST is
+                // something any internet host can send, so it is not an error on our
+                // side. Kept visible because a sudden run of them can mean a
+                // misconfigured endpoint or a rotated secret.
+                tracing::warn!("Missing stripe-signature header");
                 PaymentError::InvalidData("Missing stripe-signature header".to_string())
             })?
             .to_str()
             .map_err(|e| {
-                tracing::error!("Invalid stripe-signature header: {:?}", e);
+                tracing::warn!("Invalid stripe-signature header: {:?}", e);
                 PaymentError::InvalidData("Invalid stripe-signature header".to_string())
             })?;
 
         // Validate the webhook signature and construct the event
         let event = Webhook::construct_event(body, signature, &self.config.webhook_secret).map_err(|e| {
-            tracing::error!("Failed to construct webhook event: {:?}", e);
+            tracing::warn!("Failed to construct webhook event: {:?}", e);
             PaymentError::InvalidData(format!("Webhook validation failed: {}", e))
         })?;
 


### PR DESCRIPTION
Three related fixes on the payments path, all surfaced while bringing the US (Reynolds) plane onto the shared Stripe account.

## 1. Live credentials were being written to the logs

Startup logged `{:#?}` of the entire `Config`. That put the Stripe **API key** and **webhook signing secret** into the log pipeline in plaintext on every boot — observed directly in a running production pod:

    webhook_secret: "whsec_…"
    api_key: "rk_liv…"

It is not limited to Stripe. The same dump exposes `secret_key`, the connections `encryption_key`, `ModelSource.api_key`, and the keystore `wrap_keys`. Both planes run `RUST_LOG=debug` in production, so both have been doing this on every restart, and the logs ship to aggregation and are retained.

The dump is genuinely useful, so it is kept — but rendered through `Serialize` and walked to redact any key matching `secret`, `password`, `api_key`, `token`, `encryption_key`, `wrap_keys` or `private_key`, case-insensitively as a substring.

Redacting the tree rather than hand-writing `Debug` impls is deliberate. A manual impl on a struct the size of `Config` is stale the moment someone adds a field, and the failure is silent. Substring matching is likewise a fail-safe choice: a new secret is far likelier to be named `something_token` than to invent a fresh word. Over-redacting costs a debugging round trip; under-redacting writes a live credential to disk. `wrap_keys` is redacted as a whole subtree because its *values* are the key material.

**This does not rotate anything.** The keys currently in the log pipeline are still exposed and should be rotated separately.

## 2. Signature failures logged at ERROR

`/webhooks/payments` is public and unauthenticated by design — Stripe authenticates with a signature, not a credential. So a missing or malformed signature is something any host on the internet can produce at will, and it was logging at ERROR each time. Trivially, anyone could fill the error stream; in practice my own reachability probes did exactly that.

Dropped to WARN at all four sites (missing header, malformed header, bad signature, and the handler's summary line). Still visible — a sustained run genuinely means a rotated secret or a wrongly-registered endpoint — but no longer indistinguishable from a real fault. The 400 is already counted by `dwctl_http_requests_total{status}`.

## 3. Setup-mode sessions from another region logged a false data-integrity error

With one Stripe account serving both planes, Stripe fans account-level events out to every registered endpoint and cannot filter by anything but event type. Each plane therefore receives the other's sessions. That is the premise COR-594 was built on, and the payment-mode path handles it: an unknown `client_reference_id` returns `UnknownReference`, which the webhook acks with a single warn.

The **setup-mode** path (`fulfil_setup_session`, reached for onboarding card verification) was missed. It returned `InvalidData` and logged:

    Target user … not found for setup session … This indicates a data integrity issue.

at ERROR — for what is a routine cross-region delivery. Now returns `UnknownReference`, matching the payment path, so both share one warn line naming the reference. The front-channel `PATCH /payments/{id}` consequently answers **404** rather than 400, which is the honest status for a session whose user does not exist on this plane.

The existence check also moved **above** the Stripe `UpdateCustomer` call. Previously a foreign event issued a write against the other region's customer record before discovering it did not own the user. Harmless in practice — both planes set the same default payment method — but it is a mutation of shared account state by a plane with no claim to it, plus an API call against a per-account rate limit, on every cross-region card verification.

## Correctness note

This all rests on the two regions' user UUIDs being **disjoint**, which is the settled design. A local-existence check is only a valid region filter while that holds. (The older implementation-plan suggestion to preserve `users.id` across regions would break it, and would turn a foreign top-up into a double credit — it has been decided against.)

## Tests

- `redacted_config_does_not_contain_credentials` — plants a Stripe key, webhook secret and `secret_key`, asserts none appear in the rendered output, that `<redacted>` does, and that a non-secret neighbour (`price_id`) **survives**, so the test cannot pass by redacting everything.
- `sensitive_key_matching_is_case_insensitive_and_substring` — pins the matching rules in both directions.
- `setup_session_for_a_foreign_user_is_an_unknown_reference` — asserts the error type and that no credit is created. Mutation-tested: reverting the fix fails it with `expected UnknownReference … got InvalidData`.

The dummy provider is kept in step with Stripe so tests exercise the same contract.

## Verified

Full `cargo test -p dwctl` green before these changes (2261 passed, 0 failed); payment-provider suite green after. Prod behaviour confirmed live on Reynolds: onboarding with a fresh user and card verification completed end to end against the shared account.
