### PR TITLE
fix: preserve model query results across additive schema migrations

### DIFF
--- a/dwctl/src/db/handlers/deployments.rs
+++ b/dwctl/src/db/handlers/deployments.rs
@@ -325,7 +325,15 @@ impl<'c> Repository for Deployments<'c> {
                 reasoning_translation_overrides
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38)
-            RETURNING *
+            RETURNING id, model_name, alias, display_name, description,
+                type, capabilities, created_by, hosted_on, status,
+                last_sync, deleted, created_at, updated_at, requests_per_second,
+                burst_size, capacity, batch_capacity, throughput, downstream_pricing_mode,
+                downstream_input_price_per_token, downstream_output_price_per_token, downstream_hourly_rate, downstream_input_token_cost_ratio, is_composite,
+                lb_strategy, fallback_enabled, fallback_on_rate_limit, fallback_on_status, fallback_with_replacement,
+                fallback_max_attempts, backoff_enabled, backoff_initial_ms, backoff_max_ms, backoff_factor,
+                backoff_jitter, backoff_max_total_ms, sanitize_responses, trusted, reasoning_translation_overrides,
+                allowed_batch_completion_windows, metadata, provisioning_source
             "#,
         )
         .bind(request.model_name.trim())
@@ -614,7 +622,15 @@ impl<'c> Repository for Deployments<'c> {
 
             updated_at = NOW()
         WHERE id = $1
-        RETURNING *
+        RETURNING id, model_name, alias, display_name, description,
+                type, capabilities, created_by, hosted_on, status,
+                last_sync, deleted, created_at, updated_at, requests_per_second,
+                burst_size, capacity, batch_capacity, throughput, downstream_pricing_mode,
+                downstream_input_price_per_token, downstream_output_price_per_token, downstream_hourly_rate, downstream_input_token_cost_ratio, is_composite,
+                lb_strategy, fallback_enabled, fallback_on_rate_limit, fallback_on_status, fallback_with_replacement,
+                fallback_max_attempts, backoff_enabled, backoff_initial_ms, backoff_max_ms, backoff_factor,
+                backoff_jitter, backoff_max_total_ms, sanitize_responses, trusted, reasoning_translation_overrides,
+                allowed_batch_completion_windows, metadata, provisioning_source
         "#,
         )
         .bind(id)
@@ -695,9 +711,21 @@ impl<'c> Repository for Deployments<'c> {
 
     #[instrument(skip(self, filter), fields(limit = filter.limit, skip = filter.skip), err)]
     async fn list(&mut self, filter: &Self::Filter) -> Result<Vec<Self::Response>> {
-        // Use LEFT JOIN with inference_endpoints to enable searching by endpoint name
-        let mut query =
-            QueryBuilder::new("SELECT dm.* FROM deployed_models dm LEFT JOIN inference_endpoints ie ON dm.hosted_on = ie.id WHERE 1=1");
+        // Explicit results keep prepared statements compatible with additive migrations,
+        // including server statements retained by a transaction pooler across clients.
+        // Use LEFT JOIN with inference_endpoints to enable searching by endpoint name.
+        let mut query = QueryBuilder::new(
+            "SELECT dm.id, dm.model_name, dm.alias, dm.display_name, dm.description,
+                dm.type, dm.capabilities, dm.created_by, dm.hosted_on, dm.status,
+                dm.last_sync, dm.deleted, dm.created_at, dm.updated_at, dm.requests_per_second,
+                dm.burst_size, dm.capacity, dm.batch_capacity, dm.throughput, dm.downstream_pricing_mode,
+                dm.downstream_input_price_per_token, dm.downstream_output_price_per_token, dm.downstream_hourly_rate, dm.downstream_input_token_cost_ratio, dm.is_composite,
+                dm.lb_strategy, dm.fallback_enabled, dm.fallback_on_rate_limit, dm.fallback_on_status, dm.fallback_with_replacement,
+                dm.fallback_max_attempts, dm.backoff_enabled, dm.backoff_initial_ms, dm.backoff_max_ms, dm.backoff_factor,
+                dm.backoff_jitter, dm.backoff_max_total_ms, dm.sanitize_responses, dm.trusted, dm.reasoning_translation_overrides,
+                dm.allowed_batch_completion_windows, dm.metadata, dm.provisioning_source
+             FROM deployed_models dm LEFT JOIN inference_endpoints ie ON dm.hosted_on = ie.id WHERE 1=1",
+        );
 
         Self::apply_filters(&mut query, filter);
 
@@ -873,7 +901,7 @@ impl<'c> Deployments<'c> {
         // Build a CTE that selects the filtered model set (ignoring pagination,
         // sort, and search so facets reflect the full universe visible to this user).
         let mut query = QueryBuilder::new(
-            "WITH visible AS (SELECT dm.* FROM deployed_models dm LEFT JOIN inference_endpoints ie ON dm.hosted_on = ie.id WHERE 1=1",
+            "WITH visible AS (SELECT dm.metadata, dm.capabilities, dm.type FROM deployed_models dm LEFT JOIN inference_endpoints ie ON dm.hosted_on = ie.id WHERE 1=1",
         );
 
         let facets_filter = DeploymentFilter {

--- a/scripts/tests/pooled/README.md
+++ b/scripts/tests/pooled/README.md
@@ -66,3 +66,18 @@ To check that the test detects a listener-routing regression, temporarily replac
 `DynPools::new(pools.main.pooled.clone())` in the application's listener provider,
 build a separate binary, and run the harness against it. The notification test
 must fail before its 15-second deadline; restore the production code afterwards.
+
+## Migrations with retained prepared statements
+
+After the session-isolation checks, the same PgBouncer process switches off
+`server_reset_query_always`. A negative control prepares a wildcard query on both
+backends, adds a column through a direct connection, and verifies PostgreSQL's
+`cached plan must not change result type` error from both an existing client and
+a fresh client. This assertion prevents a fixture that silently clears prepared
+statements from making the migration checks pass.
+
+The application then warms the models list queries, adds an unused model column
+through the direct connection, and verifies unchanged HTTP responses from the
+running application and after an application restart. PgBouncer stays alive.
+Both shared and scoped CI jobs run this phase. Reintroducing `SELECT dm.*` in the
+models list must fail the HTTP assertion after the column is added.

--- a/scripts/tests/pooled/e2e.py
+++ b/scripts/tests/pooled/e2e.py
@@ -26,6 +26,12 @@ from psycopg import sql
 from psycopg.conninfo import conninfo_to_dict
 from psycopg.rows import dict_row
 
+from schema_change import (
+    characterize_stale_plans,
+    characterize_returning_and_type_changes,
+    verify_models_schema_change,
+)
+
 LEADER_LOCK = 0x4457435450524F42
 
 
@@ -247,8 +253,7 @@ def verify_scoped_identity(direct, pooled_dsn, main_role):
         ).fetchone()[0],
         "Fusillade does not own its schema",
     )
-    drift = direct.execute(
-        """
+    drift = direct.execute("""
         SELECT c.relname FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
         WHERE n.nspname='fusillade' AND c.relowner <> current_user::regrole
         UNION ALL
@@ -257,8 +262,7 @@ def verify_scoped_identity(direct, pooled_dsn, main_role):
         UNION ALL
         SELECT t.typname FROM pg_type t JOIN pg_namespace n ON n.oid=t.typnamespace
         WHERE n.nspname='fusillade' AND t.typowner <> current_user::regrole
-        """
-    ).fetchall()
+        """).fetchall()
     check(not drift, f"Fusillade object ownership drift: {drift}")
     check(
         direct.execute("SELECT count(*) FROM fusillade._sqlx_migrations").fetchone()[0]
@@ -864,6 +868,25 @@ ignore_startup_parameters=extra_float_digits
             "PASS: shared application role retains public schema without CREATEROLE",
             flush=True,
         )
+        # Keep the hostile reset mode above for session-routing regressions. This
+        # second phase models production prepared statements surviving clients.
+        ini.write_text(
+            ini.read_text().replace(
+                "server_reset_query_always=1", "server_reset_query_always=0"
+            )
+        )
+        pool_admin.execute("RELOAD")
+        eventually(
+            "pooler retains prepared statements between transactions",
+            lambda: any(
+                row["key"] == "server_reset_query_always" and row["value"] == "0"
+                for row in pool_admin.execute("SHOW CONFIG").fetchall()
+            ),
+        )
+        characterize_stale_plans(direct, dsn(roles[0], True))
+        characterize_returning_and_type_changes(direct, dsn(roles[0], True))
+        verify_models_schema_change(app, direct)
+
     print("PASS: all pooled application E2E checks", flush=True)
 
 

--- a/scripts/tests/pooled/schema_change.py
+++ b/scripts/tests/pooled/schema_change.py
@@ -1,0 +1,183 @@
+"""Schema changes must preserve results on retained prepared server statements."""
+
+import uuid
+
+import psycopg
+import requests
+
+
+def characterize_stale_plans(direct, pooled_dsn):
+    """Negative control: prove both existing and fresh clients see the old bug."""
+    direct.execute("CREATE TABLE pool_test_plan_shape (id integer)")
+    query = "SELECT * FROM pool_test_plan_shape"
+    with (
+        psycopg.connect(pooled_dsn, autocommit=True) as old,
+        psycopg.connect(pooled_dsn, autocommit=True) as other,
+    ):
+        # Hold both backends so the test cannot pass by using an unprimed one.
+        old.execute("BEGIN")
+        other.execute("BEGIN")
+        pids = set()
+        for client in (old, other):
+            pids.add(client.execute("SELECT pg_backend_pid()").fetchone()[0])
+            client.execute(query, prepare=True).fetchall()
+        assert len(pids) == 2
+        old.execute("COMMIT")
+        other.execute("COMMIT")
+        direct.execute("ALTER TABLE pool_test_plan_shape ADD COLUMN added text")
+        with psycopg.connect(pooled_dsn, autocommit=True) as fresh:
+            for client in (old, fresh):
+                assert client.execute("SELECT pg_backend_pid()").fetchone()[0] in pids
+                try:
+                    client.execute(query, prepare=True).fetchall()
+                except psycopg.errors.FeatureNotSupported as error:
+                    assert "cached plan must not change result type" in str(error)
+                else:
+                    raise AssertionError("stale wildcard plan unexpectedly succeeded")
+    # All original clients are gone; only the pooler's backend sessions remain.
+    with psycopg.connect(pooled_dsn, autocommit=True) as replacement:
+        assert replacement.execute("SELECT pg_backend_pid()").fetchone()[0] in pids
+        try:
+            replacement.execute(query, prepare=True).fetchall()
+        except psycopg.errors.FeatureNotSupported as error:
+            assert "cached plan must not change result type" in str(error)
+        else:
+            raise AssertionError(
+                "closing all application clients unexpectedly cleared backend plans"
+            )
+    direct.execute("DROP TABLE pool_test_plan_shape")
+    print(
+        "PASS: wildcard plan fails after ADD COLUMN for existing and fresh clients",
+        flush=True,
+    )
+
+
+def verify_models_schema_change(app, direct):
+    """Exercise SQLx and the HTTP handler before/after DDL and a pod replacement."""
+    base = f"http://127.0.0.1:{app.config['port']}"
+    app.start()
+    session = requests.Session()
+    response = session.post(
+        base + "/authentication/login",
+        json={
+            "email": "pool-test@example.invalid",
+            "password": "local-pool-test-password",
+        },
+        timeout=20,
+    )
+    response.raise_for_status()
+
+    def listings():
+        results = []
+        # Exercise both populated and empty pages and cycle both server connections.
+        for _ in range(8):
+            for skip in (0, 100):
+                response = session.get(
+                    base + f"/admin/api/v1/models?limit=100&skip={skip}", timeout=20
+                )
+                assert (
+                    response.status_code == 200
+                ), f"models list failed: {response.status_code} {response.text[:300]}"
+                results.append(response.json())
+        return results
+
+    def writes():
+        endpoint = str(
+            direct.execute("SELECT id FROM inference_endpoints LIMIT 1").fetchone()[0]
+        )
+        for _ in range(4):
+            alias = "schema-test-" + uuid.uuid4().hex
+            response = session.post(
+                base + "/admin/api/v1/models",
+                json={
+                    "type": "standard",
+                    "model_name": alias,
+                    "alias": alias,
+                    "hosted_on": endpoint,
+                },
+                timeout=20,
+            )
+            assert (
+                response.status_code == 200
+            ), f"model create failed: {response.status_code} {response.text[:300]}"
+            model = response.json()
+            response = session.patch(
+                base + "/admin/api/v1/models/" + model["id"],
+                json={"description": "schema compatibility"},
+                timeout=20,
+            )
+            assert (
+                response.status_code == 200
+            ), f"model update failed: {response.status_code} {response.text[:300]}"
+            assert response.json()["description"] == "schema compatibility"
+
+    writes()
+    before = listings()
+    direct.execute(
+        "ALTER TABLE deployed_models ADD COLUMN pool_test_future_column text"
+    )
+    try:
+        assert listings() == before, "additive DDL changed the models API response"
+        writes()
+        before_restart = listings()
+        app.stop(strict=True)
+        # Keep PgBouncer and its PostgreSQL connections running across the restart.
+        app.start()
+        assert (
+            listings() == before_restart
+        ), "new application client failed after additive DDL"
+        writes()
+    finally:
+        app.stop()
+        direct.execute(
+            "ALTER TABLE deployed_models DROP COLUMN pool_test_future_column"
+        )
+        session.close()
+    print(
+        "PASS: models API survives additive DDL and application replacement with retained plans",
+        flush=True,
+    )
+
+
+def characterize_returning_and_type_changes(direct, pooled_dsn):
+    """Protect the fixture against write-result and incompatible-type blind spots."""
+    direct.execute("CREATE TABLE pool_test_write_shape (id integer)")
+    direct.execute("INSERT INTO pool_test_write_shape VALUES (1)")
+    wildcard = "UPDATE pool_test_write_shape SET id = id RETURNING *"
+    stable = "UPDATE pool_test_write_shape SET id = id RETURNING id"
+    read = "SELECT id FROM pool_test_write_shape"
+    with psycopg.connect(pooled_dsn, autocommit=True) as client:
+        # Round-robin visits both backends; execute each query on both.
+        for query in (wildcard, stable, read):
+            for _ in range(4):
+                assert client.execute(query, prepare=True).fetchall() == [(1,)]
+        direct.execute("ALTER TABLE pool_test_write_shape ADD COLUMN added text")
+        for _ in range(4):
+            try:
+                client.execute(wildcard, prepare=True).fetchall()
+            except psycopg.errors.FeatureNotSupported as error:
+                assert "cached plan must not change result type" in str(error)
+            else:
+                raise AssertionError(
+                    "RETURNING wildcard unexpectedly survived ADD COLUMN"
+                )
+        with psycopg.connect(pooled_dsn, autocommit=True) as fresh:
+            for connection in (client, fresh):
+                for query in (stable, read):
+                    for _ in range(4):
+                        assert connection.execute(query, prepare=True).fetchall() == [
+                            (1,)
+                        ]
+        direct.execute("ALTER TABLE pool_test_write_shape ALTER COLUMN id TYPE bigint")
+        # Explicit projection protects additive DDL, not changing selected types.
+        try:
+            client.execute(read, prepare=True).fetchall()
+        except psycopg.errors.FeatureNotSupported as error:
+            assert "cached plan must not change result type" in str(error)
+        else:
+            raise AssertionError("selected column type change unexpectedly succeeded")
+    direct.execute("DROP TABLE pool_test_write_shape")
+    print(
+        "PASS: RETURNING wildcard and incompatible type failures reproduced; explicit results survive ADD COLUMN",
+        flush=True,
+    )


### PR DESCRIPTION
## Change

Adding a column to `deployed_models` could make the models list return HTTP 500 because a transaction pooler retained prepared statements expecting the old wildcard result shape. Replacing application clients did not necessarily clear those backend statements.

Use explicit result columns for model listing, creation, and updates, and select only the fields needed by facets. Add a retained-statement phase to both required pooled database E2E jobs without weakening their existing hostile session-reset phase.

The regression warms real model API queries, adds a column through the direct connection, then verifies listing, creation, and updates before and after an application restart while PgBouncer stays alive. Negative controls reproduce wildcard SELECT and RETURNING failures, including reuse after all original application clients close, and demonstrate that explicit columns still require compatible column types.

## Validation

- Unchanged main binary failed the new models-list regression with HTTP 500 and `cached plan must not change result type`.
- Fixed binary passed full shared and scoped pooled E2E runs, including model create/update/list across additive DDL and restart.
- `just lint rust` passed, including SQLx metadata and repository guards.
- Full `just test rust -- --test-threads=4` passed, including doctests.

No database migration or pool reset is included. Follow-up #1759 extends explicit projections to other repositories, enforces the reviewed query audit, documents migration compatibility, and adds a diagnostic metric.
