### PR TITLE
perf(fusillade): page batchless archive discovery and hot-loop busy movers

### DIFF
--- a/fusillade-arsenal/src/postgres/retained_response.rs
+++ b/fusillade-arsenal/src/postgres/retained_response.rs
@@ -3357,6 +3357,14 @@ async fn move_graph<P: PoolProvider>(
 // deletion day can still be in the future. This keeps an arbitrary due legacy
 // backlog outside the bounded probe budget while the lock-time checks remain
 // authoritative. A graph is one request, so its group id is its request id.
+//
+// Discovery is paged: one probe returns up to `$5` of the oldest eligible
+// graphs, in global terminal order, instead of a single row. Each tier arm
+// still walks the validated retention-due index in order, so the per-tier
+// `LIMIT $5` is an index-range read, and the outer sort merges the (at most)
+// tier-count small arms. A serial one-row probe per candidate was the whole
+// pass's critical path once moves fanned out: 512 round trips of discovery
+// before the first mover started.
 const CANDIDATE_DISCOVERY_SQL: &str = r#"
         WITH policy(service_tier, archive_after) AS (
             SELECT * FROM UNNEST($1::text[], $2::timestamptz[])
@@ -3394,41 +3402,48 @@ const CANDIDATE_DISCOVERY_SQL: &str = r#"
                              WHEN 'canceled' THEN request.canceled_at
                          END,
                          request.id
-                LIMIT 1
+                LIMIT $5
             ) candidate
             ORDER BY candidate.terminal_at, candidate.id
-            LIMIT 1
+            LIMIT $5
         )
         SELECT candidate.request_id, candidate.group_id
         FROM candidate_seed candidate
+        ORDER BY candidate.terminal_at, candidate.request_id
         "#;
 
-async fn next_candidate<P: PoolProvider>(
+/// One discovery probe: up to `page_size` of the oldest eligible graphs not
+/// already excluded, oldest first. Fewer rows than asked for means the
+/// eligible set is exhausted beyond this page.
+async fn next_candidates<P: PoolProvider>(
     manager: &PostgresRequestManager<P>,
     tiers: &[String],
     archive_after: &[DateTime<Utc>],
     terminal_before: DateTime<Utc>,
     excluded_request_ids: &[Uuid],
-) -> MovementResult<Option<Candidate>> {
-    let row: Option<(Uuid, Uuid)> = sqlx::query_as(CANDIDATE_DISCOVERY_SQL)
+    page_size: i64,
+) -> MovementResult<Vec<Candidate>> {
+    let rows: Vec<(Uuid, Uuid)> = sqlx::query_as(CANDIDATE_DISCOVERY_SQL)
         .bind(tiers)
         .bind(archive_after)
         .bind(terminal_before)
         .bind(excluded_request_ids)
-        .fetch_optional(manager.read_executor())
+        .bind(page_size)
+        .fetch_all(manager.read_executor())
         .await
         .map_err(database_failure)?;
-    let Some((request_id, group_id)) = row else {
-        return Ok(None);
-    };
-    if group_id != request_id {
-        return Err(incomplete_graph());
-    }
-    Ok(Some(Candidate {
-        request_id,
-        group_id,
-        discovered_topology: graph_topology(request_id),
-    }))
+    rows.into_iter()
+        .map(|(request_id, group_id)| {
+            if group_id != request_id {
+                return Err(incomplete_graph());
+            }
+            Ok(Candidate {
+                request_id,
+                group_id,
+                discovered_topology: graph_topology(request_id),
+            })
+        })
+        .collect()
 }
 
 pub(crate) async fn archive_terminal_batchless_responses<P: PoolProvider>(
@@ -3537,32 +3552,41 @@ async fn archive_batchless_responses<P: PoolProvider>(
         });
     }
     let candidate_limit = max_groups.saturating_add(1);
+    // Discovery normally completes in one probe: a page of `candidate_limit`
+    // rows. Further probes only run when a page came back full of graphs
+    // this pass had already seen (deduplicated by group), and even then the
+    // probe count stays bounded so a pathological queue cannot spin here.
     let max_probes = candidate_limit.saturating_mul(2);
-    let mut candidates = Vec::new();
+    let mut candidates: Vec<Candidate> = Vec::new();
     let mut seen_groups = std::collections::HashSet::new();
     let mut excluded_request_ids = Vec::new();
     let mut discovery_exhausted = false;
     for _ in 0..max_probes {
-        if candidates.len() as i64 == candidate_limit {
+        let page_size = candidate_limit - candidates.len() as i64;
+        if page_size <= 0 {
             break;
         }
-        let Some(candidate) = next_candidate(
+        let page = next_candidates(
             manager,
             &tiers,
             &archive_after,
             cutoffs.terminal_before(),
             &excluded_request_ids,
+            page_size,
         )
-        .await?
-        else {
-            discovery_exhausted = true;
-            break;
-        };
-        excluded_request_ids.extend(candidate.discovered_topology.request_ids.iter().copied());
+        .await?;
+        let page_exhausted = (page.len() as i64) < page_size;
+        for candidate in page {
+            excluded_request_ids.extend(candidate.discovered_topology.request_ids.iter().copied());
+            if seen_groups.insert(candidate.group_id) {
+                candidates.push(candidate);
+            }
+        }
         excluded_request_ids.sort_unstable();
         excluded_request_ids.dedup();
-        if seen_groups.insert(candidate.group_id) {
-            candidates.push(candidate);
+        if page_exhausted {
+            discovery_exhausted = true;
+            break;
         }
     }
     let mut outcome = RetainedResponseArchiveOutcome {
@@ -4147,6 +4171,7 @@ mod tests {
             .bind(vec![timestamp("2026-08-01T00:00:00Z")])
             .bind(timestamp("2026-08-08T00:00:00Z"))
             .bind(Vec::<Uuid>::new())
+            .bind(513_i64)
             .fetch_one(&mut *tx)
             .await
             .expect("candidate discovery must be explainable");

--- a/fusillade-arsenal/tests/retained_responses.rs
+++ b/fusillade-arsenal/tests/retained_responses.rs
@@ -2839,6 +2839,68 @@ async fn deferred_oldest_group_does_not_consume_the_movement_budget(pool: PgPool
 }
 
 #[sqlx::test]
+async fn one_pass_discovers_a_page_of_the_oldest_graphs_across_tiers(pool: PgPool) {
+    install_candidate_index(&pool).await;
+    ensure_partition(&pool, archive_date("2026-08-03")).await;
+    // Interleave tiers so oldest-first across the whole queue differs from
+    // oldest-first within any one tier: a paged probe must merge the tier
+    // arms, not drain one tier before looking at the next.
+    let mut graphs = Vec::new();
+    for (index, (tier, hour)) in [
+        ("flex", 8),
+        ("priority", 9),
+        ("flex", 10),
+        ("priority", 11),
+        ("flex", 12),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        graphs.push(
+            singleton(
+                &pool,
+                tier,
+                TerminalState::Completed,
+                timestamp(&format!("2026-08-01T{hour:02}:00:00Z")),
+                &format!("paged-{index}"),
+            )
+            .await,
+        );
+    }
+    let manager = manager(&pool).await;
+    let retention_policy = policy(&[("flex", 86_400), ("priority", 86_400)]);
+
+    let first = archive(&manager, &retention_policy, 3, i64::MAX)
+        .await
+        .expect("a paged pass must archive up to its graph budget");
+
+    assert_eq!(first.groups_archived, 3);
+    assert!(
+        first.may_have_more,
+        "the spare discovered candidate proves more work"
+    );
+    for graph in &graphs[..3] {
+        assert_wholly_retained(&pool, graph).await;
+    }
+    for graph in &graphs[3..] {
+        assert_wholly_live(&pool, graph).await;
+    }
+
+    let second = archive(&manager, &retention_policy, 3, i64::MAX)
+        .await
+        .expect("the remainder must archive on the next pass");
+
+    assert_eq!(second.groups_archived, 2);
+    assert!(
+        !second.may_have_more,
+        "a short page proves the eligible set is exhausted"
+    );
+    for graph in &graphs {
+        assert_wholly_retained(&pool, graph).await;
+    }
+}
+
+#[sqlx::test]
 async fn archives_singleton_request_template_as_one_group(pool: PgPool) {
     install_candidate_index(&pool).await;
     ensure_partition(&pool, archive_date("2026-08-03")).await;

--- a/fusillade/src/daemon/mod.rs
+++ b/fusillade/src/daemon/mod.rs
@@ -960,6 +960,11 @@ async fn run_batch_archive_phase<S>(
     }
 }
 
+/// Runs one batchless archive pass. Returns `true` when the pass proved more
+/// eligible work remains (`may_have_more`), so the worker can go straight
+/// into its next pass instead of sleeping out the tick interval. A failed or
+/// cancelled pass returns `false`: it keeps the metric raised, but a hot loop
+/// on a failing pass would only amplify the failure.
 async fn run_batchless_archive_phase<S>(
     storage: &S,
     shutdown: &tokio_util::sync::CancellationToken,
@@ -967,7 +972,8 @@ async fn run_batchless_archive_phase<S>(
     retention_policy: &RetentionPolicy,
     cutoffs: &RetainedResponseArchiveCutoffs,
     tick: ArchiveMoverTick,
-) where
+) -> bool
+where
     S: DaemonStorage,
 {
     let started = std::time::Instant::now();
@@ -1054,8 +1060,9 @@ async fn run_batchless_archive_phase<S>(
                     "Retained-response archive phase completed"
                 );
             }
+            outcome.may_have_more
         }
-        Ok(None) => {}
+        Ok(None) => false,
         Err(error) => {
             // A failed pass has not proven the queue empty: keep the
             // "may have more" signal raised so a drain operator never reads a
@@ -1070,10 +1077,13 @@ async fn run_batchless_archive_phase<S>(
                 error = %error,
                 "Failed to archive retained-response graphs"
             );
+            false
         }
     }
 }
 
+/// Runs one mover tick. Returns `true` when the batchless phase reported
+/// more eligible work, which the worker loop treats as "run again now".
 async fn run_archive_mover_tick<S>(
     storage: Arc<S>,
     shutdown: &tokio_util::sync::CancellationToken,
@@ -1081,13 +1091,15 @@ async fn run_archive_mover_tick<S>(
     retention_policy: &RetentionPolicy,
     tick: ArchiveMoverTick,
     retained_runway_ready: &AtomicBool,
-) where
+) -> bool
+where
     S: DaemonStorage + 'static,
 {
     let observed_at = chrono::Utc::now();
     if tick.batch_enabled {
         run_batch_archive_phase(storage.clone(), shutdown, query_timeout, tick).await;
     }
+    let mut more_work = false;
     if tick.batchless_enabled {
         let index_ready = match maintenance_query(
             shutdown,
@@ -1112,7 +1124,7 @@ async fn run_archive_mover_tick<S>(
         };
         if !index_ready || !retained_runway_ready.load(Ordering::Acquire) {
             gauge!("fusillade_retained_response_archive_ready", "worker" => tick.worker).set(0.0);
-            return;
+            return false;
         }
         gauge!("fusillade_retained_response_archive_ready", "worker" => tick.worker).set(1.0);
         let cutoffs = match retained_archive_cutoffs_at(
@@ -1129,10 +1141,10 @@ async fn run_archive_mover_tick<S>(
                     error = %error,
                     "Archive mover could not resolve immutable cutoffs"
                 );
-                return;
+                return false;
             }
         };
-        run_batchless_archive_phase(
+        more_work = run_batchless_archive_phase(
             storage.as_ref(),
             shutdown,
             query_timeout,
@@ -1142,6 +1154,7 @@ async fn run_archive_mover_tick<S>(
         )
         .await;
     }
+    more_work
 }
 
 fn supervise_daemon_handles(
@@ -3489,12 +3502,26 @@ where
                         batchless_enabled,
                         "Archive mover started"
                     );
+                    // The interval paces an idle worker. While a pass keeps
+                    // proving there is more to move, the next pass starts
+                    // straight away: sleeping a full interval between
+                    // back-to-back passes of a multi-day drain is pure idle
+                    // time on the critical path. Errors and empty passes fall
+                    // back to the interval, so a failing pass never hot-loops.
+                    let mut more_work = false;
                     loop {
-                        tokio::select! {
-                            _ = tokio::time::sleep(Duration::from_millis(interval_ms)) => {},
-                            _ = shutdown.cancelled() => break,
+                        if more_work {
+                            if shutdown.is_cancelled() {
+                                break;
+                            }
+                            tokio::task::yield_now().await;
+                        } else {
+                            tokio::select! {
+                                _ = tokio::time::sleep(Duration::from_millis(interval_ms)) => {},
+                                _ = shutdown.cancelled() => break,
+                            }
                         }
-                        run_archive_mover_tick(
+                        more_work = run_archive_mover_tick(
                             storage.clone(),
                             &shutdown,
                             query_timeout,
@@ -3858,6 +3885,8 @@ mod tests {
         fail_route_cleanup: std::sync::atomic::AtomicBool,
         batchless_cutoffs: std::sync::Mutex<Vec<RetainedResponseArchiveCutoffs>>,
         overdue_concurrency: std::sync::Mutex<Vec<usize>>,
+        batchless_may_have_more: std::sync::atomic::AtomicBool,
+        fail_batchless: std::sync::atomic::AtomicBool,
         fail_weekly: std::sync::atomic::AtomicBool,
         fail_retained: std::sync::atomic::AtomicBool,
         block_retained: std::sync::atomic::AtomicBool,
@@ -3889,6 +3918,8 @@ mod tests {
                 fail_route_cleanup: std::sync::atomic::AtomicBool::new(false),
                 batchless_cutoffs: std::sync::Mutex::new(Vec::new()),
                 overdue_concurrency: std::sync::Mutex::new(Vec::new()),
+                batchless_may_have_more: std::sync::atomic::AtomicBool::new(false),
+                fail_batchless: std::sync::atomic::AtomicBool::new(false),
                 fail_weekly: std::sync::atomic::AtomicBool::new(false),
                 fail_retained: std::sync::atomic::AtomicBool::new(false),
                 block_retained: std::sync::atomic::AtomicBool::new(false),
@@ -3911,6 +3942,18 @@ mod tests {
 
         fn record(&self, event: &'static str) {
             self.events.lock().unwrap().push(event);
+        }
+
+        fn batchless_outcome(&self) -> Result<crate::RetainedResponseArchiveOutcome> {
+            if self.fail_batchless.load(Ordering::SeqCst) {
+                return Err(FusilladeError::Other(anyhow::anyhow!(
+                    "batchless archive failed"
+                )));
+            }
+            Ok(crate::RetainedResponseArchiveOutcome {
+                may_have_more: self.batchless_may_have_more.load(Ordering::SeqCst),
+                ..Default::default()
+            })
         }
     }
 
@@ -3964,7 +4007,7 @@ mod tests {
             self.batchless_calls.fetch_add(1, Ordering::SeqCst);
             self.batchless_cutoffs.lock().unwrap().push(*cutoffs);
             self.record("batchless_move");
-            Ok(crate::RetainedResponseArchiveOutcome::default())
+            self.batchless_outcome()
         }
 
         async fn archive_overdue_batchless_responses(
@@ -3979,7 +4022,7 @@ mod tests {
             self.batchless_cutoffs.lock().unwrap().push(*cutoffs);
             self.overdue_concurrency.lock().unwrap().push(concurrency);
             self.record("batchless_overdue_move");
-            Ok(crate::RetainedResponseArchiveOutcome::default())
+            self.batchless_outcome()
         }
 
         async fn ensure_retained_response_partitions(
@@ -4627,6 +4670,54 @@ mod tests {
         assert_eq!(
             recorder.values("fusillade_retained_response_movers_active"),
             vec![1.0, 0.0]
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_reports_more_work_only_when_the_pass_proved_it() {
+        let storage = Arc::new(FakeMaintenanceStorage::default());
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let policy = configured_batchless_maintenance().policy().clone();
+        let mut tick = mover_tick(false, true);
+        tick.worker = "backfill";
+        tick.include_overdue = true;
+        let ready = std::sync::atomic::AtomicBool::new(true);
+
+        let run = |storage: Arc<FakeMaintenanceStorage>| {
+            run_archive_mover_tick(
+                storage,
+                &shutdown,
+                Duration::from_secs(1),
+                &policy,
+                tick,
+                &ready,
+            )
+        };
+
+        assert!(
+            !run(storage.clone()).await,
+            "an empty pass paces the worker on its interval"
+        );
+
+        storage
+            .batchless_may_have_more
+            .store(true, Ordering::SeqCst);
+        assert!(
+            run(storage.clone()).await,
+            "a pass that proved more work asks for an immediate next pass"
+        );
+
+        storage.fail_batchless.store(true, Ordering::SeqCst);
+        assert!(
+            !run(storage.clone()).await,
+            "a failing pass must never hot-loop, whatever the queue held"
+        );
+
+        storage.fail_batchless.store(false, Ordering::SeqCst);
+        storage.index_ready.store(false, Ordering::SeqCst);
+        assert!(
+            !run(storage.clone()).await,
+            "a pass skipped for a missing index is not more work"
         );
     }
 


### PR DESCRIPTION
## What

1. **Paged discovery.** `CANDIDATE_DISCOVERY_SQL` takes a page size (`$5`). Each tier arm is the same ordered range read on `idx_requests_batchless_retention_due`, now `LIMIT $5`, merged and re-limited by terminal time, so one probe returns the oldest `max_groups + 1` graphs across all tiers. The probe loop keeps its exclusion list, group dedupe and bounded probe count; a short page proves exhaustion. Semantics are unchanged: globally oldest-first, the same spare candidate for `may_have_more`.
2. **No idle sleep while busy.** `run_batchless_archive_phase` / `run_archive_mover_tick` now return the pass's `may_have_more`. The mover loop starts the next pass immediately (a `yield_now`, with a shutdown check) when the previous one proved more work, and only sleeps the interval when a pass was empty, failed or was skipped for readiness. A failing pass therefore never hot-loops.

Groups per tick needs no change: with the sleep gone the tick size no longer sets the duty cycle.

## Tests

- `candidate_discovery_plan_uses_batchless_retention_due_index` binds the page size and still asserts the index plan.
- New `one_pass_discovers_a_page_of_the_oldest_graphs_across_tiers`: five interleaved flex/priority graphs, a pass of 3 archives exactly the three oldest across tiers with `may_have_more`, the next pass drains the rest and reports exhaustion.
- New `tick_reports_more_work_only_when_the_pass_proved_it`: true only for a successful pass with `may_have_more`; false for empty, failed, and index-not-ready passes.
- Ran locally: `fusillade` daemon tests (47 passed), `fusillade-arsenal` lib retained_response tests (15 passed), `fusillade-arsenal` retained_responses integration suite (72 passed), clippy clean.

## Rollout

No config or migration. Expect the backfill's `fusillade_retained_response_archive_duration_seconds` to drop and `groups_archived_total` rate to rise on deploy; the sweep worker also benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)