### PR TITLE
feat(dashboard): filter responses by account on the console

### DIFF
--- a/dashboard/src/components/features/async-requests/AsyncRequests.test.tsx
+++ b/dashboard/src/components/features/async-requests/AsyncRequests.test.tsx
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { AsyncRequests } from "./AsyncRequests";
 import * as hooks from "../../../api/control-layer/hooks";
+import * as authorization from "../../../utils/authorization";
+import * as orgContext from "../../../contexts/organization/useOrganizationContext";
 
 // Mock the hooks
 vi.mock("../../../api/control-layer/hooks", () => ({
@@ -14,28 +17,36 @@ vi.mock("../../../api/control-layer/hooks", () => ({
     isPending: false,
   })),
   useModels: vi.fn(),
+  useUsers: vi.fn(),
 }));
 
 // Mock authorization hook
 vi.mock("../../../utils/authorization", () => ({
-  useAuthorization: vi.fn(() => ({
-    userRoles: ["PlatformManager"],
-    isLoading: false,
-    hasPermission: () => true,
-    canAccessRoute: () => true,
-    getFirstAccessibleRoute: () => "/batches",
-  })),
+  useAuthorization: vi.fn(),
 }));
 
 // Mock organization context
 vi.mock("../../../contexts/organization/useOrganizationContext", () => ({
-  useOrganizationContext: vi.fn(() => ({
-    activeOrganizationId: null,
-    activeOrganization: null,
-    isOrgContext: false,
-    setActiveOrganization: vi.fn(),
-  })),
+  useOrganizationContext: vi.fn(),
 }));
+
+// Re-applied in beforeEach. A per-test mockReturnValue survives
+// vi.clearAllMocks() (only mockReset would drop it), so without an explicit
+// default every override would leak into the tests that follow it.
+const DEFAULT_AUTH = {
+  userRoles: ["PlatformManager"],
+  isLoading: false,
+  hasPermission: () => true,
+  canAccessRoute: () => true,
+  getFirstAccessibleRoute: () => "/batches",
+};
+
+const DEFAULT_ORG = {
+  activeOrganizationId: null,
+  activeOrganization: null,
+  isOrgContext: false,
+  setActiveOrganization: vi.fn(),
+};
 
 // Mock modals
 vi.mock("../../modals/CreateAsyncModal/CreateAsyncModal", () => ({
@@ -61,9 +72,27 @@ const createWrapper = () => {
   );
 };
 
+// One individual and one organization: the account filter has to offer both,
+// because org-scoped keys bill their traffic to the org rather than to the
+// member who holds the key.
+const ACCOUNTS = [
+  { id: "user-1", email: "dev@example.com", user_type: "individual" },
+  { id: "org-1", email: "ops@example.com", user_type: "organization" },
+];
+
 describe("AsyncRequests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Filters persist to localStorage, so a value written by one test would
+    // otherwise seed the next one.
+    localStorage.clear();
+
+    vi.mocked(authorization.useAuthorization).mockReturnValue(
+      DEFAULT_AUTH as any,
+    );
+    vi.mocked(orgContext.useOrganizationContext).mockReturnValue(
+      DEFAULT_ORG as any,
+    );
 
     vi.mocked(hooks.useConfig).mockReturnValue({
       data: {
@@ -82,6 +111,11 @@ describe("AsyncRequests", () => {
 
     vi.mocked(hooks.useModels).mockReturnValue({
       data: { data: [] },
+      isLoading: false,
+    } as any);
+
+    vi.mocked(hooks.useUsers).mockReturnValue({
+      data: { data: ACCOUNTS },
       isLoading: false,
     } as any);
   });
@@ -183,6 +217,130 @@ describe("AsyncRequests", () => {
         .mock.calls.at(-1)?.[0];
       expect(lastCall?.created_after).toBeUndefined();
       expect(lastCall?.created_before).toBeUndefined();
+    });
+  });
+
+  // `member_id` on this endpoint filters `fusillade.requests.created_by` —
+  // the account a request billed to, not the person who made it. dwctl
+  // rejects the param from anyone below PlatformManager, so the control has
+  // to be gated to match or it 400s the very people it renders for.
+  describe("Account filter", () => {
+    // The filter row lives in the table's headerActions, which DataTable
+    // swaps for the empty state when there are no rows — so these tests need
+    // a row before any filter is on screen.
+    beforeEach(() => {
+      vi.mocked(hooks.useAsyncRequests).mockReturnValue({
+        data: {
+          data: [
+            {
+              id: "req-1",
+              batch_id: null,
+              model: "test-model",
+              status: "completed",
+              created_at: "2026-09-09T12:00:00.000Z",
+              completed_at: "2026-09-09T12:00:01.000Z",
+              failed_at: null,
+              duration_ms: 1000,
+              response_status: 200,
+              service_tier: "flex",
+              prompt_tokens: 1,
+              completion_tokens: 1,
+              reasoning_tokens: null,
+              total_tokens: 2,
+              total_cost: 0.01,
+              // Deliberately not one of the ACCOUNTS addresses: the row
+              // renders its billing email in the User column, and a match
+              // would make the popover assertions ambiguous.
+              created_by_email: "billed@example.com",
+            },
+          ],
+          total_count: 1,
+          skip: 0,
+          limit: 10,
+        },
+        isLoading: false,
+      } as any);
+    });
+
+    it("offers organizations as well as individuals", async () => {
+      const user = userEvent.setup();
+      const { container } = render(<AsyncRequests />, {
+        wrapper: createWrapper(),
+      });
+
+      await user.click(
+        within(container).getByRole("combobox", { name: /filter by account/i }),
+      );
+
+      // Org-scoped keys bill to the org, so an org is often the only account
+      // that has the traffic a platform manager is looking for. Excluding
+      // them — as the Batches member filter does — would hide it.
+      expect(screen.getByText("ops@example.com")).toBeInTheDocument();
+      expect(screen.getByText("dev@example.com")).toBeInTheDocument();
+      expect(screen.getByText("Org")).toBeInTheDocument();
+    });
+
+    it("sends the selected account as member_id", async () => {
+      const user = userEvent.setup();
+      const { container } = render(<AsyncRequests />, {
+        wrapper: createWrapper(),
+      });
+
+      await user.click(
+        within(container).getByRole("combobox", { name: /filter by account/i }),
+      );
+      await user.click(screen.getByText("ops@example.com"));
+
+      const lastCall = vi.mocked(hooks.useAsyncRequests).mock.calls.at(-1)?.[0];
+      expect(lastCall?.member_id).toBe("org-1");
+    });
+
+    it("hides the filter, and sends no member_id, below PlatformManager", () => {
+      vi.mocked(authorization.useAuthorization).mockReturnValue({
+        userRoles: ["StandardUser"],
+        isLoading: false,
+        hasPermission: () => true,
+        canAccessRoute: () => true,
+        getFirstAccessibleRoute: () => "/batches",
+      } as any);
+
+      const { container } = render(<AsyncRequests />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(
+        within(container).queryByRole("combobox", { name: /filter by account/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        vi.mocked(hooks.useAsyncRequests).mock.calls.at(-1)?.[0]?.member_id,
+      ).toBeUndefined();
+    });
+
+    // dwctl checks member_id BEFORE it checks the active organization, so a
+    // stale personal-context selection would silently widen an org-scoped
+    // view. The page must not send it while the control is hidden.
+    it("drops a persisted account id in an org context", () => {
+      localStorage.setItem(
+        "filters:responses",
+        JSON.stringify({ account: "org-1" }),
+      );
+      vi.mocked(orgContext.useOrganizationContext).mockReturnValue({
+        activeOrganizationId: "org-2",
+        activeOrganization: null,
+        isOrgContext: true,
+        setActiveOrganization: vi.fn(),
+      } as any);
+
+      const { container } = render(<AsyncRequests />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(
+        within(container).queryByRole("combobox", { name: /filter by account/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        vi.mocked(hooks.useAsyncRequests).mock.calls.at(-1)?.[0]?.member_id,
+      ).toBeUndefined();
     });
   });
 });

--- a/dashboard/src/components/features/async-requests/AsyncRequests.tsx
+++ b/dashboard/src/components/features/async-requests/AsyncRequests.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Code, Play, Filter, Clock, DollarSign, Check, ChevronsUpDown, Zap, FastForward, Moon, Trash2, Loader2 } from "lucide-react";
+import { Code, Play, Filter, Clock, DollarSign, Check, ChevronsUpDown, Users, Zap, FastForward, Moon, Trash2, Loader2 } from "lucide-react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { toast } from "sonner";
 import { Button } from "../../ui/button";
@@ -36,8 +36,9 @@ import {
   CommandList,
 } from "../../ui/command";
 import { cn } from "../../../lib/utils";
-import { useAsyncRequests, useDeleteAsyncRequest, useModels } from "../../../api/control-layer/hooks";
+import { useAsyncRequests, useDeleteAsyncRequest, useModels, useUsers } from "../../../api/control-layer/hooks";
 import { useAuthorization } from "../../../utils/authorization";
+import { useDebounce } from "../../../hooks/useDebounce";
 import type {
   AsyncRequest,
   AsyncRequestStatus,
@@ -309,10 +310,57 @@ export function AsyncRequests() {
   const modelParam = searchParams.get("model");
   const [createModalOpen, setCreateModalOpen] = useState(createParam === "true");
   const [showApiExamples, setShowApiExamples] = useState(false);
-  const { hasPermission } = useAuthorization();
+  const { userRoles, hasPermission } = useAuthorization();
   const isPlatformManager = hasPermission("manage-models");
   const { isOrgContext, activeOrganizationId } = useOrganizationContext();
   const showUserColumn = isPlatformManager || isOrgContext;
+
+  // Account filter. `member_id` on /batches/requests filters
+  // `fusillade.requests.created_by` — the account a request was BILLED to,
+  // which ingest takes from `api_keys.user_id`. So it selects an *account*,
+  // not a person:
+  //   - an individual  → their personal-key traffic
+  //   - an organization → that org's traffic, all members together
+  // Organizations are therefore included in the picker, unlike the Batches
+  // member filter (which resolves a person to their hidden per-member batch
+  // keys and so deliberately excludes orgs). Picking an org *member* here
+  // would return nothing, because their org-key traffic bills to the org.
+  //
+  // Gated on the PlatformManager ROLE, not on `hasPermission("manage-models")`
+  // above: dwctl gates `member_id` on `can_read_all_resources(Batches)`, which
+  // is PlatformManager (or a legacy admin) and nothing else. Anyone else gets
+  // a 400, so the control must not render for them.
+  //
+  // Personal context only. In an org context the page is already scoped to
+  // that org, which is the right answer there; offering a cross-account picker
+  // on top would only let a PM contradict the context they are sitting in.
+  const showAccountFilter =
+    userRoles.includes("PlatformManager") && !isOrgContext;
+
+  const [accountSearch, setAccountSearch] = useState("");
+  const debouncedAccountSearch = useDebounce(accountSearch, 300);
+  const { data: searchedAccounts } = useUsers({
+    search: debouncedAccountSearch,
+    limit: 50,
+    enabled: showAccountFilter,
+  });
+  // Only the id is persisted — an address list is PII and there is no reason
+  // to leave customer emails in localStorage on a shared workstation. The
+  // label is re-resolved from the live search results on render.
+  const [selectedAccountId, setSelectedAccountId] = usePersistedFilter(
+    PERSIST_SCOPE,
+    "account",
+    "",
+  );
+  const [accountPopoverOpen, setAccountPopoverOpen] = useState(false);
+  const accountList = searchedAccounts?.data ?? [];
+  const selectedAccount = accountList.find((a) => a.id === selectedAccountId);
+  // Never send a persisted id while the control is hidden — an org context
+  // would otherwise be silently overridden by a stale personal-context filter,
+  // since dwctl checks `member_id` before it checks the active organization.
+  const accountIdFilter = showAccountFilter
+    ? selectedAccountId || undefined
+    : undefined;
   // Filters — persisted to URL params + localStorage so they survive
   // navigation to detail pages and across reloads. Date range is intentionally
   // excluded — restoring stale absolute timestamps on a later visit would be
@@ -365,6 +413,10 @@ export function AsyncRequests() {
     setModelFilter(EMPTY_MODEL_FILTER);
     setTierFilter(DEFAULT_TIER_FILTER);
     setDateRange(undefined);
+    // An account selected in personal context means nothing inside an org,
+    // and vice versa — clear it rather than carry it across the switch.
+    setSelectedAccountId("");
+    setAccountSearch("");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeOrganizationId]);
 
@@ -405,6 +457,7 @@ export function AsyncRequests() {
         ? (statusFilter as AsyncRequestStatus)
         : undefined,
     model: modelFilter.length > 0 ? modelFilter.join(",") : undefined,
+    member_id: accountIdFilter,
     created_after: dateRange?.from.toISOString(),
     created_before: dateRange?.to.toISOString(),
     ...pagination.queryParams,
@@ -471,6 +524,98 @@ export function AsyncRequests() {
                 Active first
               </label>
             </div>
+            {showAccountFilter && (
+              <Popover
+                open={accountPopoverOpen}
+                onOpenChange={setAccountPopoverOpen}
+              >
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={accountPopoverOpen}
+                    // role="combobox" does not take its accessible name from
+                    // its content, so the visible label alone leaves this
+                    // button unnamed to assistive tech.
+                    aria-label="Filter by account"
+                    className="w-[220px] h-9 justify-between font-normal"
+                  >
+                    <div className="flex items-center gap-1.5 truncate">
+                      <Users className="w-3.5 h-3.5 shrink-0 text-gray-500" />
+                      <span className="truncate">
+                        {!selectedAccountId
+                          ? "All accounts"
+                          : (selectedAccount?.email ?? "Selected account")}
+                      </span>
+                    </div>
+                    <ChevronsUpDown className="ml-1 h-3.5 w-3.5 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-[300px] p-0" align="start">
+                  {/* Server-side search — the results are already narrowed by
+                      the query, so the Command must not filter them again. */}
+                  <Command shouldFilter={false}>
+                    <CommandInput
+                      placeholder="Search users and organizations..."
+                      value={accountSearch}
+                      onValueChange={setAccountSearch}
+                    />
+                    <CommandList>
+                      <CommandEmpty>No accounts found.</CommandEmpty>
+                      <CommandGroup>
+                        <CommandItem
+                          value="all-accounts"
+                          onSelect={() => {
+                            setSelectedAccountId("");
+                            setAccountSearch("");
+                            setAccountPopoverOpen(false);
+                            pagination.handleReset();
+                          }}
+                        >
+                          <Check
+                            className={cn(
+                              "mr-2 h-4 w-4",
+                              !selectedAccountId ? "opacity-100" : "opacity-0",
+                            )}
+                          />
+                          All accounts
+                        </CommandItem>
+                        {accountList.map((account) => (
+                          <CommandItem
+                            key={account.id}
+                            value={account.id}
+                            onSelect={() => {
+                              setSelectedAccountId(account.id);
+                              setAccountSearch("");
+                              setAccountPopoverOpen(false);
+                              pagination.handleReset();
+                            }}
+                          >
+                            <Check
+                              className={cn(
+                                "mr-2 h-4 w-4",
+                                selectedAccountId === account.id
+                                  ? "opacity-100"
+                                  : "opacity-0",
+                              )}
+                            />
+                            <span className="truncate">{account.email}</span>
+                            {/* Organizations hold every member's org-key
+                                traffic, so the distinction changes what the
+                                filter returns and has to be visible. */}
+                            {account.user_type === "organization" && (
+                              <span className="ml-2 shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-gray-600">
+                                Org
+                              </span>
+                            )}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+            )}
             <Select
               value={statusFilter}
               onValueChange={(v) => {


### PR DESCRIPTION
The console Responses view can filter by status, model, tier and date — but not by who the traffic belongs to. Batches has had a member filter for a while; Responses never got the equivalent, so "show me this customer's responses" has meant going to the database.

dwctl already accepts `member_id` on `/admin/api/v1/batches/requests`, and already gates it on `can_read_all_resources(Batches)`. **No server-side change** — this adds the control the parameter has been waiting for.

## Why "account", not "member"

The parameter filters `fusillade.requests.created_by`, which ingest takes from `api_keys.user_id` — the account a request **bills** to. So it selects an account, not a person:

- an **individual** → their personal-key traffic
- an **organization** → that org's traffic, every member together

Organizations are therefore offered in the picker and tagged `ORG`, where the Batches member filter deliberately excludes them. That difference is not an oversight in either place: Batches resolves a person to their hidden per-member batch keys via `fusillade.batches.api_key_id` and so can genuinely filter by human. Realtime responses have no equivalent column, so picking an org *member* here would return nothing. Calling this "member" would promise attribution it cannot deliver.

## Two things the gating has to get right

- **Role, not the page's existing permission proxy.** The page computes `isPlatformManager` from `hasPermission("manage-models")`. dwctl allows `member_id` only for read-all-batches holders — PlatformManager or a legacy admin — so the control is gated on `userRoles.includes("PlatformManager")`. Anything looser renders a filter that 400s, which is the bug just removed from the customer-facing app in doublewordai/app-doubleword-private#217.
- **Personal context only, and never sent while hidden.** dwctl checks `member_id` *before* it checks the active organization, so a persisted personal-context selection would silently widen an org-scoped view. The id is dropped both on the org switch and at the call site.

Only the id is persisted, not the address — an email list is PII and there is no reason to leave customer addresses in localStorage on a shared workstation. The label is re-resolved from the live search results.

## Test setup change worth a look

`useAuthorization` and `useOrganizationContext` now get their defaults re-applied in `beforeEach` rather than baked into the `vi.mock` factory, and localStorage is cleared there too. `vi.clearAllMocks()` does not undo a `mockReturnValue` (only `mockReset` does), so a per-test override leaked into every test after it — the new gating tests would have passed for the wrong reason. Existing assertions are untouched.

Also adds `aria-label="Filter by account"`: `role="combobox"` does not take its accessible name from its content, so the visible label alone leaves the button unnamed to assistive tech.

## Checks

`tsc -b tsconfig.app.json` clean, `eslint .` clean over the whole dashboard, full vitest suite green (714 tests, 59 files) with 4 new. `just lint ts` cannot run locally — the frozen install fails against local pnpm 11, which no longer reads `pnpm.overrides` from package.json; the committed lockfile is correct for CI's pinned pnpm.

## Not in scope

The User column still shows the billing account. doublewordai/control-layer#1732 adds the key holder to this endpoint's payload, but only the customer-facing app renders it — so a platform manager filtering to an organization still sees one address repeated down the column and cannot tell members apart. Mirroring #217's column here is the natural follow-up.