### PR TITLE
fix(onwards): pass provider reasoning fields through non-strict gateways

### DIFF
--- a/onwards/docs/src/configuration.md
+++ b/onwards/docs/src/configuration.md
@@ -204,3 +204,11 @@ See [Authentication](authentication.md) for details.
   }
 }
 ```
+
+### Reasoning controls through internal gateways
+
+Non-strict gateways forward provider-native reasoning fields such as
+`chat_template_kwargs.enable_thinking` unchanged. This permits an internal
+gateway to receive requests already translated by a public gateway. Strict
+mode rejects these fields in favor of canonical reasoning controls. Configured
+`reasoning_effort` translations still apply in either mode.

--- a/onwards/src/handlers.rs
+++ b/onwards/src/handlers.rs
@@ -572,9 +572,11 @@ pub async fn target_message_handler<T: HttpClient>(
         let body: serde_json::Value = serde_json::from_slice(&body_bytes).map_err(|_| {
             OnwardsErrorResponse::bad_request("Request body must be valid JSON.", None)
         })?;
-        crate::reasoning::validate_canonical_reasoning(&canonical_request_path, &body).map_err(
-            |error| OnwardsErrorResponse::reasoning(&error),
-        )?
+        crate::reasoning::parse_reasoning_request(
+            &canonical_request_path,
+            &body,
+            state.targets.strict_mode,
+        ).map_err(|error| OnwardsErrorResponse::reasoning(&error))?
     } else {
         None
     };

--- a/onwards/src/lib.rs
+++ b/onwards/src/lib.rs
@@ -3161,6 +3161,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_provider_reasoning_fields_pass_through_only_in_non_strict_mode() {
+        for strict_mode in [false, true] {
+            for stream in [false, true] {
+                for path in ["/v1/chat/completions", "/v1/responses", "/v1/completions"] {
+                    let targets_map = Arc::new(DashMap::new());
+                    targets_map.insert(
+                        "model".to_string(),
+                        pool(
+                            Target::builder()
+                                .url("https://engine.example.com".parse().unwrap())
+                                .build(),
+                        ),
+                    );
+                    let targets = Targets {
+                        targets: targets_map,
+                        key_rate_limiters: Arc::new(DashMap::new()),
+                        key_concurrency_limiters: Arc::new(DashMap::new()),
+                        key_labels: Arc::new(DashMap::new()),
+                        strict_mode,
+                        http_pool_config: None,
+                    };
+                    let mock_client = MockHttpClient::new(StatusCode::OK, "{}");
+                    let server = TestServer::new(build_router(AppState::with_client(
+                        targets,
+                        mock_client.clone(),
+                    )))
+                    .unwrap();
+                    // Already translated by the public gateway; some mappings retain
+                    // the canonical effort alongside the provider-native controls.
+                    let mut body = json!({
+                        "model": "model", "messages": [], "input": "hello", "prompt": "hello",
+                        "stream": stream,
+                        "chat_template_kwargs": {"enable_thinking": true},
+                        "thinking_token_budget": 512
+                    });
+                    if path.ends_with("chat/completions") {
+                        body["reasoning_effort"] = json!("high");
+                    }
+                    let response = server.post(path).json(&body).await;
+                    let requests = mock_client.get_requests();
+                    if strict_mode {
+                        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+                        assert!(requests.is_empty());
+                    } else {
+                        assert_eq!(response.status_code(), StatusCode::OK);
+                        assert_eq!(requests.len(), 1);
+                        let forwarded: serde_json::Value =
+                            serde_json::from_slice(&requests[0].body).unwrap();
+                        assert_eq!(forwarded, body);
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn test_provider_reasoning_translation_applies_to_upstream_body() {
         let reasoning_translation = serde_json::from_value(json!({
             "chat_completions": {

--- a/onwards/src/reasoning.rs
+++ b/onwards/src/reasoning.rs
@@ -407,8 +407,21 @@ pub fn validate_canonical_reasoning(
     path: &str,
     body: &Value,
 ) -> Result<Option<CanonicalReasoningRequest>, ReasoningError> {
+    parse_reasoning_request(path, body, true)
+}
+
+/// Parse canonical controls while optionally rejecting provider-native fields.
+/// Internal non-strict gateways must accept bodies translated by an earlier hop.
+pub(crate) fn parse_reasoning_request(
+    path: &str,
+    body: &Value,
+    strict: bool,
+) -> Result<Option<CanonicalReasoningRequest>, ReasoningError> {
     let surface = ApiSurface::from_path(path);
     if surface == ApiSurface::Completions {
+        if !strict {
+            return Ok(None);
+        }
         let unsupported = [
             ("/reasoning_effort", "reasoning_effort"),
             ("/reasoning", "reasoning"),
@@ -465,7 +478,7 @@ pub fn validate_canonical_reasoning(
         .find(|(pointer, _)| body.pointer(pointer).is_some()),
         ApiSurface::Completions | ApiSurface::Other => None,
     };
-    if let Some((_, param)) = unsupported {
+    if strict && let Some((_, param)) = unsupported {
         let canonical = surface
             .parameter_name()
             .expect("reasoning API surfaces have canonical parameters");


### PR DESCRIPTION
Requests translated by a public gateway can contain `chat_template_kwargs.enable_thinking`; a second non-strict Onwards gateway currently rejects them with HTTP 400. Restrict provider-native reasoning-field rejection to strict mode, while preserving canonical effort parsing and configured provider translation in both modes.

Validation: 438 Onwards unit tests, all 4 graceful-shutdown integration tests, and 10 doctests passed (2 ignored). Regression coverage checks streaming and non-streaming forwarding on Chat Completions, Responses, and Completions, plus strict rejection. Existing translation tests pass. Package formatting and Clippy checked; existing unrelated Clippy warnings remain. No drain code changed.
