### PR TITLE
ci: bump versions for perf, refactor and other commit types

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -16,6 +16,25 @@ jobs:
         uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep in sync with `changelog-sections` in release-please-config.json.
+          # Every type here except `release` produces a release: `feat` bumps
+          # minor, `!`/BREAKING CHANGE bumps major, everything else bumps patch.
+          # `release` is reserved for release-please's own release pull requests.
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            revert
+            deps
+            docs
+            build
+            ci
+            chore
+            test
+            style
+            release
 
       - name: Skip pull request title validation for merge-group commits
         if: github.event_name == 'merge_group'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,74 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": false,
   "separate-pull-requests": true,
+  "pull-request-title-pattern": "release${scope}: release${component} ${version}",
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features",
+      "hidden": false
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes",
+      "hidden": false
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements",
+      "hidden": false
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": false
+    },
+    {
+      "type": "revert",
+      "section": "Reverts",
+      "hidden": false
+    },
+    {
+      "type": "deps",
+      "section": "Dependencies",
+      "hidden": false
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": false
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": false
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": false
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous",
+      "hidden": false
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": false
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": false
+    },
+    {
+      "type": "release",
+      "section": "Releases",
+      "hidden": true
+    }
+  ],
   "packages": {
     ".": {
       "component": "dwctl",


### PR DESCRIPTION
## Why

release-please only created a release for `feat` (minor), `fix` (patch), `revert` (patch) and breaking changes (major). Every other conventional-commit type in use here was **silent**: it never produced a release on its own and only shipped when a later `feat`/`fix` landed.

Types that were previously silent, with counts from the last 400 commits on `main`:

| Type | Commits | Example |
|---|---|---|
| `chore` (mostly `chore(deps)` bumps) | 158 | #1393 bump lettre |
| `test` | 5 | #1561 |
| `ci` | 4 | #1536 |
| `refactor` | 3 | #1424 |
| `perf` | 3 | #1516 index the batchless demand query |
| `docs` | 3 | #1515 |
| `build`, `style`, `deps` | 0 | not used yet, but allowed by the title check |

A `perf` fix or a security `chore(deps)` bump could sit unreleased indefinitely.

## How release-please decides

Verified against release-please 17.11.2 source (the version bundled by `release-please-action@v4`):

- The version bump is computed from every commit in the package's range by `DefaultVersioningStrategy.determineReleaseType`: breaking → major, `feat` → minor, **anything else → patch** ([src/versioning-strategies/default.ts](https://github.com/googleapis/release-please/blob/main/src/versioning-strategies/default.ts)).
- Whether a release PR is opened at all is decided by whether the generated changelog is empty (`changelogEmpty` in [src/strategies/base.ts](https://github.com/googleapis/release-please/blob/main/src/strategies/base.ts)). A commit type is dropped from the changelog when it is absent from `changelog-sections` or listed with `hidden: true`, unless it carries a BREAKING CHANGE note. The defaults hide `docs`, `style`, `chore`, `refactor`, `test`, `build`, `ci`.
- `changelog-sections` set at the top level of the manifest config is inherited by every package unless the package overrides it (`mergeReleaserConfig` in [src/manifest.ts](https://github.com/googleapis/release-please/blob/main/src/manifest.ts)). Docs: [manifest-releaser.md, `changelog-sections`](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile) and [customizing.md, versioning strategies](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#versioning-strategies).

## What changes

**`release-please-config.json`**: add a top-level `changelog-sections` listing every allowed type with `hidden: false`. All four packages (`.`/dwctl, `fusillade-arsenal`, `fusillade-core`, `onwards`) inherit it.

| Commit | Before | After |
|---|---|---|
| `feat:` | minor | minor (unchanged) |
| `fix:`, `revert:` | patch | patch (unchanged) |
| `perf:`, `refactor:`, `deps:`, `docs:`, `build:`, `ci:`, `chore:`, `test:`, `style:` | no release | patch |
| `type!:` or `BREAKING CHANGE:` footer | major | major (unchanged) |

Each type now also gets its own CHANGELOG section (Performance Improvements, Code Refactoring, Dependencies, Documentation, Build System, Continuous Integration, Miscellaneous, Tests, Styles).

### Release-please's own release commits

release-please excludes a package's *own* release commit by SHA, but the root package `.` (dwctl) receives **every** commit in the repository (`path === ROOT_PROJECT_PATH ? commits : splitCommits[path]` in `manifest.ts`). Today `chore(main): release onwards 1.0.0` (#1504) lands in dwctl's range and is ignored only because `chore` is hidden. With `chore` visible it would trigger a spurious dwctl patch release after every onwards / fusillade release, and a fusillade-core release would similarly trigger fusillade-arsenal via the lockfile sync commit.

To keep `chore` releasable without that loop, release PRs are retitled with `pull-request-title-pattern: "release${scope}: release${component} ${version}"`, giving `release(main): release 11.5.2` and `release(main): release onwards 1.0.1`. The `release` type is declared with `hidden: true`, so those commits still produce an empty changelog and no follow-on release. Round-tripped through `PullRequestTitle.parse` for the bare, `onwards` and `fusillade-core` cases with the bundled library; existing tags and already-merged `chore(main): release …` PRs are unaffected because releases are located by tag.

**`.github/workflows/pr-title-check.yml`**: `amannn/action-semantic-pull-request` defaulted to the `conventional-commit-types` list (`feat fix docs style refactor perf test build ci chore revert`), which allowed neither `deps` nor the new `release` type. It now lists the same types as `changelog-sections` explicitly, with a comment pointing at the config so the two lists stay in sync.

## Verification

- `python3 -c 'json.load(...)'` on the config; the JSON schema only requires `type` and `section`, `hidden` is an optional boolean.
- Using `release-please@17.11.2` locally: `chore(deps): …` now yields changelog lines (releasable), `release(main): release onwards 1.0.1` yields none (skipped), `refactor(dwctl)!: …` is parsed as breaking (major) as before.
- No CI run against a real release; the first release PR after merge will carry the new `release(main): …` title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
