### PR TITLE
fix(onwards): drain active responses during shutdown

### DIFF
--- a/.github/scripts/openresponses-compliance.mjs
+++ b/.github/scripts/openresponses-compliance.mjs
@@ -1,0 +1,24 @@
+// Keep the upstream runner and validators, but make the tool-call request
+// match its assertion. With the default `auto`, a clarification is valid and
+// model behaviour can fail CI even when the protocol implementation is correct.
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const root = resolve(process.env.OPENRESPONSES_DIR ?? "/tmp/openresponses");
+const { testTemplates } = await import(
+  pathToFileURL(`${root}/src/lib/compliance-tests.ts`).href
+);
+const template = testTemplates.find((test) => test.id === "tool-calling");
+if (!template) {
+  throw new Error(
+    "Upstream tool-calling test is missing; review the CI adapter",
+  );
+}
+const getRequest = template.getRequest;
+template.getRequest = (config) => ({
+  ...getRequest(config),
+  tool_choice: "required",
+});
+
+// The CLI imports the same module instance and reads the original argv flags.
+await import(pathToFileURL(`${root}/bin/compliance-test.ts`).href);

--- a/.github/scripts/openresponses-compliance.test.mjs
+++ b/.github/scripts/openresponses-compliance.test.mjs
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const root = resolve(process.env.OPENRESPONSES_DIR ?? "/tmp/openresponses");
+const { testTemplates } = await import(
+  pathToFileURL(`${root}/src/lib/compliance-tests.ts`).href
+);
+const fixture = testTemplates
+  .find((template) => template.id === "response-output-phase-schema")
+  .getMockResponse({ model: "fixture-model" });
+
+async function run(output, invalidSchema = false) {
+  const requests = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const body = await request.json();
+      requests.push({
+        body,
+        path: new URL(request.url).pathname,
+        auth: request.headers.get("authorization"),
+      });
+      const response = {
+        ...fixture,
+        output: body.tools ? output : fixture.output,
+      };
+      if (invalidSchema) response.created_at = "invalid";
+      return Response.json(response);
+    },
+  });
+  const child = Bun.spawn({
+    cmd: [
+      process.execPath,
+      "run",
+      resolve(import.meta.dir, "openresponses-compliance.mjs"),
+      "--base-url",
+      `http://127.0.0.1:${server.port}/v1`,
+      "--api-key",
+      "fixture-key",
+      "--model",
+      "fixture-model",
+      "--filter",
+      "basic-response,tool-calling",
+      "--json",
+    ],
+    env: { ...process.env, OPENRESPONSES_DIR: root },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const timeout = setTimeout(() => child.kill(), 10_000);
+  try {
+    const [status, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    expect(stderr).toBe("");
+    return { status, results: JSON.parse(stdout), requests };
+  } finally {
+    clearTimeout(timeout);
+    child.kill();
+    server.stop(true);
+  }
+}
+
+const toolOutput = [
+  {
+    id: "fc_fixture",
+    type: "function_call",
+    status: "completed",
+    call_id: "call_fixture",
+    name: "get_weather",
+    arguments: '{"location":"San Francisco, CA"}',
+  },
+];
+
+test("real upstream CLI sends required tool choice and preserves the other case and flags", async () => {
+  const { status, results, requests } = await run(toolOutput);
+  expect(status).toBe(0);
+  expect(results.summary.passed).toBe(2);
+  expect(requests).toHaveLength(2);
+  const tool = requests.find(({ body }) => body.tools);
+  const original = testTemplates
+    .find((template) => template.id === "tool-calling")
+    .getRequest({ model: "fixture-model" });
+  expect(tool.body).toEqual({ ...original, tool_choice: "required" });
+  expect(
+    requests.find(({ body }) => !body.tools).body.tool_choice,
+  ).toBeUndefined();
+  for (const request of requests) {
+    expect(request.path).toBe("/v1/responses");
+    expect(request.auth).toBe("Bearer fixture-key");
+  }
+});
+
+test("unchanged validators still reject a message instead of a tool call", async () => {
+  const { status, results } = await run(fixture.output);
+  expect(status).toBe(1);
+  expect(
+    results.results.find((result) => result.id === "tool-calling").errors,
+  ).toContain('Expected output item of type "function_call" but none found');
+});
+
+test("unchanged schema validation still rejects malformed responses", async () => {
+  const { status, results } = await run(toolOutput, true);
+  expect(status).toBe(1);
+  expect(results.summary.failed).toBe(2);
+  expect(
+    results.results.every((result) =>
+      result.errors.some((error) => error.startsWith("created_at:")),
+    ),
+  ).toBe(true);
+});

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -957,7 +957,7 @@ jobs:
           exit 1
 
       - name: Checkout code
-        if: env.RUN_COMPLIANCE == 'true' && matrix.surface == 'onwards-passthrough'
+        if: env.RUN_COMPLIANCE == 'true'
         uses: actions/checkout@v6
 
       - name: Install Rust

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1022,6 +1022,10 @@ jobs:
         if: env.RUN_COMPLIANCE == 'true'
         run: cd /tmp/openresponses && bun install
 
+      - name: Test compliance runner adapter
+        if: env.RUN_COMPLIANCE == 'true'
+        run: bun test ./.github/scripts/openresponses-compliance.test.mjs
+
       - name: Run compliance tests
         if: env.RUN_COMPLIANCE == 'true'
         run: |
@@ -1034,7 +1038,7 @@ jobs:
           echo
 
           set +e
-          bun run bin/compliance-test.ts \
+          bun run "${GITHUB_WORKSPACE}/.github/scripts/openresponses-compliance.mjs" \
             --base-url "${COMPLIANCE_BASE_URL}" \
             --api-key "${COMPLIANCE_API_KEY}" \
             --model "${TEST_MODEL}" \
@@ -1083,7 +1087,7 @@ jobs:
               echo
               echo "=== Retry failed test(s): ${failed_filters} ==="
               set +e
-              bun run bin/compliance-test.ts \
+              bun run "${GITHUB_WORKSPACE}/.github/scripts/openresponses-compliance.mjs" \
                 --base-url "${COMPLIANCE_BASE_URL}" \
                 --api-key "${COMPLIANCE_API_KEY}" \
                 --model "${TEST_MODEL}" \
@@ -1116,7 +1120,7 @@ jobs:
               else
                 echo
                 echo "=== Verbose rerun of failed test(s): ${failed_filters} ==="
-                bun run bin/compliance-test.ts \
+                bun run "${GITHUB_WORKSPACE}/.github/scripts/openresponses-compliance.mjs" \
                   --base-url "${COMPLIANCE_BASE_URL}" \
                   --api-key "${COMPLIANCE_API_KEY}" \
                   --model "${TEST_MODEL}" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwctl"
-version = "11.4.1"
+version = "11.4.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4341,6 +4341,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rand 0.9.4",
+ "reqwest",
  "rstest",
  "serde",
  "serde_json",

--- a/onwards/Cargo.toml
+++ b/onwards/Cargo.toml
@@ -43,6 +43,7 @@ tokio = { version = "1.45.1", features = [
   "fs",
   "sync",
   "time",
+  "signal",
 ] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1.41"
@@ -65,3 +66,5 @@ futures-util = "0.3"
 rstest = "0.26.1"
 tower = "0.5"
 wiremock = "0.6"
+reqwest = { version = "0.13", features = ["json", "stream"] }
+tokio = { version = "1.45.1", features = ["process", "io-util"] }

--- a/onwards/README.md
+++ b/onwards/README.md
@@ -54,6 +54,7 @@ curl -X POST http://localhost:3000/v1/chat/completions \
 - Strict mode for request validation and error standardization
 - Response sanitization for OpenAI schema compliance
 - Prometheus metrics
+- Graceful standalone gateway shutdown, with readiness withdrawal and streaming response drain
 - Custom response headers
 
 ## Performance Tuning

--- a/onwards/docs/src/SUMMARY.md
+++ b/onwards/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Quickstart](quickstart.md)
 - [Configuration](configuration.md)
 - [Command Line Options](cli.md)
+- [Graceful Shutdown](shutdown.md)
 - [API Usage](api-usage.md)
 
 # Features

--- a/onwards/docs/src/cli.md
+++ b/onwards/docs/src/cli.md
@@ -6,8 +6,14 @@
 | `--port <port>` | Port to listen on | `3000` |
 | `--watch` | Enable configuration file watching for hot-reloading | `true` |
 | `--metrics` | Enable Prometheus metrics endpoint | `true` |
-| `--metrics-port <port>` | Port for Prometheus metrics | `9090` |
+| `--metrics-port <port>` | Port for metrics and `/healthz`, `/readyz` | `9090` |
 | `--metrics-prefix <prefix>` | Prefix for metric names | `onwards` |
+| `--shutdown-delay-secs <seconds>` | Continue serving after readiness fails, before closing admission | `5` |
+| `--shutdown-timeout-secs <seconds>` | Deadline for draining accepted requests after closing admission; must be positive | `300` |
+
+The shutdown settings also accept `ONWARDS_SHUTDOWN_DELAY_SECS` and
+`ONWARDS_SHUTDOWN_TIMEOUT_SECS`. See [Graceful shutdown](shutdown.md) for the
+signal sequence, health probes and Kubernetes termination budget.
 
 ## Examples
 

--- a/onwards/docs/src/shutdown.md
+++ b/onwards/docs/src/shutdown.md
@@ -1,0 +1,83 @@
+# Graceful shutdown
+
+The standalone `onwards` binary handles SIGTERM and SIGINT using Axum's
+`with_graceful_shutdown`. Applications embedding the Onwards library still
+own their HTTP server and its shutdown policy.
+
+On receipt of a signal:
+
+1. `/readyz` on the metrics port changes from HTTP 200 to HTTP 503.
+2. For `--shutdown-delay-secs` (default 5), requests continue to be served
+   while load balancers observe the readiness change.
+3. Axum stops accepting new proxy connections, closes idle keep-alive
+   connections, and waits for accepted requests and response bodies to finish.
+   An SSE response keeps the process alive until its body ends, even though
+   its headers were sent earlier.
+4. Metrics and `/healthz` remain available while the proxy drains. When the
+   proxy finishes, the metrics server closes and tracing is flushed.
+
+If draining exceeds `--shutdown-timeout-secs` (default 300), the process
+logs the timeout and exits unsuccessfully. Remaining streams are cut off;
+this is a forced termination, not a successful drain. The metrics server
+has a separate five-second shutdown ceiling after the proxy stops.
+
+Use HTTP probes on the metrics port, not TCP probes on the proxy listener:
+
+```yaml
+terminationGracePeriodSeconds: 360
+containers:
+  - name: onwards
+    # Pin the release containing this feature, or its immutable image digest.
+    args:
+      - --targets
+      - /etc/onwards/targets.json
+      - --shutdown-delay-secs
+      - "5"
+      - --shutdown-timeout-secs
+      - "300"
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: 9090
+      periodSeconds: 2
+      failureThreshold: 1
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 9090
+```
+
+The pod's termination budget must exceed the propagation delay, proxy drain,
+metrics shutdown and tracing flush. Set it using the request durations your
+service supports. The example allows 55 seconds beyond the default 305-second
+propagation-plus-drain budget. The propagation delay replaces a sleep-only
+`preStop` hook; adding such a hook would consume extra time before SIGTERM.
+The health routes reveal only process readiness/liveness, are unauthenticated,
+and should remain internal alongside metrics. Readiness does not test every
+configured upstream model.
+
+Do not apply a normal rolling update to old gateway versions that lack this
+behavior while they have active streams. Create a separate deployment and
+Service, move callers to its distinct hostname without restarting them,
+then verify the old gateways have no new requests and zero in-flight work
+before retiring them. Merely changing a Service selector does not move
+established connections. Validate client configuration propagation and retry
+behavior in a rehearsal before using this procedure in production.
+
+After all replicas support draining, use required pod anti-affinity on
+`kubernetes.io/hostname`, a suitable PodDisruptionBudget, and enough spare
+capacity for rolling updates. These controls and signal handling do not
+preserve TCP streams through an abrupt node failure.
+
+The Unix integration tests start the actual binary and a gated HTTP backend.
+They cover SSE completion across SIGTERM, a unary request still waiting for
+headers, deadline expiry with a stuck stream, and idle HTTP/1.1 keep-alive
+closure on SIGINT. They use synthetic traffic and do not terminate production
+pods. Run them with:
+
+```bash
+cargo test --package onwards --test graceful_shutdown
+```
+
+See [Axum's server API](https://docs.rs/axum/latest/axum/serve/struct.Serve.html#method.with_graceful_shutdown)
+and [Kubernetes pod termination](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination).

--- a/onwards/src/config.rs
+++ b/onwards/src/config.rs
@@ -13,7 +13,7 @@ pub struct Config {
     #[arg(short = 'p', long, default_value_t = 3000)]
     pub port: u16,
 
-    /// The port on which the metrics server will listen.
+    /// The port for metrics and the /healthz and /readyz probes.
     #[arg(long, default_value_t = 9090)]
     pub metrics_port: u16,
 
@@ -32,6 +32,15 @@ pub struct Config {
     /// The prefix to use for metrics.
     #[arg(long, default_value = "onwards")]
     pub metrics_prefix: String,
+
+    /// Seconds to continue serving after readiness fails, before closing admission.
+    #[arg(long, env = "ONWARDS_SHUTDOWN_DELAY_SECS", default_value_t = 5)]
+    pub shutdown_delay_secs: u64,
+
+    /// Maximum seconds to drain accepted requests after closing admission.
+    #[arg(long, env = "ONWARDS_SHUTDOWN_TIMEOUT_SECS", default_value_t = 300,
+          value_parser = clap::value_parser!(u64).range(1..))]
+    pub shutdown_timeout_secs: u64,
 }
 
 impl Config {

--- a/onwards/src/main.rs
+++ b/onwards/src/main.rs
@@ -8,8 +8,10 @@ use onwards::{
     target::{Targets, WatchedFile},
     telemetry,
 };
-use tokio::{net::TcpListener, task::JoinSet};
-use tracing::{error, info, instrument};
+use tokio::net::TcpListener;
+use tracing::{info, instrument};
+
+mod server;
 #[tokio::main]
 #[instrument]
 pub async fn main() -> anyhow::Result<()> {
@@ -46,21 +48,18 @@ async fn run() -> anyhow::Result<()> {
             .await?;
     }
 
-    let mut serves = JoinSet::new();
+    // Install OS signal handlers before opening either listener.
+    let shutdown_signal = server::shutdown_signal()?;
     // If we are running with metrics enabled, set up the metrics layer and router.
-    let prometheus_layer = if config.metrics {
+    let (prometheus_layer, metrics_router) = if config.metrics {
         let (prometheus_layer, prometheus_handle) =
             build_metrics_layer_and_handle(config.metrics_prefix.clone());
 
         let metrics_router = build_metrics_router(prometheus_handle);
-        let bind_addr = format!("0.0.0.0:{}", config.metrics_port);
-        let listener = TcpListener::bind(&bind_addr).await?;
-        serves.spawn(axum::serve(listener, metrics_router).into_future());
-        info!("Metrics endpoint enabled on {}", bind_addr);
-        Some(prometheus_layer)
+        (Some(prometheus_layer), metrics_router)
     } else {
         info!("Metrics endpoint disabled");
-        None
+        (None, Router::new())
     };
 
     // Register the sanitizer globally - per-target sanitize_response flag controls when it's applied
@@ -84,14 +83,18 @@ async fn run() -> anyhow::Result<()> {
     };
     let bind_addr = format!("0.0.0.0:{}", config.port);
     let listener = TcpListener::bind(&bind_addr).await?;
-    serves.spawn(axum::serve(listener, router).into_future());
+    let metrics_addr = format!("0.0.0.0:{}", config.metrics_port);
+    let metrics_listener = TcpListener::bind(&metrics_addr).await?;
     info!("AI Gateway listening on {}", bind_addr);
+    info!("Metrics and health endpoint listening on {}", metrics_addr);
 
-    // Wait for all servers to complete
-    if let Some(result) = serves.join_next().await {
-        result?.map_err(anyhow::Error::from)
-    } else {
-        error!("No server tasks were spawned");
-        Err(anyhow::anyhow!("No server tasks were spawned"))
-    }
+    server::serve(
+        listener,
+        router,
+        metrics_listener,
+        metrics_router,
+        &config,
+        shutdown_signal,
+    )
+    .await
 }

--- a/onwards/src/server.rs
+++ b/onwards/src/server.rs
@@ -1,0 +1,163 @@
+//! Lifecycle of the standalone gateway. Library consumers own their own server.
+//!
+//! Readiness fails first, then the proxy closes its listener and drains HTTP
+//! connections through Axum/Hyper. The metrics listener stays up until proxy
+//! response bodies finish, so scrapes and liveness probes cannot end the drain.
+
+use std::{
+    future::Future,
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use anyhow::{Context, anyhow};
+use axum::{Router, http::StatusCode, routing::get};
+use onwards::config::Config;
+#[cfg(unix)]
+use tokio::signal::unix::{SignalKind, signal};
+use tokio::{
+    net::TcpListener,
+    sync::oneshot,
+    time::{sleep, timeout},
+};
+use tracing::{info, warn};
+
+#[cfg(unix)]
+/// Register termination signals before opening the listening sockets.
+pub fn shutdown_signal() -> io::Result<impl Future<Output = io::Result<()>>> {
+    let mut terminate = signal(SignalKind::terminate())?;
+    let mut interrupt = signal(SignalKind::interrupt())?;
+    Ok(async move {
+        tokio::select! {
+            _ = terminate.recv() => {},
+            _ = interrupt.recv() => {},
+        }
+        Ok(())
+    })
+}
+
+#[cfg(not(unix))]
+/// Listen for the platform's console interrupt signal.
+pub fn shutdown_signal() -> io::Result<impl Future<Output = io::Result<()>>> {
+    Ok(tokio::signal::ctrl_c())
+}
+
+/// Serve both listeners, retaining health and metrics until Axum drains the proxy.
+pub async fn serve(
+    listener: TcpListener,
+    router: Router,
+    metrics_listener: TcpListener,
+    metrics_router: Router,
+    config: &Config,
+    shutdown_signal: impl Future<Output = io::Result<()>>,
+) -> anyhow::Result<()> {
+    let ready = Arc::new(AtomicBool::new(true));
+    let readiness = ready.clone();
+    let metrics_router = metrics_router
+        .route("/healthz", get(|| async { StatusCode::OK }))
+        .route(
+            "/readyz",
+            get(move || {
+                let readiness = readiness.clone();
+                async move {
+                    if readiness.load(Ordering::Acquire) {
+                        (StatusCode::OK, "ready")
+                    } else {
+                        (StatusCode::SERVICE_UNAVAILABLE, "draining")
+                    }
+                }
+            }),
+        );
+
+    let (stop_proxy, proxy_stopped) = oneshot::channel();
+    let mut proxy = tokio::spawn(
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async {
+                let _ = proxy_stopped.await;
+            })
+            .into_future(),
+    );
+    let (stop_metrics, metrics_stopped) = oneshot::channel();
+    let mut metrics = tokio::spawn(
+        axum::serve(metrics_listener, metrics_router)
+            .with_graceful_shutdown(async {
+                let _ = metrics_stopped.await;
+            })
+            .into_future(),
+    );
+
+    let mut metrics_finished = false;
+    let trigger = tokio::select! {
+        result = shutdown_signal => result.context("shutdown signal listener failed"),
+        result = &mut proxy => {
+            metrics.abort();
+            result.context("proxy server task failed")??;
+            return Err(anyhow!("proxy server stopped unexpectedly"));
+        },
+        result = &mut metrics => {
+            metrics_finished = true;
+            Err(anyhow!("metrics server stopped unexpectedly: {result:?}"))
+        },
+    };
+
+    ready.store(false, Ordering::Release);
+    info!(
+        delay_secs = config.shutdown_delay_secs,
+        "Gateway draining; readiness withdrawn"
+    );
+    // Kubernetes removes the pod from its Service while existing connections
+    // continue to work during endpoint propagation. Do not reject them with 503.
+    sleep(Duration::from_secs(config.shutdown_delay_secs)).await;
+    let _ = stop_proxy.send(());
+    info!(
+        timeout_secs = config.shutdown_timeout_secs,
+        "Closing proxy admission; waiting for response streams"
+    );
+
+    // Axum waits for connection tasks, including streaming bodies, not merely
+    // for handlers to produce headers. It also closes idle keep-alive sockets.
+    let drained = match timeout(
+        Duration::from_secs(config.shutdown_timeout_secs),
+        &mut proxy,
+    )
+    .await
+    {
+        Ok(result) => result
+            .context("proxy server task failed while draining")
+            .and_then(|result| result.context("proxy server failed while draining")),
+        Err(_) => {
+            proxy.abort();
+            warn!(
+                timeout_secs = config.shutdown_timeout_secs,
+                "Gateway drain deadline exceeded; terminating active streams"
+            );
+            Err(anyhow!(
+                "gateway drain deadline exceeded after {} seconds",
+                config.shutdown_timeout_secs
+            ))
+        }
+    };
+    if drained.is_ok() {
+        info!("Gateway request drain complete");
+    }
+
+    let _ = stop_metrics.send(());
+    let metrics_result = if metrics_finished {
+        Ok(())
+    } else {
+        match timeout(Duration::from_secs(5), &mut metrics).await {
+            Ok(result) => result
+                .context("metrics server task failed")
+                .and_then(|result| result.context("metrics server failed")),
+            Err(_) => {
+                metrics.abort();
+                Err(anyhow!("metrics server shutdown deadline exceeded"))
+            }
+        }
+    };
+    trigger.and(drained).and(metrics_result)
+}

--- a/onwards/tests/graceful_shutdown.rs
+++ b/onwards/tests/graceful_shutdown.rs
@@ -1,0 +1,351 @@
+//! Exercise the real gateway process, OS signals and proxied response bodies.
+#![cfg(unix)]
+
+use std::{
+    convert::Infallible,
+    fs,
+    net::SocketAddr,
+    path::PathBuf,
+    process::{ExitStatus, Stdio},
+    sync::Arc,
+    time::Duration,
+};
+
+use axum::{Json, Router, body::Body, extract::State, response::Response, routing::post};
+use futures_util::StreamExt;
+use reqwest::{Client, StatusCode};
+use serde_json::{Value, json};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    process::{Child, Command},
+    sync::Semaphore,
+    task::JoinHandle,
+    time::{sleep, timeout},
+};
+use uuid::Uuid;
+
+const FIRST: &str = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"first\"},\"finish_reason\":null}]}\n\n";
+const LAST: &str = "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n";
+
+struct Engine {
+    started: Semaphore,
+    finish: Semaphore,
+}
+
+async fn completion(State(engine): State<Arc<Engine>>, Json(request): Json<Value>) -> Response {
+    engine.started.add_permits(1);
+    if request["stream"] == true {
+        let stream = async_stream::stream! {
+            yield Ok::<_, Infallible>(FIRST);
+            engine.finish.acquire().await.unwrap().forget();
+            yield Ok::<_, Infallible>(LAST);
+        };
+        Response::builder()
+            .header("content-type", "text/event-stream")
+            .body(Body::from_stream(stream))
+            .unwrap()
+    } else {
+        engine.finish.acquire().await.unwrap().forget();
+        Response::builder().header("content-type", "application/json")
+            .body(Body::from(json!({"choices":[{"message":{"role":"assistant","content":"finished"},"finish_reason":"stop"}]}).to_string())).unwrap()
+    }
+}
+
+struct Gateway {
+    child: Child,
+    dir: PathBuf,
+    proxy: SocketAddr,
+    metrics: SocketAddr,
+    client: Client,
+    engine: Arc<Engine>,
+    engine_task: JoinHandle<()>,
+}
+
+impl Gateway {
+    async fn start(drain_timeout: u64) -> Self {
+        let engine = Arc::new(Engine {
+            started: Semaphore::new(0),
+            finish: Semaphore::new(0),
+        });
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let backend = listener.local_addr().unwrap();
+        let router = Router::new()
+            .route("/v1/chat/completions", post(completion))
+            .with_state(engine.clone());
+        let engine_task = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let metrics_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy = proxy_listener.local_addr().unwrap();
+        let metrics = metrics_listener.local_addr().unwrap();
+        let dir = std::env::temp_dir().join(format!("onwards-shutdown-{}", Uuid::new_v4()));
+        fs::create_dir(&dir).unwrap();
+        fs::write(
+            dir.join("targets.json"),
+            json!({"targets":{"test-model":{"url":format!("http://{backend}/v1")}}}).to_string(),
+        )
+        .unwrap();
+        let log = fs::File::create(dir.join("gateway.log")).unwrap();
+        drop((proxy_listener, metrics_listener));
+        let child = Command::new(env!("CARGO_BIN_EXE_onwards"))
+            .args([
+                "--port",
+                &proxy.port().to_string(),
+                "--metrics-port",
+                &metrics.port().to_string(),
+                "--targets",
+            ])
+            .arg(dir.join("targets.json"))
+            .args([
+                "--shutdown-delay-secs",
+                "1",
+                "--shutdown-timeout-secs",
+                &drain_timeout.to_string(),
+            ])
+            .env_remove("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .env("RUST_LOG", "info")
+            .stdout(Stdio::from(log.try_clone().unwrap()))
+            .stderr(Stdio::from(log))
+            .kill_on_drop(true)
+            .spawn()
+            .unwrap();
+        let mut gateway = Self {
+            child,
+            dir,
+            proxy,
+            metrics,
+            client: Client::builder()
+                .no_proxy()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .unwrap(),
+            engine,
+            engine_task,
+        };
+        timeout(Duration::from_secs(15), async {
+            loop {
+                if let Some(status) = gateway.child.try_wait().unwrap() {
+                    panic!("gateway exited at startup: {status}: {}", gateway.log());
+                }
+                if gateway
+                    .client
+                    .get(gateway.admin("/readyz"))
+                    .send()
+                    .await
+                    .is_ok_and(|r| r.status() == StatusCode::OK)
+                {
+                    break;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("gateway readiness deadline");
+        gateway
+    }
+
+    fn admin(&self, path: &str) -> String {
+        format!("http://{}{path}", self.metrics)
+    }
+    fn log(&self) -> String {
+        fs::read_to_string(self.dir.join("gateway.log")).unwrap()
+    }
+
+    async fn signal(&self, signal: &str) {
+        assert!(
+            Command::new("kill")
+                .args([signal, &self.child.id().unwrap().to_string()])
+                .status()
+                .await
+                .unwrap()
+                .success()
+        );
+    }
+
+    async fn wait_for_drain(&mut self) {
+        timeout(Duration::from_secs(5), async {
+            loop {
+                let response = self.client.get(self.admin("/readyz")).send().await.unwrap();
+                if response.status() == StatusCode::SERVICE_UNAVAILABLE {
+                    break;
+                }
+                assert_eq!(response.status(), StatusCode::OK);
+                sleep(Duration::from_millis(10)).await;
+            }
+            assert_eq!(
+                self.client
+                    .get(self.admin("/healthz"))
+                    .send()
+                    .await
+                    .unwrap()
+                    .status(),
+                StatusCode::OK
+            );
+            assert!(
+                self.child.try_wait().unwrap().is_none(),
+                "active response must keep process alive"
+            );
+            // New TCP connections eventually stop, while the accepted response
+            // and the independently served health/metrics endpoints stay alive.
+            while TcpStream::connect(self.proxy).await.is_ok() {
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("proxy did not close admission");
+    }
+
+    async fn exit(&mut self) -> ExitStatus {
+        timeout(Duration::from_secs(8), self.child.wait())
+            .await
+            .expect("gateway did not exit")
+            .unwrap()
+    }
+
+    fn request(&self, stream: bool) -> reqwest::RequestBuilder {
+        self.client.post(format!("http://{}/v1/chat/completions", self.proxy))
+            .json(&json!({"model":"test-model","messages":[{"role":"user","content":"test"}],"stream":stream}))
+    }
+}
+
+impl Drop for Gateway {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+        self.engine_task.abort();
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[tokio::test]
+async fn sigterm_preserves_sse_and_metrics_until_the_body_finishes() {
+    let mut gateway = Gateway::start(10).await;
+    let response = gateway.request(true).send().await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut body = response.bytes_stream();
+    let first = timeout(Duration::from_secs(5), body.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.as_ref(), FIRST.as_bytes());
+    gateway.signal("-TERM").await;
+    gateway.wait_for_drain().await;
+    let metrics = gateway
+        .client
+        .get(gateway.admin("/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(metrics.contains("onwards_model_inflight{model=\"test-model\"} 1"));
+    assert!(gateway.child.try_wait().unwrap().is_none());
+    gateway.engine.finish.add_permits(1);
+    let mut tail = Vec::new();
+    while let Some(chunk) = body.next().await {
+        tail.extend(chunk.unwrap());
+    }
+    assert_eq!(tail, LAST.as_bytes());
+    assert!(gateway.exit().await.success(), "{}", gateway.log());
+    assert!(gateway.log().contains("Gateway request drain complete"));
+}
+
+#[tokio::test]
+async fn sigterm_waits_for_a_request_that_has_not_produced_headers() {
+    let mut gateway = Gateway::start(10).await;
+    let request = gateway.request(false);
+    let response = tokio::spawn(async move { request.send().await.unwrap() });
+    timeout(Duration::from_secs(5), gateway.engine.started.acquire())
+        .await
+        .unwrap()
+        .unwrap()
+        .forget();
+    assert!(!response.is_finished());
+    gateway.signal("-TERM").await;
+    gateway.wait_for_drain().await;
+    assert!(!response.is_finished());
+    gateway.engine.finish.add_permits(1);
+    let response = response.await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.json::<Value>().await.unwrap()["choices"][0]["message"]["content"],
+        "finished"
+    );
+    assert!(gateway.exit().await.success(), "{}", gateway.log());
+}
+
+#[tokio::test]
+async fn stuck_stream_exits_unsuccessfully_at_the_drain_deadline() {
+    let mut gateway = Gateway::start(1).await;
+    let response = gateway.request(true).send().await.unwrap();
+    let mut body = response.bytes_stream();
+    assert_eq!(
+        body.next().await.unwrap().unwrap().as_ref(),
+        FIRST.as_bytes()
+    );
+    gateway.signal("-TERM").await;
+    gateway.wait_for_drain().await;
+    // Never release the upstream response; shutdown must remain bounded.
+    assert!(!gateway.exit().await.success());
+    assert!(
+        gateway
+            .log()
+            .contains("gateway drain deadline exceeded after 1 seconds")
+    );
+    assert!(!gateway.log().contains("Gateway request drain complete"));
+    assert!(
+        body.next().await.unwrap().is_err(),
+        "unfinished HTTP body must not look complete"
+    );
+}
+
+#[tokio::test]
+async fn sigint_closes_idle_keep_alive_connections_without_waiting_for_the_deadline() {
+    let mut gateway = Gateway::start(30).await;
+    let mut idle = TcpStream::connect(gateway.proxy).await.unwrap();
+    idle.write_all(b"GET /v1/models HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")
+        .await
+        .unwrap();
+    let mut response = Vec::new();
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let mut chunk = [0; 1024];
+            let count = idle.read(&mut chunk).await.unwrap();
+            assert_ne!(count, 0, "connection must stay open after the response");
+            response.extend_from_slice(&chunk[..count]);
+            if let Some(end) = response.windows(4).position(|w| w == b"\r\n\r\n") {
+                let headers = String::from_utf8_lossy(&response[..end]).to_lowercase();
+                assert!(headers.starts_with("http/1.1 200"));
+                let length: usize = headers
+                    .lines()
+                    .find_map(|l| l.strip_prefix("content-length: "))
+                    .unwrap()
+                    .parse()
+                    .unwrap();
+                if response.len() >= end + 4 + length {
+                    break;
+                }
+            }
+        }
+    })
+    .await
+    .unwrap();
+    gateway.signal("-INT").await;
+    assert!(
+        timeout(Duration::from_secs(4), gateway.exit())
+            .await
+            .unwrap()
+            .success()
+    );
+    let mut byte = [0];
+    assert_eq!(
+        timeout(Duration::from_secs(1), idle.read(&mut byte))
+            .await
+            .unwrap()
+            .unwrap(),
+        0
+    );
+}


### PR DESCRIPTION
SIGTERM previously terminated the standalone Onwards gateway immediately,
interrupting active proxy responses during pod replacement. Use Axum's native
graceful shutdown to finish accepted requests and SSE bodies, with readiness
withdrawal before admission closes and metrics available throughout the drain.

Add configurable propagation and drain deadlines, a nonzero exit on timeout,
and deployment guidance for migrating from gateway versions without draining.
The integration tests start the real binary and send OS signals while holding
upstream responses open.

Validation: `just lint rust`, `just lint ts` and `just test rust` pass
(3,261 passed, zero failed, 31 ignored). This includes four real-process
Onwards tests for SSE, pending response headers, deadline expiry and idle
keep-alive closure. Onwards package formatting/Clippy and both documentation
builds also pass. Local workspace checks used Python 3.11 and an isolated
PostgreSQL 17 fixture, which was removed after validation.

The provider compliance test previously asserted a function call while allowing
`tool_choice: auto`, so a valid clarification could fail CI. Its request now
requires a tool call; the upstream runner and validators are unchanged. Three
local CLI tests verify the request, retained function-call validation and
retained schema validation. Rust and TypeScript lint checks pass again after
the CI-only change.
