### PR TITLE
perf(fusillade): serve the Responses page from the plain created_at indexes

### DIFF
--- a/fusillade-arsenal/migrations/20260907000000_responses_page_single_sort_index.down.sql
+++ b/fusillade-arsenal/migrations/20260907000000_responses_page_single_sort_index.down.sql
@@ -1,0 +1,28 @@
+-- Restore the two rank-ordered listing indexes and drop the archive sort index.
+--
+-- Definitions transcribed from 20260630000000_formalize_user_sort_indexes and
+-- from production pg_get_indexdef for idx_requests_active_first_tier.
+--
+-- Both rebuilds are non-concurrent and will hold ACCESS EXCLUSIVE on `requests`
+-- for the duration; each is several GB on a production-sized database. Build
+-- them CONCURRENTLY out-of-band first if this ever has to be run against a live
+-- deployment.
+
+CREATE INDEX IF NOT EXISTS idx_requests_user_active_sort
+  ON requests (
+    created_by,
+    (CASE state WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END),
+    created_at DESC,
+    id DESC,
+    service_tier
+  ) WHERE created_by IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_requests_active_first_tier
+  ON requests (
+    (CASE state WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END),
+    created_at DESC,
+    id DESC,
+    service_tier
+  );
+
+DROP INDEX IF EXISTS idx_retained_response_objects_created;

--- a/fusillade-arsenal/migrations/20260907000000_responses_page_single_sort_index.up.sql
+++ b/fusillade-arsenal/migrations/20260907000000_responses_page_single_sort_index.up.sql
@@ -1,0 +1,112 @@
+-- Replace two rank-ordered listing indexes with one archive sort index.
+--
+-- Follows the COR-537 index audit (see 20260904020000_drop_unused_indexes) and
+-- pairs with the Responses page query rewrite in the same change. Net effect on
+-- a production-sized database: +204 MB, -7,101 MB.
+--
+-- ---------------------------------------------------------------------------
+-- Why the two dropped indexes stopped earning their keep
+-- ---------------------------------------------------------------------------
+--
+--   idx_requests_user_active_sort    3983 MB     3,427 scans
+--   idx_requests_active_first_tier   3118 MB       169 scans
+--
+-- Both exist for one reason: to materialize `ORDER BY CASE state WHEN
+-- 'processing' THEN 0 ... ELSE 3 END`, the "active first" ordering of the
+-- Responses page. That is a presentation choice, not a data property, and three
+-- things made it a bad one to encode in an index:
+--
+-- 1. The rank column is unbounded. In (created_by, RANK, created_at DESC, id
+--    DESC) the rank sits between the equality column and the range column, and
+--    nothing ever supplies an equality on it. On PostgreSQL 17 that stops
+--    `created_at` from being a scan boundary (no btree skip scan until 18), so
+--    a date-filtered page walked every entry newer than the requested range
+--    instead of seeking to it -- measured at 1,774,936 index entries walked to
+--    return a 10-row page.
+--
+-- 2. The ordering it provides is almost meaningless now. These indexes were
+--    formalized in 20260630000000, when batchless responses were new. The
+--    batchless population is now overwhelmingly terminal: at the time of
+--    writing exactly one row is non-terminal, so ~7 GB of index existed to
+--    order 20M rows by a column that is constant for all but one of them.
+--
+-- 3. They competed for cache with everything else. `requests` carried ~29 GB of
+--    indexes against a 32 GB compute cache, and these two were half of the
+--    ~14.5 GB spent on listing while serving under 4,000 scans between them --
+--    against 278M for the 401 MB idx_requests_state. On network-attached
+--    storage every evicted page is a round trip, so the reclaim helps queries
+--    that never touch the Responses page at all.
+--
+-- The rewrite removes the need for both. The in-flight rows are read from a
+-- materialized CTE bounded by concurrency rather than history, which
+-- idx_requests_state already serves, and which is small enough to sort by rank
+-- with no index support. Every other arm orders by created_at alone, which
+-- idx_requests_user_created_sort (owner-scoped) and idx_requests_created_tier
+-- (unscoped) already provide.
+--
+-- ---------------------------------------------------------------------------
+-- Why the new index is required
+-- ---------------------------------------------------------------------------
+--
+-- retained_response_objects has owner-leading, state-leading, model-leading and
+-- tier-leading sort indexes but nothing that yields plain newest-first across
+-- all owners. Without it the unscoped (platform manager, no active
+-- organization) archive arm plans as Append + Sort over the whole retained
+-- history and cannot push the LIMIT down; it did not complete inside 240s. With
+-- it the arm becomes a Merge Append of per-partition index scans: 2 ms warm.
+--
+-- Naming the terminal states in the query instead does NOT work -- the planner
+-- then prefers the state-leading index and returns to Append + Sort.
+--
+-- Mechanics: this is a partitioned index, so creating it on the parent cascades
+-- to every attached child. ensure_retained_response_partition builds each daily
+-- partition with `LIKE retained_response_objects INCLUDING ALL` and then
+-- ATTACHes it, so future partitions inherit it with no change to that function.
+--
+-- ---------------------------------------------------------------------------
+-- Production deploy
+-- ---------------------------------------------------------------------------
+--
+-- Run all three out-of-band BEFORE deploying, so the statements below are
+-- no-ops. Both plain forms take an ACCESS EXCLUSIVE lock on tables whose
+-- longest-running statements last tens of seconds under load, with everything
+-- else queuing behind the waiter.
+--
+-- CREATE INDEX CONCURRENTLY cannot target a partitioned parent, so the archive
+-- index needs the per-child build plus attach:
+--
+--   -- 1. one per attached partition
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_rro_created_d20260908
+--     ON retained_response_objects_d20260908 (created_at DESC, object_id DESC)
+--     WHERE object_kind = 'request';
+--   -- 2. parent, created invalid until every child is attached
+--   CREATE INDEX IF NOT EXISTS idx_retained_response_objects_created
+--     ON ONLY retained_response_objects (created_at DESC, object_id DESC)
+--     WHERE object_kind = 'request';
+--   -- 3. one per partition; the parent flips to valid on the last attach
+--   ALTER INDEX idx_retained_response_objects_created
+--     ATTACH PARTITION idx_rro_created_d20260908;
+--
+--   -- then the drops
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_requests_user_active_sort;
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_requests_active_first_tier;
+--
+-- ANALYZE the retained partitions after step 3 and before deploying. Until the
+-- new index has statistics the planner keeps choosing the owner-leading index
+-- and sorting: the unscoped date-filtered page measured 280s before ANALYZE and
+-- 3 ms after.
+--
+-- Ordering matters for rollback. The drops must not land before the rewrite is
+-- serving: the previous query against the post-drop index set does not complete
+-- inside 300s. Deploy the CONCURRENT creates first, then the release; the drops
+-- are safe from the moment the new binary is live.
+
+CREATE INDEX IF NOT EXISTS idx_retained_response_objects_created
+  ON retained_response_objects (created_at DESC, object_id DESC)
+  WHERE object_kind = 'request';
+
+COMMENT ON INDEX idx_retained_response_objects_created IS
+'Plain newest-first ordering for the Responses archive arm. The owner-, state-, model- and tier-leading sort indexes cannot serve an unscoped page ordered by created_at alone.';
+
+DROP INDEX IF EXISTS idx_requests_user_active_sort;
+DROP INDEX IF EXISTS idx_requests_active_first_tier;

--- a/fusillade-arsenal/src/postgres/retained_response.rs
+++ b/fusillade-arsenal/src/postgres/retained_response.rs
@@ -1192,6 +1192,15 @@ const COUNT_BUDGET: &str = "100ms";
 /// indefinitely behind a lock queue.
 const ESTIMATE_BUDGET: &str = "5s";
 
+/// Budget for the page query itself. Every measured shape returns in
+/// single-digit milliseconds warm, so this only trips on a pathological filter
+/// combination -- notably a status filter whose value matches nothing, where
+/// the scan has no early exit and walks the whole history. Without a budget
+/// that query ran unbounded on the WRITE pool (`begin_primary_read`), holding a
+/// primary connection for minutes and outliving the request that started it. A
+/// bounded failure is strictly better than an unbounded hang.
+const PAGE_BUDGET: &str = "15s";
+
 /// `SET LOCAL` is transaction-scoped: it is applied once per transaction and
 /// re-applied whenever the fallback replaces the transaction.
 async fn apply_statement_budget(tx: &mut Transaction<'_, Postgres>, budget: &str) -> Result<()> {
@@ -1268,12 +1277,49 @@ async fn count_requests_with_budget<P: PoolProvider>(
     Ok(total)
 }
 
-fn list_requests_page_sql(active_first: bool, owner_scoped: bool) -> String {
-    // Separate SQL shapes let generic prepared plans use the owner-leading
-    // indexes. A nullable-owner OR cannot become an index condition in those
-    // plans. Values remain bound, including the NULL owner for admin listings.
+/// Which optional filters are present, and therefore which SQL shape to emit.
+///
+/// Every optional filter used to be written `($n IS NULL OR col = $n)`. A
+/// disjunction can never become an index boundary condition in a generic
+/// prepared plan, so the owner and the `created_at` range both degraded to
+/// residual filters and the scan walked the whole history. Emitting the
+/// predicate only when the caller supplied it keeps every value bound while
+/// letting the planner use it as a scan bound. Owner already worked this way;
+/// this extends it to the two `created_at` bounds, which is what made date
+/// filtering slow.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct PageShape {
+    pub(crate) active_first: bool,
+    pub(crate) owner_scoped: bool,
+    pub(crate) created_after: bool,
+    pub(crate) created_before: bool,
+}
+
+impl PageShape {
+    fn of(filter: &ListRequestsFilter) -> Self {
+        Self {
+            active_first: filter.active_first,
+            owner_scoped: filter.created_by.is_some(),
+            created_after: filter.created_after.is_some(),
+            created_before: filter.created_before.is_some(),
+        }
+    }
+}
+
+fn list_requests_page_sql(shape: PageShape) -> String {
+    let PageShape {
+        active_first,
+        owner_scoped,
+        created_after,
+        created_before,
+    } = shape;
     let live_owner = if owner_scoped {
         "request.created_by = $1::text"
+    } else {
+        "$1::text IS NULL"
+    };
+    let active_owner = if owner_scoped {
+        "active.created_by = $1::text"
     } else {
         "$1::text IS NULL"
     };
@@ -1282,23 +1328,78 @@ fn list_requests_page_sql(active_first: bool, owner_scoped: bool) -> String {
     } else {
         "$1::text IS NULL"
     };
+    let live_dates = format!(
+        "{}{}",
+        if created_after {
+            "\n              AND request.created_at >= $4"
+        } else {
+            ""
+        },
+        if created_before {
+            "\n              AND request.created_at <= $5"
+        } else {
+            ""
+        },
+    );
+    let active_dates = format!(
+        "{}{}",
+        if created_after {
+            "\n              AND active.created_at >= $4"
+        } else {
+            ""
+        },
+        if created_before {
+            "\n              AND active.created_at <= $5"
+        } else {
+            ""
+        },
+    );
+    // V1 proves created_at < delete_on, so the necessary lower bound also
+    // enables daily partition pruning.
+    let retained_dates = format!(
+        "{}{}",
+        if created_after {
+            "\n              AND object.created_at >= $4\n              AND object.delete_on > ($4 AT TIME ZONE 'UTC')::date"
+        } else {
+            ""
+        },
+        if created_before {
+            "\n              AND object.created_at <= $5"
+        } else {
+            ""
+        },
+    );
+    let rank_of = |column: &str| {
+        format!(
+            "CASE {column} WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END"
+        )
+    };
     let order_clause = if active_first {
-        "CASE sort_state WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END ASC, sort_created_at DESC, sort_id DESC"
+        format!(
+            "{} ASC, sort_created_at DESC, sort_id DESC",
+            rank_of("sort_state")
+        )
     } else {
-        "sort_created_at DESC, sort_id DESC"
+        "sort_created_at DESC, sort_id DESC".to_string()
     };
-    // Each arm carries its own ORDER BY + LIMIT so the planner can satisfy
-    // the page from ordered indexes (Merge Append over two bounded arms)
-    // instead of sorting the whole union. The live arm's expressions mirror
-    // idx_requests_active_first_tier / idx_requests_created_tier exactly.
-    let live_order = if active_first {
-        "CASE request.state WHEN 'processing' THEN 0 WHEN 'claimed' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END ASC, request.created_at DESC, request.id DESC"
+    // The in-flight arm reads from a materialized CTE of at most a few
+    // thousand rows, so it can afford to sort by the full page ordering --
+    // including the rank -- without any index that encodes that rank. This is
+    // what lets the two ~4 GB rank-ordered indexes go away: nothing sorts a
+    // large set by state any more. Ordering it by created_at alone is a silent
+    // correctness bug once more rows are in flight than fit on one page.
+    let active_order = if active_first {
+        format!(
+            "{} ASC, active.created_at DESC, active.id DESC",
+            rank_of("active.state")
+        )
     } else {
-        "request.created_at DESC, request.id DESC"
+        "active.created_at DESC, active.id DESC".to_string()
     };
-    // RetainedRequestPayloadV1::validate requires a terminal request. Every
-    // retained row therefore has the same active-first rank; omitting that
-    // constant key permits the existing owner/created_at/object_id index scan.
+    // Terminal live rows and retained rows all share one rank, so ordering
+    // them by created_at alone is equivalent to the page ordering -- and it is
+    // an ordering the plain (owner,) created_at DESC indexes already provide.
+    let terminal_order = "request.created_at DESC, request.id DESC";
     let retained_order = "object.created_at DESC, object.object_id DESC";
     format!(
         r#"
@@ -1323,7 +1424,63 @@ fn list_requests_page_sql(active_first: bool, owner_scoped: bool) -> String {
               AND pg_get_expr(child.relpartbound, child.oid) = format(
                   'FOR VALUES FROM (%L) TO (%L)', bucket.delete_on, bucket.delete_on + 1
               )
-        ), candidates AS (
+        ),
+        -- The entire in-flight population, materialized up front. Its size is
+        -- bounded by how much work can be simultaneously in flight, not by how
+        -- much history the table holds, so this stays cheap as `requests`
+        -- grows. `idx_requests_state` serves it; no rank-ordered index needed.
+        active AS MATERIALIZED (
+            SELECT id, state, created_at, created_by, model, service_tier, batch_id,
+                   completed_at, failed_at, started_at, response_status
+            FROM requests
+            WHERE created_by IS NOT NULL
+              AND state IN ('processing', 'claimed', 'pending')
+        ),
+        candidates AS (
+            (SELECT
+                active.id AS sort_id,
+                active.state AS sort_state,
+                active.created_at AS sort_created_at,
+                FALSE AS retained,
+                jsonb_build_object(
+                    'id', active.id,
+                    'batch_id', active.batch_id,
+                    'model', active.model,
+                    'status', active.state,
+                    'created_at', active.created_at,
+                    'completed_at', active.completed_at,
+                    'failed_at', active.failed_at,
+                    'duration_ms', (CASE
+                        WHEN active.completed_at IS NOT NULL AND active.started_at IS NOT NULL
+                        THEN EXTRACT(EPOCH FROM (active.completed_at - active.started_at)) * 1000
+                        ELSE NULL END)::float8,
+                    'response_status', active.response_status,
+                    'service_tier', active.service_tier,
+                    'created_by', active.created_by
+                ) AS live_summary,
+                NULL::date AS delete_on,
+                NULL::uuid AS group_id,
+                NULL::text AS object_kind,
+                NULL::uuid AS object_id,
+                NULL::uuid AS request_id,
+                NULL::text AS created_by,
+                NULL::text AS service_tier,
+                NULL::text AS state,
+                NULL::text AS model,
+                NULL::timestamptz AS created_at,
+                NULL::timestamptz AS terminal_at,
+                NULL::smallint AS schema_version,
+                NULL::jsonb AS payload
+            FROM active
+            WHERE {active_owner}
+              AND ($2::text IS NULL OR active.state = $2)
+              AND ($3::text[] IS NULL OR active.model = ANY($3)){active_dates}
+              AND ($6::text[] IS NULL OR active.service_tier = ANY($6))
+            ORDER BY {active_order}
+            LIMIT $7 + $8)
+
+            UNION ALL
+
             (SELECT
                 request.id AS sort_id,
                 request.state AS sort_state,
@@ -1361,12 +1518,13 @@ fn list_requests_page_sql(active_first: bool, owner_scoped: bool) -> String {
             FROM requests request
             WHERE request.created_by IS NOT NULL
               AND {live_owner}
+              -- Complement of the `active` CTE: together the two live arms
+              -- cover every batchless row exactly once.
+              AND request.state NOT IN ('processing', 'claimed', 'pending')
               AND ($2::text IS NULL OR request.state = $2)
-              AND ($3::text[] IS NULL OR request.model = ANY($3))
-              AND ($4::timestamptz IS NULL OR request.created_at >= $4)
-              AND ($5::timestamptz IS NULL OR request.created_at <= $5)
+              AND ($3::text[] IS NULL OR request.model = ANY($3)){live_dates}
               AND ($6::text[] IS NULL OR request.service_tier = ANY($6))
-            ORDER BY {live_order}
+            ORDER BY {terminal_order}
             LIMIT $7 + $8)
 
             UNION ALL
@@ -1412,12 +1570,7 @@ fn list_requests_page_sql(active_first: bool, owner_scoped: bool) -> String {
               AND object.created_by IS NOT NULL
               AND {retained_owner}
               AND ($2::text IS NULL OR object.state = $2)
-              AND ($3::text[] IS NULL OR object.model = ANY($3))
-              AND ($4::timestamptz IS NULL OR object.created_at >= $4)
-              -- V1 proves created_at < delete_on, so this necessary lower
-              -- bound enables daily partition pruning.
-              AND ($4::timestamptz IS NULL OR object.delete_on > ($4 AT TIME ZONE 'UTC')::date)
-              AND ($5::timestamptz IS NULL OR object.created_at <= $5)
+              AND ($3::text[] IS NULL OR object.model = ANY($3)){retained_dates}
               AND ($6::text[] IS NULL OR object.service_tier = ANY($6))
               AND NOT EXISTS (
                   SELECT 1 FROM requests live
@@ -1454,8 +1607,9 @@ pub(crate) async fn list_requests<P: PoolProvider>(
 
     let count = count_requests_with_budget(manager, &filter).await?;
     let mut tx = begin_primary_read(manager).await?;
+    apply_statement_budget(&mut tx, PAGE_BUDGET).await?;
 
-    let query = list_requests_page_sql(filter.active_first, filter.created_by.is_some());
+    let query = list_requests_page_sql(PageShape::of(&filter));
     let rows = sqlx::query(&query)
         .bind(filter.created_by.as_deref())
         .bind(filter.status.as_deref())
@@ -3808,7 +3962,12 @@ mod tests {
         for active_first in [true, false] {
             let sql = format!(
                 "PREPARE owner_page(text, text, text[], timestamptz, timestamptz, text[], bigint, bigint) AS {}",
-                list_requests_page_sql(active_first, true)
+                list_requests_page_sql(PageShape {
+                    active_first,
+                    owner_scoped: true,
+                    created_after: false,
+                    created_before: false
+                })
             );
             sqlx::raw_sql(&sql).execute(&mut *tx).await.unwrap();
             let plan: serde_json::Value = sqlx::query_scalar(
@@ -3889,25 +4048,39 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(list_count, 1);
-        let page_rows = sqlx::query(&list_requests_page_sql(false, false))
-            .bind(Option::<&str>::None)
-            .bind(Option::<&str>::None)
-            .bind(Option::<Vec<String>>::None)
-            .bind(Some(timestamp("2026-08-10T00:00:00Z")))
-            .bind(Option::<DateTime<Utc>>::None)
-            .bind(Option::<Vec<String>>::None)
-            .bind(20_i64)
-            .bind(0_i64)
-            .fetch_all(&pool)
-            .await
-            .unwrap();
+        let page_rows = sqlx::query(&list_requests_page_sql(PageShape {
+            active_first: false,
+            owner_scoped: false,
+            created_after: true,
+            created_before: false,
+        }))
+        .bind(Option::<&str>::None)
+        .bind(Option::<&str>::None)
+        .bind(Option::<Vec<String>>::None)
+        .bind(Some(timestamp("2026-08-10T00:00:00Z")))
+        .bind(Option::<DateTime<Utc>>::None)
+        .bind(Option::<Vec<String>>::None)
+        .bind(20_i64)
+        .bind(0_i64)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
         assert_eq!(page_rows.len(), 1);
         assert!(page_rows[0].get::<bool, _>("retained"));
         assert_eq!(page_rows[0].get::<Uuid, _>("object_id"), planner_request_id);
 
         for (label, sql, page) in [
             ("count", LIST_REQUESTS_COUNT_SQL.to_owned(), false),
-            ("page", list_requests_page_sql(false, false), true),
+            (
+                "page",
+                list_requests_page_sql(PageShape {
+                    active_first: false,
+                    owner_scoped: false,
+                    created_after: true,
+                    created_before: false,
+                }),
+                true,
+            ),
         ] {
             let plan = explain_bounded_list_query(&pool, &sql, page).await;
             assert!(
@@ -4323,6 +4496,65 @@ mod tests {
             },
             request_payload(),
         )
+    }
+
+    #[test]
+    fn page_sql_emits_date_bounds_directly_or_omits_them() {
+        // A `($n IS NULL OR col >= $n)` bound can never become an index
+        // boundary condition in a generic prepared plan, so the scan walks
+        // every row newer than the requested range instead of seeking to it.
+        // Emitting the predicate only when the caller supplied it is what makes
+        // date-filtered pages fast; the value stays bound either way.
+        let both = list_requests_page_sql(PageShape {
+            active_first: true,
+            owner_scoped: true,
+            created_after: true,
+            created_before: true,
+        });
+        assert!(both.contains("AND request.created_at >= $4"));
+        assert!(both.contains("AND request.created_at <= $5"));
+        assert!(both.contains("AND active.created_at >= $4"));
+        assert!(both.contains("AND object.created_at <= $5"));
+        assert!(!both.contains("$4::timestamptz IS NULL"));
+        assert!(!both.contains("$5::timestamptz IS NULL"));
+
+        // With neither bound the predicates vanish rather than degrading into a
+        // disjunction.
+        let neither = list_requests_page_sql(PageShape {
+            active_first: true,
+            owner_scoped: true,
+            created_after: false,
+            created_before: false,
+        });
+        assert!(!neither.contains("created_at >= $4"));
+        assert!(!neither.contains("created_at <= $5"));
+        assert!(!neither.contains("delete_on > ($4"));
+
+        // The retained lower bound that drives daily partition pruning rides
+        // with created_after, and only with created_after.
+        let after_only = list_requests_page_sql(PageShape {
+            active_first: false,
+            owner_scoped: false,
+            created_after: true,
+            created_before: false,
+        });
+        assert!(after_only.contains("AND object.delete_on > ($4 AT TIME ZONE 'UTC')::date"));
+        assert!(!after_only.contains("created_at <= $5"));
+    }
+
+    #[test]
+    fn live_arms_partition_the_state_space_exactly_once() {
+        // The in-flight CTE and the terminal live arm must be exact
+        // complements: any overlap duplicates rows on the page, any gap drops
+        // them silently.
+        let sql = list_requests_page_sql(PageShape {
+            active_first: true,
+            owner_scoped: true,
+            created_after: false,
+            created_before: false,
+        });
+        assert!(sql.contains("state IN ('processing', 'claimed', 'pending')"));
+        assert!(sql.contains("request.state NOT IN ('processing', 'claimed', 'pending')"));
     }
 
     #[test]

--- a/fusillade-arsenal/src/postgres/retained_response.rs
+++ b/fusillade-arsenal/src/postgres/retained_response.rs
@@ -1425,10 +1425,23 @@ fn list_requests_page_sql(shape: PageShape) -> String {
                   'FOR VALUES FROM (%L) TO (%L)', bucket.delete_on, bucket.delete_on + 1
               )
         ),
-        -- The entire in-flight population, materialized up front. Its size is
-        -- bounded by how much work can be simultaneously in flight, not by how
-        -- much history the table holds, so this stays cheap as `requests`
-        -- grows. `idx_requests_state` serves it; no rank-ordered index needed.
+        -- The entire non-terminal batchless population, materialized up front,
+        -- read via `idx_requests_state`. Sorting it by rank costs nothing at
+        -- the sizes seen so far, which is what lets the two ~4 GB rank-ordered
+        -- indexes go away.
+        --
+        -- Sizing caveat: `claimed` and `processing` are bounded by daemon
+        -- concurrency, but `pending` is a QUEUE, so this is bounded by backlog
+        -- depth rather than by concurrency. It is decoupled from history depth
+        -- -- the thing that actually grows without limit -- but it is not
+        -- constant, and there is no LIMIT here, so a sustained drain stall
+        -- makes this CTE proportional to the backlog. Today production holds a
+        -- single non-terminal batchless row. If that ever stops being true, the
+        -- fix is a partial index on
+        -- (created_by, rank, created_at DESC, id DESC) restricted to these
+        -- three states, which lets the arm become a bounded ordered scan; it
+        -- indexes only non-terminal rows, so it is sized by the backlog it
+        -- guards against rather than by the table.
         active AS MATERIALIZED (
             SELECT id, state, created_at, created_by, model, service_tier, batch_id,
                    completed_at, failed_at, started_at, response_status

--- a/fusillade-arsenal/tests/retained_responses.rs
+++ b/fusillade-arsenal/tests/retained_responses.rs
@@ -3660,6 +3660,110 @@ async fn read_apis_preserve_exact_values_filters_pages_and_counts_after_move(poo
 }
 
 #[sqlx::test]
+async fn active_first_page_ranks_in_flight_rows_before_newer_ones(pool: PgPool) {
+    // The in-flight arm reads from a materialized CTE and must apply the full
+    // page ordering itself, rank included. Ordering it by created_at alone is
+    // invisible until more rows are in flight than fit on one page: the arm
+    // then returns the NEWEST in-flight rows, and a lower-ranked but older row
+    // that belongs on page one is silently dropped off the end.
+    let base = timestamp("2026-08-01T12:00:00Z");
+    let mut ids = Vec::new();
+    for (index, suffix) in ["rank-oldest", "rank-second", "rank-third", "rank-newest"]
+        .iter()
+        .enumerate()
+    {
+        let graph = singleton(&pool, "priority", TerminalState::Pending, base, suffix).await;
+        ids.push(graph.request_ids[0]);
+        // created_at strictly ascending across ids[0..4].
+        sqlx::query("UPDATE requests SET created_at = $2 WHERE id = $1")
+            .bind(graph.request_ids[0])
+            .bind(base - TimeDelta::minutes(40 - 10 * index as i64))
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+    // Ranks deliberately disagree with recency. claimed/processing carry the
+    // daemon and timestamp fields their CHECK constraints require.
+    for (id, state) in [
+        (ids[0], "processing"),
+        (ids[1], "pending"),
+        (ids[2], "claimed"),
+        (ids[3], "pending"),
+    ] {
+        sqlx::query(
+            "UPDATE requests
+                SET state = $2,
+                    daemon_id = CASE WHEN $2 = 'pending' THEN NULL ELSE $3 END,
+                    claimed_at = CASE WHEN $2 = 'pending' THEN NULL ELSE $4 END,
+                    started_at = CASE WHEN $2 = 'processing' THEN $4 ELSE NULL END
+              WHERE id = $1",
+        )
+        .bind(id)
+        .bind(state)
+        .bind(Uuid::nil())
+        .bind(base)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    let request_manager = manager(&pool).await;
+
+    // processing, then claimed, then the two pending newest-first.
+    let expected = [ids[0], ids[2], ids[3], ids[1]];
+    for (skip, expected_id) in expected.iter().enumerate() {
+        let page = request_manager
+            .list_requests(ListRequestsFilter {
+                created_by: Some(OWNER.to_owned()),
+                active_first: true,
+                limit: 1,
+                skip: skip as i64,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            page.data.iter().map(|r| r.id).collect::<Vec<_>>(),
+            vec![*expected_id],
+            "active-first page at skip={skip} must rank in-flight rows before newer ones"
+        );
+    }
+
+    // A page smaller than the in-flight set is where a created_at-only in-flight
+    // arm regresses: it would surface the two newest rows instead of the two
+    // lowest-ranked ones.
+    let first_page = request_manager
+        .list_requests(ListRequestsFilter {
+            created_by: Some(OWNER.to_owned()),
+            active_first: true,
+            limit: 2,
+            skip: 0,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        first_page.data.iter().map(|r| r.id).collect::<Vec<_>>(),
+        vec![ids[0], ids[2]]
+    );
+
+    // active_first=false is a pure recency ordering over the same rows.
+    let recency = request_manager
+        .list_requests(ListRequestsFilter {
+            created_by: Some(OWNER.to_owned()),
+            active_first: false,
+            limit: 4,
+            skip: 0,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        recency.data.iter().map(|r| r.id).collect::<Vec<_>>(),
+        vec![ids[3], ids[2], ids[1], ids[0]]
+    );
+}
+
+#[sqlx::test]
 async fn retained_pages_validate_routes_before_limit_and_merge_terminal_ties(pool: PgPool) {
     install_candidate_index(&pool).await;
     let delete_on = archive_date("2026-08-03");


### PR DESCRIPTION
Stacked on #1699 — review that first. **Base must be retargeted to `main` once #1699 merges**, or this merges into a dead branch.

#1699 fixed the retained arm. This finishes the job on the live arm, and pays for itself in index footprint: **+204 MB, −7,101 MB**.

## What the page actually needs

Three separate questions, currently fused into one:

1. What is in flight? — a set bounded by *concurrency*, not history. One row in production today.
2. What finished recently? — a plain `created_at DESC` scan of live rows.
3. What finished long ago? — the same, over the archive.

## The change

**Read the in-flight rows from a materialized CTE.** Its size is bounded by how much work can be simultaneously in flight rather than by how much history `requests` holds, so it stays cheap as the table grows. `idx_requests_state` already serves it, and it is small enough to sort by rank with no index support at all. Every other arm then orders by `created_at` alone — an ordering `idx_requests_user_created_sort` and `idx_requests_created_tier` already provide.

**Emit the two `created_at` bounds directly** when the caller supplies them, exactly as the owner predicate already works after #1699. A `($n IS NULL OR col >= $n)` bound cannot become an index boundary condition in a generic prepared plan; that is what made date filtering slow, independently of the ordering. Measured before: 1,774,936 index entries walked to return a ten-row page.

**One new index.** The archive has owner-, state-, model- and tier-leading sort indexes but nothing yielding plain newest-first across all owners, so the unscoped page planned as Append + Sort over the whole retained history and did not complete inside 240s.

**A statement budget on the page query.** It runs on the write pool and had none, so a pathological filter — a status value matching nothing, where the scan has no early exit — held a primary connection unbounded and outlived the request that started it.

## Why the two dropped indexes stopped earning their keep

| index | size | scans |
| --- | --- | --- |
| `idx_requests_user_active_sort` | 3983 MB | 3,427 |
| `idx_requests_active_first_tier` | 3118 MB | 169 |

Both exist only to materialize `ORDER BY CASE state ... END`. That is a presentation choice, not a data property, and three things made it a bad one to encode:

1. **The rank column is unbounded.** In `(created_by, RANK, created_at DESC, id DESC)` nothing ever supplies an equality on RANK, so on PostgreSQL 17 `created_at` can never be a scan boundary (no btree skip scan until 18).
2. **The ordering is close to meaningless now.** These date from when batchless responses were new. The population is now overwhelmingly terminal — a single non-terminal row in production — so ~7 GB of index existed to order 20M rows by a column that is constant for all but one of them.
3. **They crowded the cache.** `requests` carried ~29 GB of indexes against a 32 GB compute cache, while these two served under 4,000 scans between them against 278M for the 401 MB `idx_requests_state`. On network-attached storage every evicted page is a round trip, so the reclaim helps queries that never touch this page.

## Validation

Against a production-sized copy, generic plans forced, all sixteen shapes of `active_first` × `owner_scoped` × `created_after` × `created_before`: **3.6–4.8 ms warm**, worst first-touch 441 ms. The SQL was extracted from the builder itself rather than retyped, so what was measured is what ships.

Swept separately on the same copy, existing indexes only: status pending/claimed/processing 2.5–2.8 ms; status completed 1.1 ms; model and tier filters 3.5–8.2 ms; skip 100/1000/5000 = 5.4/21.6/107 ms.

`cargo test -p fusillade-arsenal` passes (236 lib + 72 retained_responses + the rest). `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt` clean.

New tests:

- `active_first_page_ranks_in_flight_rows_before_newer_ones` — the in-flight arm must apply the full page ordering, rank included. Ordering it by `created_at` alone is invisible until more rows are in flight than fit on one page, at which point a lower-ranked but older row is silently dropped off the end. Confirmed the test fails against that regression before relying on it.
- `page_sql_emits_date_bounds_directly_or_omits_them` — guards the shape emission both ways, including that the retained partition-pruning lower bound rides with `created_after` and only with `created_after`.
- `live_arms_partition_the_state_space_exactly_once` — the in-flight CTE and the terminal arm must be exact complements; overlap duplicates rows, a gap drops them.

Known, pre-existing: `cargo sqlx prepare --check --workspace` fails on the base branch too (different query id). This change adds no sqlx compile-time macros, so it introduces no cached-query requirements, and the `.sqlx` cache is untouched.

## Deploy

Run all three out-of-band **before** deploying so the migration statements are no-ops; the recipe is in the migration comment. `CREATE INDEX CONCURRENTLY` cannot target a partitioned parent, so the archive index needs per-child builds plus `ALTER INDEX ... ATTACH PARTITION`. **`ANALYZE` the retained partitions after attaching and before deploying** — until the new index has statistics the planner keeps choosing the owner-leading index and sorting, which measured 280s versus 3 ms after.

Ordering matters for rollback: the drops must not land before the rewrite is serving, since the previous query against the post-drop index set does not complete inside 300s.

## Deliberately not fixed

`status=canceled` has no early exit — there are zero canceled rows anywhere in the table — so it walks the history and now hits the statement budget instead of hanging. `status=failed` scoped to an owner with very few failures is ~490 ms warm. Both are pre-existing: the current query on `main` times out at 30s on `status=pending` too. Closing them needs a fourth index for one explicitly-selected filter value, which is not worth it while `canceled` matches nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
