### PR TITLE
fix: prune retained partitions in the trailing-demand query by retent…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwctl"
-version = "11.4.1"
+version = "11.4.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/dwctl/src/lib.rs
+++ b/dwctl/src/lib.rs
@@ -3699,6 +3699,13 @@ impl Application {
             fusillade_arsenal::PostgresStorageConfig::from(&fusillade_daemon_config),
         )
         .with_retained_response_fence_seconds(config.background_services.batch_daemon.retention.max_late_writer_seconds)
+        .with_retained_response_retention_bounds_seconds(
+            config
+                .background_services
+                .batch_daemon
+                .retention
+                .batchless_retention_bounds_seconds(),
+        )
         .with_template_generation_writes(config.background_services.batch_daemon.template_generation_writes_enabled)
         .with_download_buffer_size(config.batches.files.download_buffer_size)
         .with_batch_insert_strategy(fusillade_arsenal::BatchInsertStrategy::Batched {

--- a/fusillade-arsenal/src/postgres.rs
+++ b/fusillade-arsenal/src/postgres.rs
@@ -144,6 +144,11 @@ pub struct PostgresRequestManager<P: PoolProvider> {
     pools: P,
     config: PostgresStorageConfig,
     retained_response_fence_seconds: Option<u64>,
+    /// (min, max) batchless retention seconds across configured tiers, from
+    /// [`fusillade_core::RetentionPolicy::batchless_retention_bounds_seconds`].
+    /// Lets the trailing-demand query prune retained partitions that cannot
+    /// contain in-window rows; `None` falls back to the weak necessary bound.
+    retained_response_retention_bounds_seconds: Option<(u64, u64)>,
     template_generation_writes_enabled: bool,
     partition_maintenance_pool: Option<sqlx::PgPool>,
     partition_maintenance_attested: bool,
@@ -377,6 +382,7 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
             pools,
             config,
             retained_response_fence_seconds: None,
+            retained_response_retention_bounds_seconds: None,
             template_generation_writes_enabled: false,
             partition_maintenance_pool: None,
             partition_maintenance_attested: false,
@@ -433,6 +439,19 @@ impl<P: PoolProvider> PostgresRequestManager<P> {
     /// Return the configured content-free resurrection-fence lifetime.
     pub fn retained_response_fence_seconds(&self) -> Option<u64> {
         self.retained_response_fence_seconds
+    }
+
+    /// Configure the (min, max) batchless retention seconds used to prune
+    /// retained partitions in the trailing-demand query. `None` (the
+    /// default, and the state on instances without a batchless policy) keeps
+    /// the weak necessary bound; correctness never depends on this value
+    /// being present, only scan cost does.
+    pub fn with_retained_response_retention_bounds_seconds(
+        mut self,
+        bounds: Option<(u64, u64)>,
+    ) -> Self {
+        self.retained_response_retention_bounds_seconds = bounds;
+        self
     }
 
     /// Route new file-backed template writes into the weekly generation-2
@@ -2044,11 +2063,39 @@ impl<P: PoolProvider> Storage for PostgresRequestManager<P> {
         // Scalar params + force_custom_plan get real histogram selectivity,
         // which keeps the trailing partial indexes in play. Trailing windows
         // are few (typically one), so per-window round trips are cheap.
+        // Retained-partition prune bounds ($7/$8): sweep-landed rows have
+        // delete_on ~ terminal_at + tier retention, so only partitions in
+        // [window_start + min retention, window_end + max retention] can hold
+        // in-window rows. The slack absorbs day rounding at both ends and the
+        // short transition after a retention-period raise (rows landed under
+        // the previous, smaller period while the window still covers them).
+        // Without configured bounds the SQL falls back to its weak necessary
+        // bound — correct, but it scans every active partition, including the
+        // multi-million-row delete-tomorrow buckets the overdue backfill
+        // lands (the 2026-09-05 scouter timeout).
+        const RETENTION_PRUNE_SLACK_DAYS: i64 = 2;
+        let retention_bounds = self.retained_response_retention_bounds_seconds;
         let now = Utc::now();
         let mut result: Vec<TrailingDemandCount> = Vec::new();
         for (label, start, end) in windows {
             let start_ts = now + chrono::Duration::seconds(*start);
             let end_ts = now + chrono::Duration::seconds(*end);
+            let (prune_lower, prune_upper) = match retention_bounds {
+                Some((min_secs, max_secs)) => {
+                    let min_days = (min_secs / 86_400) as i64;
+                    let max_days = max_secs.div_ceil(86_400) as i64;
+                    // Never weaker than the SQL's fallback bound (> start date).
+                    let lower_offset = (min_days - RETENTION_PRUNE_SLACK_DAYS).max(1);
+                    (
+                        Some(start_ts.date_naive() + chrono::Duration::days(lower_offset)),
+                        Some(
+                            end_ts.date_naive()
+                                + chrono::Duration::days(max_days + RETENTION_PRUNE_SLACK_DAYS),
+                        ),
+                    )
+                }
+                None => (None, None),
+            };
             let rows = sqlx::query(retained_response::TRAILING_DEMAND_SQL)
                 .bind(start_ts)
                 .bind(end_ts)
@@ -2056,6 +2103,8 @@ impl<P: PoolProvider> Storage for PostgresRequestManager<P> {
                 .bind(&tier_names)
                 .bind(tier_include_null)
                 .bind(tier_mode)
+                .bind(prune_lower)
+                .bind(prune_upper)
                 .fetch_all(&mut *tx)
                 .await
                 .map_err(|e| {

--- a/fusillade-arsenal/src/postgres.rs
+++ b/fusillade-arsenal/src/postgres.rs
@@ -2066,9 +2066,16 @@ impl<P: PoolProvider> Storage for PostgresRequestManager<P> {
         // Retained-partition prune bounds ($7/$8): sweep-landed rows have
         // delete_on ~ terminal_at + tier retention, so only partitions in
         // [window_start + min retention, window_end + max retention] can hold
-        // in-window rows. The slack absorbs day rounding at both ends and the
-        // short transition after a retention-period raise (rows landed under
-        // the previous, smaller period while the window still covers them).
+        // in-window rows. The slack absorbs day rounding at both ends and a
+        // retention-period CHANGE's transition: for up to (window + sweep
+        // dwell) after a config flip, in-window rows landed under the
+        // previous period sit against the bound the change moved — a raise
+        // presses the lower bound, a decrease the upper — and a change
+        // larger than the slack undercounts those rows for that transition
+        // window only. Retention changes are rare, deliberate ops events;
+        // widening the slack to cover arbitrary changes would permanently
+        // scan extra full-day partitions to protect a transient, so the
+        // slack stays small and the exposure is documented instead.
         // Without configured bounds the SQL falls back to its weak necessary
         // bound — correct, but it scans every active partition, including the
         // multi-million-row delete-tomorrow buckets the overdue backfill

--- a/fusillade-arsenal/src/postgres/retained_response.rs
+++ b/fusillade-arsenal/src/postgres/retained_response.rs
@@ -1610,9 +1610,18 @@ pub(crate) const TRAILING_DEMAND_SQL: &str = r#"
       AND retained.state = 'completed'
       AND retained.terminal_at >= $1
       AND retained.terminal_at < $2
-      -- V1 proves terminal_at < delete_on, so this necessary lower
-      -- bound enables daily partition pruning for the trailing window.
-      AND retained.delete_on > ($1 AT TIME ZONE 'UTC')::date
+      -- Partition-prune bounds. Sweep-landed rows satisfy
+      -- delete_on ~ terminal_at + tier retention, so a trailing terminal_at
+      -- window can only match partitions between window_start + min
+      -- retention and window_end + max retention ($7/$8, computed with
+      -- day-rounding and retention-raise slack). Backfill-landed overdue
+      -- rows (delete_on clamped to observation + 1) are strictly older
+      -- than any trailing window, so the lower bound prunes their
+      -- partitions outright instead of scanning them row by row. When the
+      -- policy is unknown ($7/$8 NULL) fall back to the weak necessary
+      -- bound: V1 proves terminal_at < delete_on.
+      AND retained.delete_on >= COALESCE($7::date, ($1 AT TIME ZONE 'UTC')::date + 1)
+      AND ($8::date IS NULL OR retained.delete_on <= $8::date)
       AND (cardinality($3::text[]) = 0 OR retained.model = ANY($3))
       AND retained.service_tier IS DISTINCT FROM 'background'
       AND (
@@ -1671,9 +1680,18 @@ pub(crate) const TRAILING_DEMAND_SQL: &str = r#"
       AND retained.state = 'failed'
       AND retained.terminal_at >= $1
       AND retained.terminal_at < $2
-      -- V1 proves terminal_at < delete_on, so this necessary lower
-      -- bound enables daily partition pruning for the trailing window.
-      AND retained.delete_on > ($1 AT TIME ZONE 'UTC')::date
+      -- Partition-prune bounds. Sweep-landed rows satisfy
+      -- delete_on ~ terminal_at + tier retention, so a trailing terminal_at
+      -- window can only match partitions between window_start + min
+      -- retention and window_end + max retention ($7/$8, computed with
+      -- day-rounding and retention-raise slack). Backfill-landed overdue
+      -- rows (delete_on clamped to observation + 1) are strictly older
+      -- than any trailing window, so the lower bound prunes their
+      -- partitions outright instead of scanning them row by row. When the
+      -- policy is unknown ($7/$8 NULL) fall back to the weak necessary
+      -- bound: V1 proves terminal_at < delete_on.
+      AND retained.delete_on >= COALESCE($7::date, ($1 AT TIME ZONE 'UTC')::date + 1)
+      AND ($8::date IS NULL OR retained.delete_on <= $8::date)
       AND (cardinality($3::text[]) = 0 OR retained.model = ANY($3))
       AND retained.service_tier IS DISTINCT FROM 'background'
       AND (
@@ -3803,6 +3821,8 @@ mod tests {
             .bind(vec!["flex".to_owned()])
             .bind(false)
             .bind("include")
+            .bind(Option::<NaiveDate>::None)
+            .bind(Option::<NaiveDate>::None)
             .fetch_all(&pool)
             .await
             .expect("exact trailing-demand SQL must execute");
@@ -3819,6 +3839,8 @@ mod tests {
             .bind(vec!["flex".to_owned()])
             .bind(false)
             .bind("include")
+            .bind(Option::<NaiveDate>::None)
+            .bind(Option::<NaiveDate>::None)
             .fetch_one(&pool)
             .await
             .expect("exact trailing-demand SQL must be explainable");
@@ -3831,6 +3853,128 @@ mod tests {
             0,
             "trailing plan must remove or avoid scanning the irrelevant daily child: {trailing_plan}"
         );
+    }
+
+    #[sqlx::test]
+    async fn trailing_demand_retention_bounds_prune_backfill_partitions(pool: PgPool) {
+        // A sweep-landed row inside the window: delete_on ~ terminal + 5d.
+        let sweep_delete_on = NaiveDate::from_ymd_opt(2026, 8, 20).unwrap();
+        // A backfill-landed bucket just past the window start: months-old
+        // terminal_at, delete_on clamped to the day after observation. The
+        // weak necessary bound (delete_on > window start) cannot prune it;
+        // the retention-derived lower bound must.
+        let backfill_delete_on = NaiveDate::from_ymd_opt(2026, 8, 11).unwrap();
+        for delete_on in [backfill_delete_on, sweep_delete_on] {
+            sqlx::query("SELECT ensure_retained_response_partition($1, NULL)")
+                .bind(delete_on)
+                .execute(&pool)
+                .await
+                .expect("bounds fixture partition must be available");
+        }
+        for (delete_on, group, request, terminal_at) in [
+            (
+                sweep_delete_on,
+                Uuid::from_u128(0xdddddddddddddddddddddddddddddddd),
+                Uuid::from_u128(0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee),
+                "2026-08-12T10:00:00Z",
+            ),
+            (
+                backfill_delete_on,
+                Uuid::from_u128(0x1dddddddddddddddddddddddddddddd1),
+                Uuid::from_u128(0x1eeeeeeeeeeeeeeeeeeeeeeeeeeeeee1),
+                "2026-05-01T10:00:00Z",
+            ),
+        ] {
+            sqlx::query(
+                r#"
+                INSERT INTO retained_response_objects (
+                    delete_on, group_id, object_kind, object_id, request_id,
+                    created_by, service_tier, state, model,
+                    created_at, terminal_at, schema_version, payload
+                ) VALUES (
+                    $1, $2, 'request', $3, $3,
+                    'bounds-owner', 'flex', 'completed', 'bounds-model',
+                    '2026-05-01T09:00:00Z', $4::timestamptz, 1, '{}'::jsonb
+                )
+                "#,
+            )
+            .bind(delete_on)
+            .bind(group)
+            .bind(request)
+            .bind(terminal_at)
+            .execute(&pool)
+            .await
+            .expect("bounds fixture row must insert");
+            sqlx::query(
+                "INSERT INTO retained_response_group_routes (group_id, delete_on) VALUES ($1, $2)",
+            )
+            .bind(group)
+            .bind(delete_on)
+            .execute(&pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO retained_response_request_routes (request_id, group_id, delete_on) VALUES ($1, $2, $3)",
+            )
+            .bind(request)
+            .bind(group)
+            .bind(delete_on)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Bounds as the impl computes them for min retention 5d / max 6d over
+        // the window [08-10, 08-15): lower = start + (5 - 2), upper =
+        // end + 6 + 2.
+        let prune_lower = NaiveDate::from_ymd_opt(2026, 8, 13).unwrap();
+        let prune_upper = NaiveDate::from_ymd_opt(2026, 8, 23).unwrap();
+
+        for (label, lower, upper, expect_backfill_scanned) in [
+            ("bounded", Some(prune_lower), Some(prune_upper), false),
+            ("unbounded", None, None, true),
+        ] {
+            let explain = format!("EXPLAIN (ANALYZE, FORMAT JSON) {TRAILING_DEMAND_SQL}");
+            let plan: serde_json::Value = sqlx::query_scalar(&explain)
+                .bind(timestamp("2026-08-10T00:00:00Z"))
+                .bind(timestamp("2026-08-15T00:00:00Z"))
+                .bind(vec!["bounds-model".to_owned()])
+                .bind(vec!["flex".to_owned()])
+                .bind(false)
+                .bind("include")
+                .bind(lower)
+                .bind(upper)
+                .fetch_one(&pool)
+                .await
+                .expect("bounded trailing-demand SQL must be explainable");
+            assert!(
+                relation_actual_loops(&plan, "retained_response_objects_d20260820") > 0,
+                "{label}: plan must execute the sweep-landed child: {plan}"
+            );
+            assert_eq!(
+                relation_actual_loops(&plan, "retained_response_objects_d20260811") > 0,
+                expect_backfill_scanned,
+                "{label}: backfill child scanned={expect_backfill_scanned} expected: {plan}"
+            );
+
+            // Same counts either way: the bounds change what is SCANNED,
+            // never what is counted (the backfill row is out-of-window).
+            let rows = sqlx::query(TRAILING_DEMAND_SQL)
+                .bind(timestamp("2026-08-10T00:00:00Z"))
+                .bind(timestamp("2026-08-15T00:00:00Z"))
+                .bind(vec!["bounds-model".to_owned()])
+                .bind(vec!["flex".to_owned()])
+                .bind(false)
+                .bind("include")
+                .bind(lower)
+                .bind(upper)
+                .fetch_all(&pool)
+                .await
+                .expect("bounded trailing-demand SQL must execute");
+            assert_eq!(rows.len(), 1, "{label}: exactly the in-window row counts");
+            assert_eq!(rows[0].get::<String, _>("model"), "bounds-model");
+            assert_eq!(rows[0].get::<i64, _>("count"), 1);
+        }
     }
 
     #[sqlx::test]

--- a/fusillade-core/src/manager.rs
+++ b/fusillade-core/src/manager.rs
@@ -76,8 +76,8 @@ impl RetentionPolicy {
             || !self.batchless_seconds_by_service_tier.is_empty()
     }
 
-    /// The (min, max) batchless retention in seconds across configured tiers,
-    /// or `None` when no batchless tier is configured.
+    /// The (min, max) batchless retention in seconds across configured
+    /// NON-background tiers, or `None` when none is configured.
     ///
     /// Feeds the trailing-demand query's partition-prune bounds: every
     /// sweep-landed retained row satisfies `delete_on ≈ terminal_at + its
@@ -87,10 +87,23 @@ impl RetentionPolicy {
     /// `delete_on` is clamped to the day after observation) are strictly
     /// older than any trailing window, and the lower bound prunes their
     /// partitions without scanning them.
+    ///
+    /// The background tier is excluded because the trailing-demand query
+    /// excludes background rows in every arm (`service_tier IS DISTINCT
+    /// FROM 'background'`); letting an outlier background retention widen
+    /// the bounds would only weaken pruning for rows the query can never
+    /// count.
     pub fn batchless_retention_bounds_seconds(&self) -> Option<(u64, u64)> {
-        let min = self.batchless_seconds_by_service_tier.values().min()?;
-        let max = self.batchless_seconds_by_service_tier.values().max()?;
-        Some((*min, *max))
+        let mut non_background = self
+            .batchless_seconds_by_service_tier
+            .iter()
+            .filter(|(tier, _)| tier.as_str() != "background")
+            .map(|(_, seconds)| *seconds);
+        let first = non_background.next()?;
+        let (min, max) = non_background.fold((first, first), |(min, max), seconds| {
+            (min.min(seconds), max.max(seconds))
+        });
+        Some((min, max))
     }
 
     /// Reject labels that cannot match a persisted service tier safely.
@@ -329,6 +342,31 @@ pub enum RetainedResponseRetirementOutcome {
 #[cfg(test)]
 mod retention_policy_tests {
     use super::*;
+
+    #[test]
+    fn retention_bounds_span_non_background_tiers_only() {
+        let mut policy = RetentionPolicy::default();
+        assert_eq!(policy.batchless_retention_bounds_seconds(), None);
+
+        // Background alone configures no bounds: the trailing-demand query
+        // excludes background rows in every arm.
+        policy
+            .batchless_seconds_by_service_tier
+            .insert("background".to_owned(), 86_400);
+        assert_eq!(policy.batchless_retention_bounds_seconds(), None);
+
+        policy
+            .batchless_seconds_by_service_tier
+            .insert("flex".to_owned(), 30 * 86_400);
+        policy
+            .batchless_seconds_by_service_tier
+            .insert("priority".to_owned(), 60 * 86_400);
+        // The background outlier (1 day) must not widen the bounds.
+        assert_eq!(
+            policy.batchless_retention_bounds_seconds(),
+            Some((30 * 86_400, 60 * 86_400))
+        );
+    }
 
     #[test]
     fn batchless_delete_on_is_the_utc_day_after_exact_expiry() {

--- a/fusillade-core/src/manager.rs
+++ b/fusillade-core/src/manager.rs
@@ -76,6 +76,23 @@ impl RetentionPolicy {
             || !self.batchless_seconds_by_service_tier.is_empty()
     }
 
+    /// The (min, max) batchless retention in seconds across configured tiers,
+    /// or `None` when no batchless tier is configured.
+    ///
+    /// Feeds the trailing-demand query's partition-prune bounds: every
+    /// sweep-landed retained row satisfies `delete_on ≈ terminal_at + its
+    /// tier's retention`, so a trailing window over `terminal_at` can only
+    /// match rows in partitions between `window_start + min retention` and
+    /// `window_end + max retention`. Backfill-landed overdue rows (whose
+    /// `delete_on` is clamped to the day after observation) are strictly
+    /// older than any trailing window, and the lower bound prunes their
+    /// partitions without scanning them.
+    pub fn batchless_retention_bounds_seconds(&self) -> Option<(u64, u64)> {
+        let min = self.batchless_seconds_by_service_tier.values().min()?;
+        let max = self.batchless_seconds_by_service_tier.values().max()?;
+        Some((*min, *max))
+    }
+
     /// Reject labels that cannot match a persisted service tier safely.
     pub fn validate(&self) -> std::result::Result<(), String> {
         if self.terminal_batch_seconds == Some(0)
@@ -1112,7 +1129,11 @@ pub trait Storage: Send + Sync {
     /// identified by `service_tier = 'priority' AND batch_id IS NULL` instead,
     /// because the orphan purger may null `template_id` on old realtime rows.
     ///
-    /// Reads the live `requests` table only. Batchless tiers (flex/priority)
+    /// Reads the live `requests` table unioned with the retained-response
+    /// store (batchless rows keep counting after the archiver moves them;
+    /// partition pruning there relies on the configured retention bounds —
+    /// see [`RetentionPolicy::batchless_retention_bounds_seconds`]).
+    /// Batchless tiers (flex/priority)
     /// are exact; batch-tier rows are moved to `batch_requests_archive` once
     /// their parent batch is terminal and frozen, so batch-tier counts cover
     /// only not-yet-archived rows (a lower bound that decays with sweep

--- a/fusillade/src/manager/postgres.rs
+++ b/fusillade/src/manager/postgres.rs
@@ -94,9 +94,11 @@ where
             ))
         })?;
         let fence_seconds = retention.policy().max_late_writer_seconds;
+        let retention_bounds = retention.policy().batchless_retention_bounds_seconds();
         let storage = Arc::new(
             PostgresStore::new(pools, (&config).into())
-                .with_retained_response_fence_seconds(fence_seconds),
+                .with_retained_response_fence_seconds(fence_seconds)
+                .with_retained_response_retention_bounds_seconds(retention_bounds),
         );
         Ok(Self::from_store(storage, config).with_retention_maintenance(retention))
     }


### PR DESCRIPTION
…ion bounds

The trailing terminal-demand query's retained arms pruned daily partitions only by the weak necessary bound (delete_on > window start), which the overdue backfill defeats: it lands months-old rows with delete_on clamped to the day after observation, so its multi-million-row delete-tomorrow buckets pass the bound and get scanned row-by-row (terminal_at is unindexed) on every scouter demand poll - 39-60s against the 60s statement timeout (2026-09-05 ScouterNotScheduling).

Sweep-landed rows satisfy delete_on ~ terminal_at + tier retention, so a trailing window can only match partitions between window_start + min retention and window_end + max retention. Pass those bounds (with day-rounding and retention-raise slack) from the configured policy down to the query; NULL falls back to the old bound, so correctness never depends on the policy being present - only scan cost does. The upper bound also keeps the query from scanning the entire retained corpus at steady state once the daily retention partitions fill.